### PR TITLE
Repair ML-DSA examples

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: thumbv7em-none-eabihf,thumbv7em-none-eabi
       
       - name: Build
         working-directory: ${{ matrix.board_directory }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", *"]
+    branches: ["main", "*"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: thumbv7em-none-eabihf,thumbv7em-none-eabi
-      
+
+      - name: Install flip-link
+        run: cargo install flip-link
+
       - name: Build
         working-directory: ${{ matrix.board_directory }}
         run: cargo build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         board_directory: [libcrux-nrf52840, libcrux-nucleo-l4r5zi]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build for all boards
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main", *"]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        board_directory: [libcrux-nrf52840, libcrux-nucleo-l4r5zi]
+
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Build
+        working-directory: ${{ matrix.board_directory }}
+        run: cargo build

--- a/libcrux-nrf52840/src/bin/mldsa_65.rs
+++ b/libcrux-nrf52840/src/bin/mldsa_65.rs
@@ -43,7 +43,7 @@ fn main() -> ! {
     let counter_start = rtc.get_counter();
     rtc.enable_counter();
     for _ in 0..100 {
-        let _ = ml_dsa_65::sign(&keypair.signing_key, &message, signing_randomness);
+        let _ = ml_dsa_65::sign(&keypair.signing_key, &message, b"", signing_randomness);
     }
     rtc.disable_counter();
     let counter_end = rtc.get_counter();
@@ -52,13 +52,13 @@ fn main() -> ! {
     let time_sign_avg = counter_sign_avg * RTC_RESOLUTION;
     defmt::println!("Took {=f32} µs to sign on average", time_sign_avg);
 
-    let signature = ml_dsa_65::sign(&keypair.signing_key, &message, signing_randomness);
+    let signature = ml_dsa_65::sign(&keypair.signing_key, &message, b"", signing_randomness).unwrap();
 
     defmt::println!("Verifying 100 times.");
     let counter_start = rtc.get_counter();
     rtc.enable_counter();
     for _ in 0..100 {
-        let _ = ml_dsa_65::verify(&keypair.verification_key, &message, &signature).unwrap();
+        let _ = ml_dsa_65::verify(&keypair.verification_key, &message, b"", &signature).unwrap();
     }
     let counter_end = rtc.get_counter();
     let counter_verify_total = counter_end - counter_start;

--- a/libcrux-nucleo-l4r5zi/src/bin/mldsa_65.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/mldsa_65.rs
@@ -43,10 +43,10 @@ fn main() -> ! {
     let signing_randomness = [4u8; 32];
     let message = [5u8; 1024];
 
-    let signature = ml_dsa_65::sign(&keypair.signing_key, &message, signing_randomness);
+    let signature = ml_dsa_65::sign(&keypair.signing_key, &message, b"", signing_randomness).unwrap();
     defmt::println!("\tSigning OK");
 
-    let result = ml_dsa_65::verify(&keypair.verification_key, &message, &signature);
+    let result = ml_dsa_65::verify(&keypair.verification_key, &message, b"", &signature);
     defmt::println!("\tVerification OK");
 
     assert!(result.is_ok());
@@ -76,7 +76,7 @@ fn main() -> ! {
             (message, keypair, signing_randomness)
         },
         |(message, keypair, signing_randomness)| {
-            ml_dsa_65::sign(&keypair.signing_key, message, *signing_randomness);
+            let _ = ml_dsa_65::sign(&keypair.signing_key, message, b"", *signing_randomness);
         },
         SIGN_ITERATIONS,
     );
@@ -89,11 +89,11 @@ fn main() -> ! {
             let message = [5u8; 1024];
 
             let keypair = ml_dsa_65::generate_key_pair(randomness_gen);
-            let signature = ml_dsa_65::sign(&keypair.signing_key, &message, signing_randomness);
+            let signature = ml_dsa_65::sign(&keypair.signing_key, &message, b"", signing_randomness).unwrap();
             (message, keypair, signature)
         },
         |(message, keypair, signature)| {
-            ml_dsa_65::verify(&keypair.verification_key, message, signature).unwrap();
+            ml_dsa_65::verify(&keypair.verification_key, message, b"", signature).unwrap();
         },
         VERIFY_ITERATIONS,
     );


### PR DESCRIPTION
With the ML-DSA FIPS updates came some changes in the public API that broke the examples here. This PR repairs the examples and also puts a build check on CI.

Once `libcrux-ml-dsa` is released on crates.io we should use that version and pin it.