### PR TITLE
`&mut` ML-KEM

### DIFF
--- a/libcrux-nucleo-l4r5zi/Cargo.toml
+++ b/libcrux-nucleo-l4r5zi/Cargo.toml
@@ -16,8 +16,9 @@ harness = false
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
 defmt = "0.3"
-# defmt-rtt = "0.4"
-rtt-target = { version = "0.6", features = ["defmt"] }
+defmt-rtt = "0.4"
+# as an alternative to defmt-rtt:
+# rtt-target = { version = "0.6", features = ["defmt"] }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 cortex-m-semihosting = "0.5.0"
 libcrux-iot-testutil = { path = "../libcrux-iot-testutil" }

--- a/libcrux-nucleo-l4r5zi/Cargo.toml
+++ b/libcrux-nucleo-l4r5zi/Cargo.toml
@@ -16,11 +16,13 @@ harness = false
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
 defmt = "0.3"
-defmt-rtt = "0.4"
+# defmt-rtt = "0.4"
+rtt-target = { version = "0.6", features = ["defmt"] }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 cortex-m-semihosting = "0.5.0"
 libcrux-iot-testutil = { path = "../libcrux-iot-testutil" }
 libcrux-testbench = { path = "../libcrux-testbench" }
+libcrux-ml-kem = { path = "../libcrux/libcrux-ml-kem" }
 embassy-stm32 = { version = "0.1.0", features = [ "stm32l4r5zi", "defmt", ] }
 embedded-alloc = "0.6.0"
 

--- a/libcrux-nucleo-l4r5zi/cycles.dat
+++ b/libcrux-nucleo-l4r5zi/cycles.dat
@@ -1,0 +1,74 @@
+[START_SECTION CCA generate_keypair] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 204) : 665440008
+[START_SECTION CPA generate keypair] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 549) : 665473233
+[START_MEASUREMENT generate_keypair_unpacked] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 554) : 665492659
+[END_MEASUREMENT generate_keypair_unpacked] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 564) : 666110417
+[START_MEASUREMENT serialize_unpacked_secret_key] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 566) : 666127177
+[END_MEASUREMENT serialize_unpacked_secret_key] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 573) : 666159852
+[END_SECTION CPA generate keypair] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 574) : 666177208
+[END_MEASUREMENT CPA generate_keypair] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 227) : 666193208
+[START_MEASUREMENT serialize_kem_secret_key_mut] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 229) : 666209085
+[END_MEASUREMENT serialize_kem_secret_key_mut] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 239) : 666347324
+[END_SECTION CCA generate_keypair] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 241) : 666364411
+[START_SECTION CCA encapsulate] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 285) : 666381509
+[START_MEASUREMENT Hash H] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 291) : 666396780
+[END_MEASUREMENT Hash H] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 293) : 666528140
+[START_MEASUREMENT Hash G] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 299) : 666542056
+[END_MEASUREMENT Hash G] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 302) : 666575320
+[START_MEASUREMENT CPA encrypt] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 305) : 666589239
+[START_SECTION CPA encrypt] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 951) : 666605880
+[START_MEASUREMENT IndCpaPublicKeyUnpacked::<K, Vector>::default()] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 954) : 666620533
+[START_MEASUREMENT build_unpacked_public_key_mut] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 957) : 666793115
+[END_MEASUREMENT build_unpacked_public_key_mut] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 962) : 667090773
+[START_MEASUREMENT encrypt_unpacked] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 963) : 667108127
+[START_SECTION encrypt_unpacked] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 750) : 667123527
+[START_MEASUREMENT encrypt_c1] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 751) : 667138928
+[START_SECTION encrypt_c1] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 806) : 667153433
+[START_MEASUREMENT sample_vector_cbd_then_ntt] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 812) : 667167930
+[END_MEASUREMENT sample_vector_cbd_then_ntt] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 822) : 667314863
+[START_MEASUREMENT sample_ring_element_cbd] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 832) : 667331770
+[END_MEASUREMENT sample_ring_element_cbd] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 842) : 667393508
+[START_MEASUREMENT PRF] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 849) : 667409555
+[END_MEASUREMENT PRF] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 852) : 667442150
+[START_MEASUREMENT sample_from_binomial_distribution] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 853) : 667455218
+[END_MEASUREMENT sample_from_binomial_distribution] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 855) : 667474218
+[START_MEASUREMENT PolynomialRingElement::from_i16_array] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 856) : 667491725
+[END_MEASUREMENT PolynomialRingElement::from_i16_array] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 858) : 667510260
+[END_MEASUREMENT compute_vector_u] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 864) : 667804713
+[START_MEASUREMENT compress_then_serialize_u] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 867) : 667820120
+[END_MEASUREMENT compress_then_serialize_u] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 869) : 667850509
+[END_SECTION encrypt_c1] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 870) : 667866843
+[END_MEASUREMENT encrypt_c1] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 772) : 667880986
+[START_MEASUREMENT encrypt_c2] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 773) : 667895129
+[END_MEASUREMENT encrypt_c2] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 781) : 667990417
+[END_SECTION encrypt_unpacked] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 782) : 668004567
+[END_MEASUREMENT encrypt_unpacked] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 990) : 668019584
+[END_SECTION CPA encrypt] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 991) : 668034596
+[START_SECTION CCA decapsulate] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 392) : 668168035
+[START_SECTION CPA encrypt] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 951) : 668454352
+[START_MEASUREMENT IndCpaPublicKeyUnpacked::<K, Vector>::default()] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 954) : 668468650
+[END_MEASUREMENT IndCpaPublicKeyUnpacked::<K, Vector>::default()] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 956) : 668490757
+[START_MEASUREMENT build_unpacked_public_key_mut] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 957) : 668510304
+[END_MEASUREMENT build_unpacked_public_key_mut] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 962) : 668803456
+[START_MEASUREMENT encrypt_unpacked] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 963) : 668820811
+[START_SECTION encrypt_unpacked] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 750) : 668836212
+[START_MEASUREMENT encrypt_c1] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 751) : 668851612
+[START_SECTION encrypt_c1] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 806) : 668866115
+[START_MEASUREMENT sample_vector_cbd_then_ntt] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 812) : 668880614
+[START_MEASUREMENT sample_ring_element_cbd] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 832) : 669045837
+[END_MEASUREMENT sample_ring_element_cbd] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 842) : 669107775
+[START_MEASUREMENT PRF] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 849) : 669124235
+[END_MEASUREMENT PRF] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 852) : 669156951
+[START_MEASUREMENT sample_from_binomial_distribution] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 853) : 669170358
+[END_MEASUREMENT sample_from_binomial_distribution] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 855) : 669189812
+[START_MEASUREMENT PolynomialRingElement::from_i16_array] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 856) : 669207773
+[END_MEASUREMENT PolynomialRingElement::from_i16_array] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 858) : 669226778
+[START_MEASUREMENT compute_vector_u] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 861) : 669245255
+[END_MEASUREMENT compress_then_serialize_u] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 869) : 669538517
+[END_SECTION encrypt_c1] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 870) : 669555270
+[END_MEASUREMENT encrypt_c1] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 772) : 669569772
+[START_MEASUREMENT encrypt_c2] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 773) : 669584270
+[END_MEASUREMENT encrypt_c2] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 781) : 669679527
+[END_SECTION encrypt_unpacked] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 782) : 669694034
+[END_MEASUREMENT encrypt_unpacked] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 990) : 669709436
+[END_SECTION CPA encrypt] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cpa.rs, 991) : 669724836
+[END_SECTION CCA decapsulate] (/home/jonas/worktrees/iot/wip/libcrux/libcrux-ml-kem/src/ind_cca.rs, 500) : 669745649

--- a/libcrux-nucleo-l4r5zi/src/bin/mlkem_cycles.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/mlkem_cycles.rs
@@ -1,0 +1,34 @@
+#![no_main]
+#![no_std]
+
+use libcrux_nucleo_l4r5zi as board; // global logger + panicking-behavior + memory layout
+
+use libcrux_ml_kem::mlkem512 as mlkem;
+
+extern crate alloc;
+
+use embedded_alloc::LlffHeap as Heap;
+
+#[global_allocator]
+static HEAP: Heap = Heap::empty();
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    // Init rtt-target defmt support
+    rtt_target::rtt_init_defmt!();
+    
+    // Initialize cycle counter
+    {
+        use cortex_m::peripheral::Peripherals;
+        let mut peripherals = Peripherals::take().unwrap();
+        peripherals.DCB.enable_trace();
+        peripherals.DWT.enable_cycle_counter();
+    }
+    
+    let randomness_gen = [1u8; libcrux_ml_kem::KEY_GENERATION_SEED_SIZE];
+    let pair = core::hint::black_box(mlkem::generate_key_pair(randomness_gen));
+    let randomness_encaps = [2u8; libcrux_ml_kem::ENCAPS_SEED_SIZE];
+    let (ciphertext, _shared_secret_initiator) = core::hint::black_box(mlkem::encapsulate(pair.public_key(), randomness_encaps));
+    let _shared_secret_responder = core::hint::black_box(mlkem::decapsulate(pair.private_key(), &ciphertext));
+    board::exit()
+}

--- a/libcrux-nucleo-l4r5zi/src/bin/mlkem_cycles.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/mlkem_cycles.rs
@@ -15,7 +15,7 @@ static HEAP: Heap = Heap::empty();
 #[cortex_m_rt::entry]
 fn main() -> ! {
     // Init rtt-target defmt support
-    rtt_target::rtt_init_defmt!();
+    // rtt_target::rtt_init_defmt!();
     
     // Initialize cycle counter
     {

--- a/libcrux-nucleo-l4r5zi/src/lib.rs
+++ b/libcrux-nucleo-l4r5zi/src/lib.rs
@@ -3,7 +3,7 @@
 
 use cortex_m_semihosting::debug;
 
-use defmt_rtt as _; // global logger
+// use defmt_rtt as _; // global logger
 
 use embassy_stm32 as _; // memory layout
 

--- a/libcrux-nucleo-l4r5zi/src/lib.rs
+++ b/libcrux-nucleo-l4r5zi/src/lib.rs
@@ -3,7 +3,7 @@
 
 use cortex_m_semihosting::debug;
 
-// use defmt_rtt as _; // global logger
+use defmt_rtt as _; // global logger
 
 use embassy_stm32 as _; // memory layout
 

--- a/libcrux/libcrux-ml-kem/Cargo.toml
+++ b/libcrux/libcrux-ml-kem/Cargo.toml
@@ -27,6 +27,8 @@ libcrux-platform = { version = "0.0.2-beta.2", path = "../libcrux-platform" }
 libcrux-sha3 = { version = "0.0.2-beta.2", path = "../libcrux-sha3" }
 libcrux-intrinsics = { version = "0.0.2-beta.2", path = "../libcrux-intrinsics" }
 hax-lib = { version = "0.1.0-alpha.1", git = "https://github.com/hacspec/hax/" }
+cortex-m = "0.7.7" # For reporting cycle counts
+defmt = "0.3"
 
 # This is only required for verification.
 # The hax config is set by the hax toolchain.
@@ -35,7 +37,7 @@ hax-lib = { version = "0.1.0-alpha.1", git = "https://github.com/hacspec/hax/" }
 
 [features]
 # By default all variants and std are enabled.
-default = ["std", "mlkem512", "mlkem768", "mlkem1024", "rand"]
+default = ["mlkem512", "mlkem768", "mlkem1024"]
 
 # Hardware features can be force enabled.
 # It is not recommended to use these. This crate performs CPU feature detection

--- a/libcrux/libcrux-ml-kem/Cargo.toml
+++ b/libcrux/libcrux-ml-kem/Cargo.toml
@@ -22,7 +22,7 @@ exclude = [
 bench = false # so libtest doesn't eat the arguments to criterion
 
 [dependencies]
-rand = { version = "0.8", optional = true }
+rand = { version = "0.9", optional = true }
 libcrux-platform = { version = "0.0.2-beta.2", path = "../libcrux-platform" }
 libcrux-sha3 = { version = "0.0.2-beta.2", path = "../libcrux-sha3" }
 libcrux-intrinsics = { version = "0.0.2-beta.2", path = "../libcrux-intrinsics" }
@@ -61,7 +61,7 @@ rand = ["dep:rand"]
 std = []
 
 [dev-dependencies]
-rand = { version = "0.8" }
+rand = { version = "0.9" }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 hex = { version = "0.4.3", features = ["serde"] }

--- a/libcrux/libcrux-ml-kem/examples/decapsulate.rs
+++ b/libcrux/libcrux-ml-kem/examples/decapsulate.rs
@@ -1,13 +1,13 @@
 use libcrux_ml_kem::{mlkem768, ENCAPS_SEED_SIZE, KEY_GENERATION_SEED_SIZE};
-use rand::{rngs::OsRng, RngCore};
+use rand::{rngs::OsRng, TryRngCore};
 
 fn main() {
     let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
-    OsRng.fill_bytes(&mut randomness);
+    OsRng.try_fill_bytes(&mut randomness).unwrap();
 
     let key_pair = mlkem768::generate_key_pair(randomness);
     let mut randomness = [0u8; ENCAPS_SEED_SIZE];
-    OsRng.fill_bytes(&mut randomness);
+    OsRng.try_fill_bytes(&mut randomness).unwrap();
     let (ct, _ss) = mlkem768::encapsulate(key_pair.public_key(), randomness);
 
     for _ in 0..100_000 {

--- a/libcrux/libcrux-ml-kem/examples/encapsulate.rs
+++ b/libcrux/libcrux-ml-kem/examples/encapsulate.rs
@@ -1,15 +1,15 @@
 use libcrux_ml_kem::{mlkem768, ENCAPS_SEED_SIZE, KEY_GENERATION_SEED_SIZE};
-use rand::{rngs::OsRng, RngCore};
+use rand::{rngs::OsRng, TryRngCore};
 
 fn main() {
     let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
-    OsRng.fill_bytes(&mut randomness);
+    OsRng.try_fill_bytes(&mut randomness).unwrap();
 
     let key_pair = mlkem768::generate_key_pair(randomness);
 
     let mut randomness = [0u8; ENCAPS_SEED_SIZE];
     for _ in 0..100_000 {
-        OsRng.fill_bytes(&mut randomness);
+        OsRng.try_fill_bytes(&mut randomness).unwrap();
         let _ = mlkem768::encapsulate(key_pair.public_key(), randomness);
     }
 }

--- a/libcrux/libcrux-ml-kem/examples/keygen.rs
+++ b/libcrux/libcrux-ml-kem/examples/keygen.rs
@@ -1,10 +1,10 @@
 use libcrux_ml_kem::{mlkem768, KEY_GENERATION_SEED_SIZE};
-use rand::{rngs::OsRng, RngCore};
+use rand::{rngs::OsRng, TryRngCore};
 
 fn main() {
     let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
     for _ in 0..100_000 {
-        OsRng.fill_bytes(&mut randomness);
+        OsRng.try_fill_bytes(&mut randomness).unwrap();
         let _ = mlkem768::generate_key_pair(randomness);
     }
 }

--- a/libcrux/libcrux-ml-kem/src/constant_time_ops.rs
+++ b/libcrux/libcrux-ml-kem/src/constant_time_ops.rs
@@ -200,7 +200,7 @@ pub(crate) fn select_shared_secret_in_constant_time(
     lhs: &[u8],
     rhs: &[u8],
     selector: u8,
-    out: &mut [u8]
+    out: &mut [u8],
 ) {
     #[cfg(eurydice)]
     return select_ct(lhs, rhs, selector, out);
@@ -222,7 +222,7 @@ pub(crate) fn compare_ciphertexts_select_shared_secret_in_constant_time(
     rhs_c: &[u8],
     lhs_s: &[u8],
     rhs_s: &[u8],
-    out: &mut [u8]
+    out: &mut [u8],
 ) {
     let selector = compare_ciphertexts_in_constant_time(lhs_c, rhs_c);
 

--- a/libcrux/libcrux-ml-kem/src/constant_time_ops.rs
+++ b/libcrux/libcrux-ml-kem/src/constant_time_ops.rs
@@ -11,8 +11,8 @@ use crate::constants::SHARED_SECRET_SIZE;
 // XXX: We have to disable this for C extraction for now. See eurydice/issues#37
 
 /// Return 1 if `value` is not zero and 0 otherwise.
-#[hax_lib::ensures(|result| fstar!(r#"($value == 0uy ==> $result == 0uy) /\
-    ($value =!= 0uy ==> $result == 1uy)"#))]
+#[hax_lib::ensures(|result| fstar!(r#"($value == (mk_u8 0) ==> $result == (mk_u8 0)) /\
+    ($value =!= (mk_u8 0) ==> $result == (mk_u8 1))"#))]
 fn inz(value: u8) -> u8 {
     let _orig_value = value;
     let value = value as u16;
@@ -22,15 +22,15 @@ fn inz(value: u8) -> u8 {
         r#"if v $_orig_value = 0 then  (
         assert($value == zero);
         lognot_lemma $value;
-        assert((~.$value +. 1us) == zero);
-        assert((Core.Num.impl__u16__wrapping_add (~.$value <: u16) 1us <: u16) == zero);
+        assert((~.$value +. (mk_u16 1)) == zero);
+        assert(($u16::wrapping_add (~.$value <: u16) (mk_u16 1) <: u16) == zero);
         logor_lemma $value zero;
-        assert(($value |. (Core.Num.impl__u16__wrapping_add (~.$value <: u16) 1us <: u16) <: u16) == $value);
-        assert (v $result == v (($value >>! 8l)));
+        assert(($value |. ($u16::wrapping_add (~.$value <: u16) (mk_u16 1) <: u16) <: u16) == $value);
+        assert (v $result == v (($value >>! (mk_i32 8))));
         assert ((v $value / pow2 8) == 0);
-        assert ($result == 0uy);
-        logand_lemma 1uy $result;
-        assert ($res == 0uy))
+        assert ($result == (mk_u8 0));
+        logand_lemma (mk_u8 1) $result;
+        assert ($res == (mk_u8 0)))
     else (
         assert (v $value <> 0);
         lognot_lemma $value;
@@ -40,17 +40,17 @@ fn inz(value: u8) -> u8 {
         assert ((v (~.$value) + 1) = (pow2 16 - pow2 8) + (pow2 8 - v $value));
         assert ((v (~.$value) + 1) = (pow2 8 - 1) * pow2 8 + (pow2 8 - v $value));
         assert ((v (~.$value) + 1)/pow2 8 = (pow2 8 - 1));
-        assert (v ((Core.Num.impl__u16__wrapping_add (~.$value <: u16) 1us <: u16) >>! 8l) = pow2 8 - 1);
+        assert (v (($u16::wrapping_add (~.$value <: u16) (mk_u16 1) <: u16) >>! (mk_i32 8)) = pow2 8 - 1);
         assert ($result = ones);
-        logand_lemma 1uy $result;
-        assert ($res = 1uy))"#
+        logand_lemma (mk_u8 1) $result;
+        assert ($res = (mk_u8 1)))"#
     );
     res
 }
 
 #[inline(never)] // Don't inline this to avoid that the compiler optimizes this out.
-#[hax_lib::ensures(|result| fstar!(r#"($value == 0uy ==> $result == 0uy) /\
-    ($value =!= 0uy ==> $result == 1uy)"#))]
+#[hax_lib::ensures(|result| fstar!(r#"($value == (mk_u8 0) ==> $result == (mk_u8 0)) /\
+    ($value =!= (mk_u8 0) ==> $result == (mk_u8 1))"#))]
 fn is_non_zero(value: u8) -> u8 {
     #[cfg(eurydice)]
     return inz(value);
@@ -62,8 +62,8 @@ fn is_non_zero(value: u8) -> u8 {
 /// Return 1 if the bytes of `lhs` and `rhs` do not exactly
 /// match and 0 otherwise.
 #[hax_lib::requires(lhs.len() == rhs.len())]
-#[hax_lib::ensures(|result| fstar!(r#"($lhs == $rhs ==> $result == 0uy) /\
-    ($lhs =!= $rhs ==> $result == 1uy)"#))]
+#[hax_lib::ensures(|result| fstar!(r#"($lhs == $rhs ==> $result == (mk_u8 0)) /\
+    ($lhs =!= $rhs ==> $result == (mk_u8 1))"#))]
 fn compare(lhs: &[u8], rhs: &[u8]) -> u8 {
     let mut r: u8 = 0;
     for i in 0..lhs.len() {
@@ -71,13 +71,13 @@ fn compare(lhs: &[u8], rhs: &[u8]) -> u8 {
             fstar!(
                 r#"v $i <= Seq.length $lhs /\
             (if (Seq.slice $lhs 0 (v $i) = Seq.slice $rhs 0 (v $i)) then
-                $r == 0uy
-                else ~ ($r == 0uy))"#
+                $r == (mk_u8 0)
+                else ~ ($r == (mk_u8 0)))"#
             )
         });
         let nr = r | (lhs[i] ^ rhs[i]);
         hax_lib::fstar!(
-            r#"if $r =. 0uy then (
+            r#"if $r =. (mk_u8 0) then (
             if (Seq.index $lhs (v $i) = Seq.index $rhs (v $i)) then (
                logxor_lemma (Seq.index $lhs (v $i)) (Seq.index $rhs (v $i));
                assert (((${lhs}.[ $i ] <: u8) ^. (${rhs}.[ $i ] <: u8) <: u8) = zero);
@@ -118,30 +118,29 @@ fn compare(lhs: &[u8], rhs: &[u8]) -> u8 {
     lhs.len() == rhs.len() &&
     lhs.len() == SHARED_SECRET_SIZE
 )]
-#[hax_lib::ensures(|result| fstar!(r#"($selector == 0uy ==> $result == $lhs) /\
-        ($selector =!= 0uy ==> $result == $rhs)"#))]
+#[hax_lib::ensures(|result| fstar!(r#"($selector == (mk_u8 0) ==> $result == $lhs) /\
+        ($selector =!= (mk_u8 0) ==> $result == $rhs)"#))]
 #[hax_lib::fstar::options("--ifuel 0 --z3rlimit 50")]
-fn select_ct(lhs: &[u8], rhs: &[u8], selector: u8) -> [u8; SHARED_SECRET_SIZE] {
+fn select_ct(lhs: &[u8], rhs: &[u8], selector: u8, out: &mut [u8]) {
     let mask = is_non_zero(selector).wrapping_sub(1);
     hax_lib::fstar!(
-        "assert (if $selector = 0uy then $mask = ones else $mask = zero);
+        "assert (if $selector = (mk_u8 0) then $mask = ones else $mask = zero);
         lognot_lemma $mask;
-        assert (if $selector = 0uy then ~.$mask = zero else ~.$mask = ones)"
+        assert (if $selector = (mk_u8 0) then ~.$mask = zero else ~.$mask = ones)"
     );
-    let mut out = [0u8; SHARED_SECRET_SIZE];
 
     for i in 0..SHARED_SECRET_SIZE {
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"v $i <= v $SHARED_SECRET_SIZE /\
-            (forall j. j < v $i ==> (if ($selector =. 0uy) then Seq.index $out j == Seq.index $lhs j else Seq.index $out j == Seq.index $rhs j)) /\
-            (forall j. j >= v $i ==> Seq.index $out j == 0uy)"#
+            (forall j. j < v $i ==> (if ($selector =. (mk_u8 0)) then Seq.index $out j == Seq.index $lhs j else Seq.index $out j == Seq.index $rhs j)) /\
+            (forall j. j >= v $i ==> Seq.index $out j == (mk_u8 0))"#
             )
         });
-        hax_lib::fstar!(r#"assert ((${out}.[ $i ] <: u8) = 0uy)"#);
+        hax_lib::fstar!(r#"assert ((${out}.[ $i ] <: u8) = (mk_u8 0))"#);
         let outi = (lhs[i] & mask) | (rhs[i] & !mask);
         hax_lib::fstar!(
-            r#"if ($selector = 0uy) then (
+            r#"if ($selector = (mk_u8 0)) then (
             logand_lemma (${lhs}.[ $i ] <: u8) $mask;
             assert (((${lhs}.[ $i ] <: u8) &. $mask <: u8) == (${lhs}.[ $i ] <: u8));
             logand_lemma (${rhs}.[ $i ] <: u8) (~.$mask);
@@ -169,20 +168,19 @@ fn select_ct(lhs: &[u8], rhs: &[u8], selector: u8) -> [u8; SHARED_SECRET_SIZE] {
     }
 
     hax_lib::fstar!(
-        "if ($selector =. 0uy) then (
+        "if ($selector =. (mk_u8 0)) then (
             eq_intro $out $lhs
         )
         else (
             eq_intro $out $rhs
         )"
     );
-    out
 }
 
 #[inline(never)] // Don't inline this to avoid that the compiler optimizes this out.
 #[hax_lib::requires(lhs.len() == rhs.len())]
-#[hax_lib::ensures(|result| fstar!(r#"($lhs == $rhs ==> $result == 0uy) /\
-    ($lhs =!= $rhs ==> $result == 1uy)"#))]
+#[hax_lib::ensures(|result| fstar!(r#"($lhs == $rhs ==> $result == (mk_u8 0)) /\
+    ($lhs =!= $rhs ==> $result == (mk_u8 1))"#))]
 pub(crate) fn compare_ciphertexts_in_constant_time(lhs: &[u8], rhs: &[u8]) -> u8 {
     #[cfg(eurydice)]
     return compare(lhs, rhs);
@@ -196,18 +194,19 @@ pub(crate) fn compare_ciphertexts_in_constant_time(lhs: &[u8], rhs: &[u8]) -> u8
     lhs.len() == rhs.len() &&
     lhs.len() == SHARED_SECRET_SIZE
 )]
-#[hax_lib::ensures(|result| fstar!(r#"($selector == 0uy ==> $result == $lhs) /\
-       ($selector =!= 0uy ==> $result == $rhs)"#))]
+#[hax_lib::ensures(|result| fstar!(r#"($selector == (mk_u8 0) ==> $result == $lhs) /\
+       ($selector =!= (mk_u8 0) ==> $result == $rhs)"#))]
 pub(crate) fn select_shared_secret_in_constant_time(
     lhs: &[u8],
     rhs: &[u8],
     selector: u8,
-) -> [u8; SHARED_SECRET_SIZE] {
+    out: &mut [u8]
+) {
     #[cfg(eurydice)]
-    return select_ct(lhs, rhs, selector);
+    return select_ct(lhs, rhs, selector, out);
 
     #[cfg(not(eurydice))]
-    core::hint::black_box(select_ct(lhs, rhs, selector))
+    core::hint::black_box(select_ct(lhs, rhs, selector, out))
 }
 
 #[hax_lib::requires(
@@ -215,16 +214,17 @@ pub(crate) fn select_shared_secret_in_constant_time(
     lhs_s.len() == rhs_s.len() &&
     lhs_s.len() == SHARED_SECRET_SIZE
 )]
-#[hax_lib::ensures(|result| fstar!(r#"let selector = if $lhs_c =. $rhs_c then 0uy else 1uy in
-    ((selector == 0uy ==> $result == $lhs_s) /\
-     (selector =!= 0uy ==> $result == $rhs_s))"#))]
+#[hax_lib::ensures(|result| fstar!(r#"if $lhs_c =. $rhs_c 
+    then $result == $lhs_s
+    else $result == $rhs_s"#))]
 pub(crate) fn compare_ciphertexts_select_shared_secret_in_constant_time(
     lhs_c: &[u8],
     rhs_c: &[u8],
     lhs_s: &[u8],
     rhs_s: &[u8],
-) -> [u8; SHARED_SECRET_SIZE] {
+    out: &mut [u8]
+) {
     let selector = compare_ciphertexts_in_constant_time(lhs_c, rhs_c);
 
-    select_shared_secret_in_constant_time(lhs_s, rhs_s, selector)
+    select_shared_secret_in_constant_time(lhs_s, rhs_s, selector, out);
 }

--- a/libcrux/libcrux-ml-kem/src/constants.rs
+++ b/libcrux/libcrux-ml-kem/src/constants.rs
@@ -33,3 +33,13 @@ pub(crate) const CPA_PKE_KEY_GENERATION_SEED_SIZE: usize = 32;
 pub(crate) const H_DIGEST_SIZE: usize = 32;
 /// SHA3 512 digest size
 pub(crate) const G_DIGEST_SIZE: usize = 64;
+
+/// K * BITS_PER_RING_ELEMENT / 8
+///
+/// [eurydice] Note that we can't use const generics here because that breaks
+///            C extraction with eurydice.
+#[hax_lib::requires(rank <= 4)]
+#[hax_lib::ensures(|result| result == rank * BITS_PER_RING_ELEMENT / 8)]
+pub(crate) const fn ranked_bytes_per_ring_element(rank: usize) -> usize {
+    rank * BITS_PER_RING_ELEMENT / 8
+}

--- a/libcrux/libcrux-ml-kem/src/hash_functions.rs
+++ b/libcrux/libcrux-ml-kem/src/hash_functions.rs
@@ -529,45 +529,20 @@ pub(crate) mod neon {
         match input.len() as u8 {
             2 => {
                 let (out0, out1) = outputs.split_at_mut(out_len);
-                x2::shake256(
-                    &input[0],
-                    &input[1],
-                    out0,
-                    out1,
-                );
+                x2::shake256(&input[0], &input[1], out0, out1);
             }
             3 => {
                 let (out0, rest) = outputs.split_at_mut(out_len);
                 let (out1, out2) = rest.split_at_mut(out_len);
-                x2::shake256(
-                    &input[0],
-                    &input[1],
-                    out0,
-                    out1,
-                );
-                x2::shake256(
-                    &input[2],
-                    &input[0],
-                    out2,
-                    &mut dummy,
-                );
+                x2::shake256(&input[0], &input[1], out0, out1);
+                x2::shake256(&input[2], &input[0], out2, &mut dummy);
             }
             4 => {
                 let (out0, rest) = outputs.split_at_mut(out_len);
                 let (out1, rest) = rest.split_at_mut(out_len);
                 let (out2, out3) = rest.split_at_mut(out_len);
-                x2::shake256(
-                    &input[0],
-                    &input[1],
-                    out0,
-                    out1,
-                );
-                x2::shake256(
-                    &input[2],
-                    &input[3],
-                    out2,
-                    out3,
-                );
+                x2::shake256(&input[0], &input[1], out0, out1);
+                x2::shake256(&input[2], &input[3], out2, out3);
             }
             _ => unreachable!("This function must only be called with N = 2, 3, 4"),
         }

--- a/libcrux/libcrux-ml-kem/src/hash_functions.rs
+++ b/libcrux/libcrux-ml-kem/src/hash_functions.rs
@@ -8,8 +8,6 @@
 // them to be properly abstracted in F*. We would like hax to do this automatically.
 // Related Issue: https://github.com/hacspec/hax/issues/616
 
-use crate::constants::{G_DIGEST_SIZE, H_DIGEST_SIZE};
-
 /// The SHA3 block size.
 pub(crate) const BLOCK_SIZE: usize = 168;
 
@@ -24,20 +22,20 @@ pub(crate) const THREE_BLOCKS: usize = BLOCK_SIZE * 3;
 /// - NEON
 /// - Portable
 #[hax_lib::attributes]
-pub(crate) trait Hash<const K: usize> {
+pub(crate) trait Hash {
     /// G aka SHA3 512
     #[requires(true)]
     #[ensures(|result|
         fstar!(r#"$result == Spec.Utils.v_G $input"#))
     ]
-    fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE];
+    fn G(input: &[u8], output: &mut [u8]);
 
     /// H aka SHA3 256
     #[requires(true)]
     #[ensures(|result|
         fstar!(r#"$result == Spec.Utils.v_H $input"#))
     ]
-    fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE];
+    fn H(input: &[u8], output: &mut [u8]);
 
     /// PRF aka SHAKE256
     #[requires(fstar!(r#"v $LEN < pow2 32"#))]
@@ -45,7 +43,7 @@ pub(crate) trait Hash<const K: usize> {
         // We need to repeat the pre-condition here because of https://github.com/hacspec/hax/issues/784
         fstar!(r#"v $LEN < pow2 32 ==> $result == Spec.Utils.v_PRF $LEN $input"#))
     ]
-    fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN];
+    fn PRF<const LEN: usize>(input: &[u8], out: &mut [u8]);
 
     /// PRFxN aka N SHAKE256
     #[requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
@@ -54,19 +52,20 @@ pub(crate) trait Hash<const K: usize> {
         fstar!(r#"(v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)) ==>
             $result == Spec.Utils.v_PRFxN $K $LEN $input"#))
     ]
-    fn PRFxN<const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K];
+    // fn PRFxN<const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K];
+    fn PRFxN(input: &[[u8; 33]], outputs: &mut [u8], out_len: usize);
 
     /// Create a SHAKE128 state and absorb the input.
     #[requires(true)]
-    fn shake128_init_absorb_final(input: [[u8; 34]; K]) -> Self;
+    fn shake128_init_absorb_final(input: &[[u8; 34]]) -> Self;
 
     /// Squeeze 3 blocks out of the SHAKE128 state.
     #[requires(true)]
-    fn shake128_squeeze_first_three_blocks(&mut self) -> [[u8; THREE_BLOCKS]; K];
+    fn shake128_squeeze_first_three_blocks(&mut self, output: &mut [[u8; THREE_BLOCKS]]);
 
     /// Squeeze 1 block out of the SHAKE128 state.
     #[requires(true)]
-    fn shake128_squeeze_next_block(&mut self) -> [[u8; BLOCK_SIZE]; K];
+    fn shake128_squeeze_next_block(&mut self, output: &mut [[u8; BLOCK_SIZE]]);
 }
 
 /// A portable implementation of [`Hash`]
@@ -79,28 +78,24 @@ pub(crate) mod portable {
     /// It's only used for SHAKE128.
     /// All other functions don't actually use any members.
     #[cfg_attr(hax, hax_lib::opaque)]
-    pub(crate) struct PortableHash<const K: usize> {
-        shake128_state: [KeccakState; K],
+    pub(crate) struct PortableHash {
+        shake128_state: [KeccakState; 4],
     }
 
     #[hax_lib::ensures(|result|
         fstar!(r#"$result == Spec.Utils.v_G $input"#))
     ]
     #[inline(always)]
-    fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE] {
-        let mut digest = [0u8; G_DIGEST_SIZE];
-        portable::sha512(&mut digest, input);
-        digest
+    fn G(input: &[u8], output: &mut [u8]) {
+        portable::sha512(output, input);
     }
 
     #[hax_lib::ensures(|result|
         fstar!(r#"$result == Spec.Utils.v_H $input"#))
     ]
     #[inline(always)]
-    fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE] {
-        let mut digest = [0u8; H_DIGEST_SIZE];
-        portable::sha256(&mut digest, input);
-        digest
+    fn H(input: &[u8], output: &mut [u8]) {
+        portable::sha256(output, input);
     }
 
     #[hax_lib::requires(fstar!(r#"v $LEN < pow2 32"#))]
@@ -108,10 +103,8 @@ pub(crate) mod portable {
         fstar!(r#"$result == Spec.Utils.v_PRF $LEN $input"#))
     ]
     #[inline(always)]
-    fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
-        let mut digest = [0u8; LEN];
-        portable::shake256(&mut digest, input);
-        digest
+    fn PRF<const LEN: usize>(input: &[u8], out: &mut [u8]) {
+        portable::shake256(out, input);
     }
 
     #[hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
@@ -119,72 +112,63 @@ pub(crate) mod portable {
         fstar!(r#"$result == Spec.Utils.v_PRFxN $K $LEN $input"#))
     ]
     #[inline(always)]
-    fn PRFxN<const K: usize, const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
-        debug_assert!(K == 2 || K == 3 || K == 4);
-
-        let mut out = [[0u8; LEN]; K];
-        for i in 0..K {
-            portable::shake256(&mut out[i], &input[i]);
+    fn PRFxN(input: &[[u8; 33]], outputs: &mut [u8], out_len: usize) {
+        for i in 0..input.len() {
+            portable::shake256(&mut outputs[i * out_len..(i + 1) * out_len], &input[i]);
         }
-        out
     }
 
     #[inline(always)]
-    fn shake128_init_absorb_final<const K: usize>(input: [[u8; 34]; K]) -> PortableHash<K> {
-        debug_assert!(K == 2 || K == 3 || K == 4);
+    fn shake128_init_absorb_final(input: &[[u8; 34]]) -> PortableHash {
+        debug_assert!(input.len() == 2 || input.len() == 3 || input.len() == 4);
 
-        let mut shake128_state = [incremental::shake128_init(); K];
-        for i in 0..K {
+        let mut shake128_state = [incremental::shake128_init(); 4];
+        for i in 0..input.len() {
             incremental::shake128_absorb_final(&mut shake128_state[i], &input[i]);
         }
         PortableHash { shake128_state }
     }
 
     #[inline(always)]
-    fn shake128_squeeze_first_three_blocks<const K: usize>(
-        st: &mut PortableHash<K>,
-    ) -> [[u8; THREE_BLOCKS]; K] {
-        debug_assert!(K == 2 || K == 3 || K == 4);
+    fn shake128_squeeze_first_three_blocks(
+        st: &mut PortableHash,
+        outputs: &mut [[u8; THREE_BLOCKS]],
+    ) {
+        debug_assert!(outputs.len() == 2 || outputs.len() == 3 || outputs.len() == 4);
 
-        let mut out = [[0u8; THREE_BLOCKS]; K];
-        for i in 0..K {
+        for i in 0..outputs.len() {
             incremental::shake128_squeeze_first_three_blocks(
                 &mut st.shake128_state[i],
-                &mut out[i],
+                &mut outputs[i],
             );
         }
-        out
     }
 
     #[inline(always)]
-    fn shake128_squeeze_next_block<const K: usize>(
-        st: &mut PortableHash<K>,
-    ) -> [[u8; BLOCK_SIZE]; K] {
-        debug_assert!(K == 2 || K == 3 || K == 4);
+    fn shake128_squeeze_next_block(st: &mut PortableHash, outputs: &mut [[u8; BLOCK_SIZE]]) {
+        debug_assert!(outputs.len() == 2 || outputs.len() == 3 || outputs.len() == 4);
 
-        let mut out = [[0u8; BLOCK_SIZE]; K];
-        for i in 0..K {
-            incremental::shake128_squeeze_next_block(&mut st.shake128_state[i], &mut out[i]);
+        for i in 0..outputs.len() {
+            incremental::shake128_squeeze_next_block(&mut st.shake128_state[i], &mut outputs[i]);
         }
-        out
     }
 
     #[hax_lib::attributes]
-    impl<const K: usize> Hash<K> for PortableHash<K> {
+    impl Hash for PortableHash {
         #[ensures(|out|
             fstar!(r#"$out == Spec.Utils.v_G $input"#))
         ]
         #[inline(always)]
-        fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE] {
-            G(input)
+        fn G(input: &[u8], output: &mut [u8]) {
+            G(input, output)
         }
 
         #[ensures(|out|
             fstar!(r#"$out == Spec.Utils.v_H $input"#))
         ]
         #[inline(always)]
-        fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE] {
-            H(input)
+        fn H(input: &[u8], output: &mut [u8]) {
+            H(input, output)
         }
 
         #[requires(fstar!(r#"v $LEN < pow2 32"#))]
@@ -193,8 +177,8 @@ pub(crate) mod portable {
             fstar!(r#"v $LEN < pow2 32 ==> $out == Spec.Utils.v_PRF $LEN $input"#))
         ]
         #[inline(always)]
-        fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
-            PRF::<LEN>(input)
+        fn PRF<const LEN: usize>(input: &[u8], out: &mut [u8]) {
+            PRF::<LEN>(input, out)
         }
 
         #[requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
@@ -203,23 +187,23 @@ pub(crate) mod portable {
                 $out == Spec.Utils.v_PRFxN $K $LEN $input"#))
         ]
         #[inline(always)]
-        fn PRFxN<const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
-            PRFxN::<K, LEN>(input)
+        fn PRFxN(input: &[[u8; 33]], outputs: &mut [u8], out_len: usize) {
+            PRFxN(input, outputs, out_len)
         }
 
         #[inline(always)]
-        fn shake128_init_absorb_final(input: [[u8; 34]; K]) -> Self {
+        fn shake128_init_absorb_final(input: &[[u8; 34]]) -> Self {
             shake128_init_absorb_final(input)
         }
 
         #[inline(always)]
-        fn shake128_squeeze_first_three_blocks(&mut self) -> [[u8; THREE_BLOCKS]; K] {
-            shake128_squeeze_first_three_blocks(self)
+        fn shake128_squeeze_first_three_blocks(&mut self, output: &mut [[u8; THREE_BLOCKS]]) {
+            shake128_squeeze_first_three_blocks(self, output)
         }
 
         #[inline(always)]
-        fn shake128_squeeze_next_block(&mut self) -> [[u8; BLOCK_SIZE]; K] {
-            shake128_squeeze_next_block(self)
+        fn shake128_squeeze_next_block(&mut self, output: &mut [[u8; BLOCK_SIZE]]) {
+            shake128_squeeze_next_block(self, output)
         }
     }
 }
@@ -246,20 +230,16 @@ pub(crate) mod avx2 {
         fstar!(r#"$result == Spec.Utils.v_G $input"#))
     ]
     #[inline(always)]
-    fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE] {
-        let mut digest = [0u8; G_DIGEST_SIZE];
-        portable::sha512(&mut digest, input);
-        digest
+    fn G(input: &[u8], output: &mut [u8]) {
+        portable::sha512(output, input);
     }
 
     #[hax_lib::ensures(|result|
         fstar!(r#"$result == Spec.Utils.v_H $input"#))
     ]
     #[inline(always)]
-    fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE] {
-        let mut digest = [0u8; H_DIGEST_SIZE];
-        portable::sha256(&mut digest, input);
-        digest
+    fn H(input: &[u8], output: &mut [u8]) {
+        portable::sha256(output, input);
     }
 
     #[hax_lib::requires(fstar!(r#"v $LEN < pow2 32"#))]
@@ -267,10 +247,8 @@ pub(crate) mod avx2 {
         fstar!(r#"$result == Spec.Utils.v_PRF $LEN $input"#))
     ]
     #[inline(always)]
-    fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
-        let mut digest = [0u8; LEN];
-        portable::shake256(&mut digest, input);
-        digest
+    fn PRF<const LEN: usize>(input: &[u8], out: &mut [u8]) {
+        portable::shake256(out, input);
     }
 
     #[hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
@@ -278,53 +256,67 @@ pub(crate) mod avx2 {
         fstar!(r#"$result == Spec.Utils.v_PRFxN $K $LEN $input"#))
     ]
     #[inline(always)]
-    fn PRFxN<const K: usize, const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
-        debug_assert!(K == 2 || K == 3 || K == 4);
-        let mut out = [[0u8; LEN]; K];
-        let mut out0 = [0u8; LEN];
-        let mut out1 = [0u8; LEN];
-        let mut out2 = [0u8; LEN];
-        let mut out3 = [0u8; LEN];
+    fn PRFxN(input: &[[u8; 33]], outputs: &mut [u8], out_len: usize) {
+        // XXX: The buffer sizes here are the maximum that we will
+        // need. PRFxN is called to fill N buffers of size
+        // `ETA1/2_RANDOMNESS_SIZE`. The maximum value for
+        // `ETA1/2_RANDOMNESS_SIZE` is in ML-KEM 512 with `ETA1 = 3`
+        // and `ETA1_RANDOMNESS_SIZE = ETA1 * 64`.  This means,
+        // unfortunately, that we overallocate and oversample in the
+        // other cases.
+        let mut dummy0 = [0u8; 3 * 64];
+        let mut dummy1 = [0u8; 3 * 64];
 
-        match K as u8 {
+        // XXX: If I understood correctly, the x4/2 SHAKEs assume that
+        // the output buffers are the same length and will write
+        // `out0.len()` bytes of output into all of them. That's okay
+        // for us, just want to document the assumption.
+        match input.len() as u8 {
             2 => {
+                let (out0, out1) = outputs.split_at_mut(out_len);
                 x4::shake256(
-                    &input[0], &input[1], &input[0], &input[0], &mut out0, &mut out1, &mut out2,
-                    &mut out3,
+                    &input[0],
+                    &input[1],
+                    &input[0],
+                    &input[0],
+                    out0,
+                    out1,
+                    &mut dummy0,
+                    &mut dummy1,
                 );
-                out[0] = out0;
-                out[1] = out1;
             }
             3 => {
+                let (out0, rest) = outputs.split_at_mut(out_len);
+                let (out1, out2) = rest.split_at_mut(out_len);
                 x4::shake256(
-                    &input[0], &input[1], &input[2], &input[0], &mut out0, &mut out1, &mut out2,
-                    &mut out3,
+                    &input[0],
+                    &input[1],
+                    &input[2],
+                    &input[0],
+                    out0,
+                    out1,
+                    out2,
+                    &mut dummy1,
                 );
-                out[0] = out0;
-                out[1] = out1;
-                out[2] = out2;
             }
             4 => {
+                let (out0, rest) = outputs.split_at_mut(out_len);
+                let (out1, rest) = rest.split_at_mut(out_len);
+                let (out2, out3) = rest.split_at_mut(out_len);
                 x4::shake256(
-                    &input[0], &input[1], &input[2], &input[3], &mut out0, &mut out1, &mut out2,
-                    &mut out3,
+                    &input[0], &input[1], &input[2], &input[3], out0, out1, out2, out3,
                 );
-                out[0] = out0;
-                out[1] = out1;
-                out[2] = out2;
-                out[3] = out3;
             }
             _ => unreachable!("This function must only be called with N = 2, 3, 4"),
         }
-        out
     }
 
     #[inline(always)]
-    fn shake128_init_absorb_final<const K: usize>(input: [[u8; 34]; K]) -> Simd256Hash {
-        debug_assert!(K == 2 || K == 3 || K == 4);
+    fn shake128_init_absorb_final(input: &[[u8; 34]]) -> Simd256Hash {
+        debug_assert!(input.len() == 2 || input.len() == 3 || input.len() == 4);
         let mut state = x4::incremental::init();
 
-        match K as u8 {
+        match input.len() as u8 {
             2 => {
                 x4::incremental::shake128_absorb_final(
                     &mut state, &input[0], &input[1], &input[0], &input[0],
@@ -349,11 +341,11 @@ pub(crate) mod avx2 {
     }
 
     #[inline(always)]
-    fn shake128_squeeze_first_three_blocks<const K: usize>(
+    fn shake128_squeeze_first_three_blocks(
         st: &mut Simd256Hash,
-    ) -> [[u8; THREE_BLOCKS]; K] {
-        debug_assert!(K == 2 || K == 3 || K == 4);
-        let mut out = [[0u8; THREE_BLOCKS]; K];
+        outputs: &mut [[u8; THREE_BLOCKS]],
+    ) {
+        debug_assert!(outputs.len() == 2 || outputs.len() == 3 || outputs.len() == 4);
         let mut out0 = [0u8; THREE_BLOCKS];
         let mut out1 = [0u8; THREE_BLOCKS];
         let mut out2 = [0u8; THREE_BLOCKS];
@@ -365,31 +357,29 @@ pub(crate) mod avx2 {
             &mut out2,
             &mut out3,
         );
-        match K as u8 {
+        match outputs.len() as u8 {
             2 => {
-                out[0] = out0;
-                out[1] = out1;
+                outputs[0] = out0;
+                outputs[1] = out1;
             }
             3 => {
-                out[0] = out0;
-                out[1] = out1;
-                out[2] = out2;
+                outputs[0] = out0;
+                outputs[1] = out1;
+                outputs[2] = out2;
             }
             4 => {
-                out[0] = out0;
-                out[1] = out1;
-                out[2] = out2;
-                out[3] = out3;
+                outputs[0] = out0;
+                outputs[1] = out1;
+                outputs[2] = out2;
+                outputs[3] = out3;
             }
             _ => unreachable!("This function must only be called with N = 2, 3, 4"),
         }
-        out
     }
 
     #[inline(always)]
-    fn shake128_squeeze_next_block<const K: usize>(st: &mut Simd256Hash) -> [[u8; BLOCK_SIZE]; K] {
-        debug_assert!(K == 2 || K == 3 || K == 4);
-        let mut out = [[0u8; BLOCK_SIZE]; K];
+    fn shake128_squeeze_next_block(st: &mut Simd256Hash, outputs: &mut [[u8; BLOCK_SIZE]]) {
+        debug_assert!(outputs.len() == 2 || outputs.len() == 3 || outputs.len() == 4);
         let mut out0 = [0u8; BLOCK_SIZE];
         let mut out1 = [0u8; BLOCK_SIZE];
         let mut out2 = [0u8; BLOCK_SIZE];
@@ -401,43 +391,42 @@ pub(crate) mod avx2 {
             &mut out2,
             &mut out3,
         );
-        match K as u8 {
+        match outputs.len() as u8 {
             2 => {
-                out[0] = out0;
-                out[1] = out1;
+                outputs[0] = out0;
+                outputs[1] = out1;
             }
             3 => {
-                out[0] = out0;
-                out[1] = out1;
-                out[2] = out2;
+                outputs[0] = out0;
+                outputs[1] = out1;
+                outputs[2] = out2;
             }
             4 => {
-                out[0] = out0;
-                out[1] = out1;
-                out[2] = out2;
-                out[3] = out3;
+                outputs[0] = out0;
+                outputs[1] = out1;
+                outputs[2] = out2;
+                outputs[3] = out3;
             }
             _ => unreachable!("This function is only called with 2, 3, 4"),
         }
-        out
     }
 
     #[hax_lib::attributes]
-    impl<const K: usize> Hash<K> for Simd256Hash {
+    impl Hash for Simd256Hash {
         #[ensures(|out|
             fstar!(r#"$out == Spec.Utils.v_G $input"#))
         ]
         #[inline(always)]
-        fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE] {
-            G(input)
+        fn G(input: &[u8], output: &mut [u8]) {
+            G(input, output)
         }
 
         #[ensures(|out|
             fstar!(r#"$out == Spec.Utils.v_H $input"#))
         ]
         #[inline(always)]
-        fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE] {
-            H(input)
+        fn H(input: &[u8], output: &mut [u8]) {
+            H(input, output)
         }
 
         #[requires(fstar!(r#"v $LEN < pow2 32"#))]
@@ -446,8 +435,8 @@ pub(crate) mod avx2 {
             fstar!(r#"v $LEN < pow2 32 ==> $out == Spec.Utils.v_PRF $LEN $input"#))
         ]
         #[inline(always)]
-        fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
-            PRF::<LEN>(input)
+        fn PRF<const LEN: usize>(input: &[u8], out: &mut [u8]) {
+            PRF::<LEN>(input, out)
         }
 
         #[requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
@@ -456,23 +445,23 @@ pub(crate) mod avx2 {
                 $out == Spec.Utils.v_PRFxN $K $LEN $input"#))
         ]
         #[inline(always)]
-        fn PRFxN<const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
-            PRFxN::<K, LEN>(input)
+        fn PRFxN(input: &[[u8; 33]], output: &mut [u8], out_len: usize) {
+            PRFxN(input, output, out_len)
         }
 
         #[inline(always)]
-        fn shake128_init_absorb_final(input: [[u8; 34]; K]) -> Self {
+        fn shake128_init_absorb_final(input: &[[u8; 34]]) -> Self {
             shake128_init_absorb_final(input)
         }
 
         #[inline(always)]
-        fn shake128_squeeze_first_three_blocks(&mut self) -> [[u8; THREE_BLOCKS]; K] {
-            shake128_squeeze_first_three_blocks(self)
+        fn shake128_squeeze_first_three_blocks(&mut self, outputs: &mut [[u8; THREE_BLOCKS]]) {
+            shake128_squeeze_first_three_blocks(self, outputs);
         }
 
         #[inline(always)]
-        fn shake128_squeeze_next_block(&mut self) -> [[u8; BLOCK_SIZE]; K] {
-            shake128_squeeze_next_block(self)
+        fn shake128_squeeze_next_block(&mut self, outputs: &mut [[u8; BLOCK_SIZE]]) {
+            shake128_squeeze_next_block(self, outputs);
         }
     }
 }
@@ -496,8 +485,8 @@ pub(crate) mod neon {
         fstar!(r#"$result == Spec.Utils.v_G $input"#))
     ]
     #[inline(always)]
-    fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE] {
-        let mut digest = [0u8; G_DIGEST_SIZE];
+    fn G(input: &[u8]) -> [u8] {
+        let mut digest = [0u8];
         libcrux_sha3::neon::sha512(&mut digest, input);
         digest
     }
@@ -506,8 +495,8 @@ pub(crate) mod neon {
         fstar!(r#"$result == Spec.Utils.v_H $input"#))
     ]
     #[inline(always)]
-    fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE] {
-        let mut digest = [0u8; H_DIGEST_SIZE];
+    fn H(input: &[u8]) -> [u8] {
+        let mut digest = [0u8];
         libcrux_sha3::neon::sha256(&mut digest, input);
         digest
     }
@@ -517,11 +506,9 @@ pub(crate) mod neon {
         fstar!(r#"$result == Spec.Utils.v_PRF $LEN $input"#))
     ]
     #[inline(always)]
-    fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
-        let mut digest = [0u8; LEN];
+    fn PRF<const LEN: usize>(input: &[u8], out: &mut [u8]) {
         let mut dummy = [0u8; LEN];
-        x2::shake256(input, input, &mut digest, &mut dummy);
-        digest
+        x2::shake256(input, input, out, &mut dummy);
     }
 
     #[hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
@@ -529,37 +516,61 @@ pub(crate) mod neon {
         fstar!(r#"$result == Spec.Utils.v_PRFxN $K $LEN $input"#))
     ]
     #[inline(always)]
-    fn PRFxN<const K: usize, const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
-        debug_assert!(K == 2 || K == 3 || K == 4);
-        let mut out = [[0u8; LEN]; K];
-        let mut out0 = [0u8; LEN];
-        let mut out1 = [0u8; LEN];
-        let mut out2 = [0u8; LEN];
-        let mut out3 = [0u8; LEN];
-        match K as u8 {
+    fn PRFxN(input: &[[u8; 33]], outputs: &mut [u8], out_len: usize) {
+        // XXX: The buffer sizes here are the maximum that we will
+        // need. PRFxN is called to fill N buffers of size
+        // `ETA1/2_RANDOMNESS_SIZE`. The maximum value for
+        // `ETA1/2_RANDOMNESS_SIZE` is in ML-KEM 512 with `ETA1 = 3`
+        // and `ETA1_RANDOMNESS_SIZE = ETA1 * 64`.  This means,
+        // unfortunately, that we overallocate and oversample in the
+        // other cases.
+        let mut dummy = [0u8; 3 * 64];
+
+        match input.len() as u8 {
             2 => {
-                x2::shake256(&input[0], &input[1], &mut out0, &mut out1);
-                out[0] = out0;
-                out[1] = out1;
+                let (out0, out1) = outputs.split_at_mut(out_len);
+                x2::shake256(
+                    &input[0],
+                    &input[1],
+                    out0,
+                    out1,
+                );
             }
             3 => {
-                x2::shake256(&input[0], &input[1], &mut out0, &mut out1);
-                x2::shake256(&input[2], &input[2], &mut out2, &mut out3);
-                out[0] = out0;
-                out[1] = out1;
-                out[2] = out2;
+                let (out0, rest) = outputs.split_at_mut(out_len);
+                let (out1, out2) = rest.split_at_mut(out_len);
+                x2::shake256(
+                    &input[0],
+                    &input[1],
+                    out0,
+                    out1,
+                );
+                x2::shake256(
+                    &input[2],
+                    &input[0],
+                    out2,
+                    &mut dummy,
+                );
             }
             4 => {
-                x2::shake256(&input[0], &input[1], &mut out0, &mut out1);
-                x2::shake256(&input[2], &input[3], &mut out2, &mut out3);
-                out[0] = out0;
-                out[1] = out1;
-                out[2] = out2;
-                out[3] = out3;
+                let (out0, rest) = outputs.split_at_mut(out_len);
+                let (out1, rest) = rest.split_at_mut(out_len);
+                let (out2, out3) = rest.split_at_mut(out_len);
+                x2::shake256(
+                    &input[0],
+                    &input[1],
+                    out0,
+                    out1,
+                );
+                x2::shake256(
+                    &input[2],
+                    &input[3],
+                    out2,
+                    out3,
+                );
             }
-            _ => unreachable!("Only 2, 3, or 4 are supported for N"),
+            _ => unreachable!("This function must only be called with N = 2, 3, 4"),
         }
-        out
     }
 
     #[inline(always)]
@@ -706,7 +717,7 @@ pub(crate) mod neon {
             fstar!(r#"$out == Spec.Utils.v_G $input"#))
         ]
         #[inline(always)]
-        fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE] {
+        fn G(input: &[u8]) -> [u8] {
             G(input)
         }
 
@@ -714,7 +725,7 @@ pub(crate) mod neon {
             fstar!(r#"$out == Spec.Utils.v_H $input"#))
         ]
         #[inline(always)]
-        fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE] {
+        fn H(input: &[u8]) -> [u8] {
             H(input)
         }
 
@@ -724,8 +735,8 @@ pub(crate) mod neon {
             fstar!(r#"v $LEN < pow2 32 ==> $out == Spec.Utils.v_PRF $LEN $input"#))
         ]
         #[inline(always)]
-        fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
-            PRF::<LEN>(input)
+        fn PRF<const LEN: usize>(input: &[u8], out: &mut [u8]) {
+            PRF::<LEN>(input, out)
         }
 
         #[requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]

--- a/libcrux/libcrux-ml-kem/src/ind_cca.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca.rs
@@ -9,7 +9,7 @@ use crate::{
     polynomial::PolynomialRingElement,
     serialize::deserialize_ring_elements_reduced,
     types::*,
-    utils::{into_padded_array, CycleCounter},
+    utils::into_padded_array,
     variant::*,
     vector::Operations,
 };
@@ -118,10 +118,12 @@ pub(crate) fn validate_public_key<
         &mut deserialized_pk,
     );
     let mut public_key_serialized = [0u8; PUBLIC_KEY_SIZE];
+    let mut scratch = Vector::ZERO();
     serialize_public_key_mut::<K, PUBLIC_KEY_SIZE, Vector>(
         &deserialized_pk,
         &public_key[ranked_bytes_per_ring_element(K)..],
         &mut public_key_serialized,
+        &mut scratch
     );
 
     *public_key == public_key_serialized
@@ -201,14 +203,12 @@ pub(crate) fn generate_keypair<
 >(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
 ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
-    CycleCounter::start_section("CCA generate_keypair", file!(), line!());
     let ind_cpa_keypair_randomness = &randomness[0..CPA_PKE_KEY_GENERATION_SEED_SIZE];
     let implicit_rejection_value = &randomness[CPA_PKE_KEY_GENERATION_SEED_SIZE..];
 
     let mut ind_cpa_private_key = [0u8; CPA_PRIVATE_KEY_SIZE];
     let mut public_key = [0u8; PUBLIC_KEY_SIZE];
-
-    CycleCounter::start_measurement("CPA generate_keypair", file!(), line!());
+    let mut scratch = PolynomialRingElement::<Vector>::ZERO();
     crate::ind_cpa::generate_keypair::<
         K,
         CPA_PRIVATE_KEY_SIZE,
@@ -223,10 +223,9 @@ pub(crate) fn generate_keypair<
         ind_cpa_keypair_randomness,
         &mut ind_cpa_private_key,
         &mut public_key,
+        &mut scratch
     );
-    CycleCounter::end_measurement("CPA generate_keypair", file!(), line!());
 
-    CycleCounter::start_measurement("serialize_kem_secret_key_mut", file!(), line!());
     let mut secret_key_serialized = [0u8; PRIVATE_KEY_SIZE];
     serialize_kem_secret_key_mut::<K, PRIVATE_KEY_SIZE, Hasher>(
         &ind_cpa_private_key,
@@ -236,9 +235,7 @@ pub(crate) fn generate_keypair<
     );
     let private_key: MlKemPrivateKey<PRIVATE_KEY_SIZE> =
         MlKemPrivateKey::from(secret_key_serialized);
-    CycleCounter::end_measurement("serialize_kem_secret_key_mut", file!(), line!());
-    
-    CycleCounter::end_section("CCA generate_keypair", file!(), line!());
+
     MlKemKeyPair::from(private_key, MlKemPublicKey::from(public_key))
 }
 
@@ -282,31 +279,27 @@ pub(crate) fn encapsulate<
     public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
     randomness: [u8; SHARED_SECRET_SIZE],
 ) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
-    CycleCounter::start_section("CCA encapsulate", file!(), line!());
     let mut processed_randomness = [0u8; 32];
     Scheme::entropy_preprocess::<K, Hasher>(&randomness, &mut processed_randomness);
     let mut to_hash: [u8; 2 * H_DIGEST_SIZE] = into_padded_array(&processed_randomness);
 
     hax_lib::fstar!(r#"eq_intro (Seq.slice $to_hash 0 32) $randomness"#);
-    CycleCounter::start_measurement("Hash H", file!(), line!());
     Hasher::H(public_key.as_slice(), &mut to_hash[H_DIGEST_SIZE..]);
-    CycleCounter::end_measurement("Hash H", file!(), line!());
+
     hax_lib::fstar!(
         "assert (Seq.slice to_hash 0 (v $H_DIGEST_SIZE) == $randomness);
         lemma_slice_append $to_hash $randomness (Spec.Utils.v_H ${public_key}.f_value);
         assert ($to_hash == concat $randomness (Spec.Utils.v_H ${public_key}.f_value))"
     );
-    CycleCounter::start_measurement("Hash G", file!(), line!());
     let mut hashed = [0u8; G_DIGEST_SIZE];
     Hasher::G(&to_hash, &mut hashed);
-    CycleCounter::end_measurement("Hash G", file!(), line!());
     let (shared_secret, pseudorandomness) = hashed.split_at(SHARED_SECRET_SIZE);
 
-    CycleCounter::start_measurement("CPA encrypt", file!(), line!());
     let mut ciphertext = [0u8; CIPHERTEXT_SIZE];
     let mut r_as_ntt: [PolynomialRingElement<Vector>; K] =
         core::array::from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
     let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
+    let mut scratch = PolynomialRingElement::<Vector>::ZERO();
     crate::ind_cpa::encrypt::<
         K,
         CIPHERTEXT_SIZE,
@@ -331,13 +324,12 @@ pub(crate) fn encapsulate<
         &mut ciphertext,
         &mut r_as_ntt,
         &mut error_2,
+        &mut scratch
     );
-    CycleCounter::end_measurement("CPA encrypt", file!(), line!());
-    
+
     let ciphertext = MlKemCiphertext::from(ciphertext);
     let mut shared_secret_array = [0u8; 32];
     Scheme::kdf::<K, CIPHERTEXT_SIZE, Hasher>(shared_secret, &ciphertext, &mut shared_secret_array);
-    CycleCounter::end_section("CCA encapsulate", file!(), line!());
     (ciphertext, shared_secret_array)
 }
 
@@ -389,7 +381,6 @@ pub(crate) fn decapsulate<
     private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
     ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
 ) -> MlKemSharedSecret {
-    CycleCounter::start_section("CCA decapsulate", file!(), line!());
     hax_lib::fstar!(
         r#"assert (v $CIPHERTEXT_SIZE == v $IMPLICIT_REJECTION_HASH_INPUT_SIZE - v $SHARED_SECRET_SIZE)"#
     );
@@ -405,6 +396,8 @@ pub(crate) fn decapsulate<
             (length ${private_key}.f_value))"#
     );
     let mut decrypted = [0u8; 32];
+    let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+
     crate::ind_cpa::decrypt::<
         K,
         CIPHERTEXT_SIZE,
@@ -412,7 +405,7 @@ pub(crate) fn decapsulate<
         VECTOR_U_COMPRESSION_FACTOR,
         VECTOR_V_COMPRESSION_FACTOR,
         Vector,
-    >(ind_cpa_secret_key, &ciphertext.value, &mut decrypted);
+        >(ind_cpa_secret_key, &ciphertext.value, &mut decrypted, &mut scratch);
 
     let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] = into_padded_array(&decrypted);
     hax_lib::fstar!(r#"eq_intro (Seq.slice $to_hash 0 32) $decrypted"#);
@@ -478,6 +471,7 @@ pub(crate) fn decapsulate<
         &mut expected_ciphertext,
         &mut r_as_ntt,
         &mut error_2,
+        &mut scratch
     );
 
     let mut implicit_rejection_shared_secret_kdf = [0u8; SHARED_SECRET_SIZE];
@@ -497,7 +491,6 @@ pub(crate) fn decapsulate<
         &implicit_rejection_shared_secret_kdf,
         &mut shared_secret,
     );
-    CycleCounter::end_section("CCA decapsulate", file!(), line!());
     shared_secret
 }
 
@@ -608,10 +601,12 @@ pub(crate) mod unpacked {
             &self,
             serialized: &mut MlKemPublicKey<PUBLIC_KEY_SIZE>,
         ) {
+            let mut scratch = Vector::ZERO();
             serialize_public_key_mut::<K, PUBLIC_KEY_SIZE, Vector>(
                 &self.ind_cpa_public_key.t_as_ntt,
                 &self.ind_cpa_public_key.seed_for_A,
                 &mut serialized.value,
+                &mut scratch
             );
         }
 
@@ -632,10 +627,12 @@ pub(crate) mod unpacked {
         )]
         pub fn serialized<const PUBLIC_KEY_SIZE: usize>(&self) -> MlKemPublicKey<PUBLIC_KEY_SIZE> {
             let mut public_key = [0u8; PUBLIC_KEY_SIZE];
+            let mut scratch = Vector::ZERO();
             serialize_public_key_mut::<K, PUBLIC_KEY_SIZE, Vector>(
                 &self.ind_cpa_public_key.t_as_ntt,
                 &self.ind_cpa_public_key.seed_for_A,
                 &mut public_key,
+                &mut scratch
             );
             MlKemPublicKey::from(public_key)
         }
@@ -810,7 +807,7 @@ pub(crate) mod unpacked {
         ) {
             let mut ind_cpa_private_key = [0u8; CPA_PRIVATE_KEY_SIZE];
             let mut ind_cpa_public_key = [0u8; PUBLIC_KEY_SIZE];
-
+            let mut scratch = Vector::ZERO();
             ind_cpa::serialize_unpacked_secret_key::<
                 K,
                 CPA_PRIVATE_KEY_SIZE,
@@ -821,6 +818,7 @@ pub(crate) mod unpacked {
                 &self.private_key.ind_cpa_private_key,
                 &mut ind_cpa_private_key,
                 &mut ind_cpa_public_key,
+                &mut scratch
             );
 
             serialize_kem_secret_key_mut::<K, PRIVATE_KEY_SIZE, PortableHash>(
@@ -871,6 +869,7 @@ pub(crate) mod unpacked {
                 Seq.index (Seq.index $result i) j ==
                     Seq.index (Seq.index $ind_cpa_a j) i)"#))
     ]
+    #[inline(always)]
     fn transpose_a<const K: usize, Vector: Operations>(
         ind_cpa_a: [[PolynomialRingElement<Vector>; K]; K],
     ) -> [[PolynomialRingElement<Vector>; K]; K] {
@@ -942,7 +941,7 @@ pub(crate) mod unpacked {
     ) {
         let ind_cpa_keypair_randomness = &randomness[0..CPA_PKE_KEY_GENERATION_SEED_SIZE];
         let implicit_rejection_value = &randomness[CPA_PKE_KEY_GENERATION_SEED_SIZE..];
-
+        let mut scratch = PolynomialRingElement::<Vector>::ZERO();
         generate_keypair_unpacked::<
             K,
             ETA1,
@@ -955,6 +954,7 @@ pub(crate) mod unpacked {
             ind_cpa_keypair_randomness,
             &mut out.private_key.ind_cpa_private_key,
             &mut out.public_key.ind_cpa_public_key,
+            &mut scratch
         );
 
         #[allow(non_snake_case)]
@@ -983,10 +983,12 @@ pub(crate) mod unpacked {
         out.public_key.ind_cpa_public_key.A = A;
 
         let mut pk_serialized = [0u8; PUBLIC_KEY_SIZE];
+        let mut scratch = Vector::ZERO();
         serialize_public_key_mut::<K, PUBLIC_KEY_SIZE, Vector>(
             &out.public_key.ind_cpa_public_key.t_as_ntt,
             &out.public_key.ind_cpa_public_key.seed_for_A,
             &mut pk_serialized,
+            &mut scratch
         );
         Hasher::H(&pk_serialized, &mut out.public_key.public_key_hash);
         out.private_key.implicit_rejection_value = implicit_rejection_value.try_into().unwrap();
@@ -1043,6 +1045,7 @@ pub(crate) mod unpacked {
         let mut r_as_ntt: [PolynomialRingElement<Vector>; K] =
             from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
         let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
+        let mut scratch = PolynomialRingElement::<Vector>::ZERO();
         ind_cpa::encrypt_unpacked::<
             K,
             CIPHERTEXT_SIZE,
@@ -1067,6 +1070,7 @@ pub(crate) mod unpacked {
             &mut ciphertext,
             &mut r_as_ntt,
             &mut error_2,
+            &mut scratch
         );
         let mut shared_secret_array = [0u8; SHARED_SECRET_SIZE];
         shared_secret_array.copy_from_slice(shared_secret);
@@ -1151,6 +1155,8 @@ pub(crate) mod unpacked {
         assert (v (Spec.MLKEM.v_C2_SIZE $K) == 32 * v (Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K))"#
         );
         let mut decrypted = [0u8; SHARED_SECRET_SIZE];
+
+        let mut scratch = PolynomialRingElement::<Vector>::ZERO();
         ind_cpa::decrypt_unpacked::<
             K,
             CIPHERTEXT_SIZE,
@@ -1162,6 +1168,7 @@ pub(crate) mod unpacked {
             &key_pair.private_key.ind_cpa_private_key,
             &ciphertext.value,
             &mut decrypted,
+            &mut scratch
         );
 
         let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] = into_padded_array(&decrypted);
@@ -1217,6 +1224,7 @@ pub(crate) mod unpacked {
             &mut expected_ciphertext,
             &mut r_as_ntt,
             &mut error_2,
+            &mut scratch
         );
 
         let selector =

--- a/libcrux/libcrux-ml-kem/src/ind_cca/incremental.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca/incremental.rs
@@ -1,0 +1,542 @@
+#![cfg(feature = "incremental")]
+
+//! # Incremental API.
+//!
+//! **WARNING:** This API is not standard compliant and may lead to insecure
+//! usage. Use at your own risk.
+use crate::{
+    constants::BITS_PER_RING_ELEMENT,
+    hash_functions::Hash,
+    ind_cca::{unpacked::MlKemPrivateKeyUnpacked, validate_public_key},
+    ind_cpa::{self, unpacked::IndCpaPrivateKeyUnpacked},
+    matrix::sample_matrix_A,
+    mlkem::impl_incr_platform,
+    polynomial::{vec_len_bytes, PolynomialRingElement},
+    utils::into_padded_array,
+    variant, vector, SHARED_SECRET_SIZE,
+};
+
+use super::{
+    unpacked::{encaps_prepare, MlKemKeyPairUnpacked, MlKemPublicKeyUnpacked},
+    MlKemSharedSecret, Operations, KEY_GENERATION_SEED_SIZE,
+};
+
+/// Key and state types.
+pub mod types;
+pub(crate) use types::*;
+
+// Platform instantiations
+
+#[cfg(feature = "simd256")]
+pub(crate) mod avx2 {
+    use super::*;
+
+    impl_incr_platform!(
+        vector::SIMD256Vector,
+        crate::hash_functions::avx2::Simd256Hash,
+        unsafe,
+        #[cfg_attr(not(hax), target_feature(enable = "avx2"))],
+        #[allow(unsafe_code)]
+    );
+}
+#[cfg(feature = "simd128")]
+pub(crate) mod neon {
+    use super::*;
+
+    impl_incr_platform!(
+        crate::vector::SIMD128Vector,
+        crate::hash_functions::neon::Simd128Hash
+    );
+}
+pub(crate) mod portable {
+    use super::*;
+
+    impl_incr_platform!(
+        vector::portable::PortableVector,
+        crate::hash_functions::portable::PortableHash<K>
+    );
+}
+
+/// Multiplexing incremental API.
+///
+/// Note that this requires alloc support and is not `no_std` compatible
+pub(crate) mod multiplexing;
+
+/// Generate a key pair for incremental encapsulation.
+///
+/// This generates a regular unpacked key pair [`MlKemKeyPairUnpacked`].
+/// The two parts of the public key can be extracted with [`pk1`] and [`pk2`].
+///
+/// To [`decapsulate`], the entire key pair is used again.
+#[inline(always)]
+pub(crate) fn generate_keypair<
+    const K: usize,
+    const CPA_PRIVATE_KEY_SIZE: usize,
+    const PRIVATE_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    Vector: Operations,
+    Hasher: Hash<K>,
+>(
+    randomness: [u8; KEY_GENERATION_SEED_SIZE],
+) -> MlKemKeyPairUnpacked<K, Vector> {
+    // Generate unpacked key pair.
+    let mut kp = MlKemKeyPairUnpacked::new();
+    super::unpacked::generate_keypair::<
+        K,
+        CPA_PRIVATE_KEY_SIZE,
+        PRIVATE_KEY_SIZE,
+        PUBLIC_KEY_SIZE,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        Vector,
+        Hasher,
+        variant::MlKem,
+    >(randomness, &mut kp);
+
+    kp
+}
+
+/// Generate a key pair for incremental encapsulation.
+///
+/// This generates a regular key pair and writes
+/// it into the `key_pair` output bytes.
+///
+/// The public keys can be extracted from the bytes.
+#[inline(always)]
+pub(crate) fn generate_keypair_compressed<
+    const K: usize,
+    const PK2_LEN: usize,
+    const CPA_PRIVATE_KEY_SIZE: usize,
+    const PRIVATE_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const KEYPAIR_LEN: usize,
+    Vector: Operations,
+    Hasher: Hash<K>,
+>(
+    randomness: [u8; KEY_GENERATION_SEED_SIZE],
+    key_pair: &mut [u8; KEYPAIR_LEN],
+) {
+    // Generate unpacked key pair.
+    let mut kp = MlKemKeyPairUnpacked::new();
+    super::unpacked::generate_keypair::<
+        K,
+        CPA_PRIVATE_KEY_SIZE,
+        PRIVATE_KEY_SIZE,
+        PUBLIC_KEY_SIZE,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        Vector,
+        Hasher,
+        variant::MlKem,
+    >(randomness, &mut kp);
+
+    let kp = KeyPair::<K, PK2_LEN, Vector>::from(kp);
+    kp.to_bytes_compressed::<KEYPAIR_LEN, CPA_PRIVATE_KEY_SIZE>(key_pair);
+}
+
+/// Generate a key pair for incremental encapsulation.
+///
+/// This generates a regular unpacked key pair [`MlKemKeyPairUnpacked`] and writes
+/// it into the `key_pair` output bytes.
+///
+/// The public keys can be extracted from the bytes TODO.
+#[inline(always)]
+pub(crate) fn generate_keypair_serialized<
+    const K: usize,
+    const PK2_LEN: usize,
+    const CPA_PRIVATE_KEY_SIZE: usize,
+    const PRIVATE_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    Vector: Operations,
+    Hasher: Hash<K>,
+>(
+    randomness: [u8; KEY_GENERATION_SEED_SIZE],
+    key_pair: &mut [u8],
+) -> Result<(), Error> {
+    // Generate unpacked key pair.
+    let mut kp = MlKemKeyPairUnpacked::new();
+    super::unpacked::generate_keypair::<
+        K,
+        CPA_PRIVATE_KEY_SIZE,
+        PRIVATE_KEY_SIZE,
+        PUBLIC_KEY_SIZE,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        Vector,
+        Hasher,
+        variant::MlKem,
+    >(randomness, &mut kp);
+
+    let kp = KeyPair::<K, PK2_LEN, Vector>::from(kp);
+    kp.to_bytes(key_pair)
+}
+
+#[inline(always)]
+pub(crate) fn encapsulate1<
+    const K: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const C1_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_U_BLOCK_LEN: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+    Vector: Operations,
+    Hasher: Hash<K>,
+>(
+    pk1: &PublicKey1,
+    randomness: [u8; SHARED_SECRET_SIZE],
+) -> (Ciphertext1<C1_SIZE>, EncapsState<K, Vector>, [u8; 32]) {
+    let hashed = encaps_prepare::<K, Hasher>(&randomness, &pk1.hash);
+    let (shared_secret, pseudorandomness) = hashed.split_at(SHARED_SECRET_SIZE);
+
+    // Rebuild the matrix A from the seed
+    let mut matrix = [[PolynomialRingElement::<Vector>::ZERO(); K]; K];
+    sample_matrix_A::<K, Vector, Hasher>(&mut matrix, into_padded_array(&pk1.seed), false);
+
+    let mut ciphertext = [0u8; C1_SIZE];
+    let (r_as_ntt, error2) = ind_cpa::encrypt_c1::<
+        K,
+        C1_SIZE,
+        VECTOR_U_COMPRESSION_FACTOR,
+        VECTOR_U_BLOCK_LEN,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        ETA2,
+        ETA2_RANDOMNESS_SIZE,
+        Vector,
+        Hasher,
+    >(&pseudorandomness, &matrix, &mut ciphertext);
+
+    let state = EncapsState {
+        randomness,
+        r_as_ntt,
+        error2,
+    };
+    (
+        Ciphertext1 { value: ciphertext },
+        state,
+        shared_secret.try_into().unwrap(),
+    )
+}
+
+#[inline(always)]
+pub(crate) fn encapsulate1_serialized<
+    const K: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const C1_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_U_BLOCK_LEN: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+    Vector: Operations,
+    Hasher: Hash<K>,
+>(
+    pk1: &PublicKey1,
+    randomness: [u8; SHARED_SECRET_SIZE],
+    state: &mut [u8],
+    shared_secret: &mut [u8],
+) -> Result<Ciphertext1<C1_SIZE>, Error> {
+    debug_assert!(shared_secret.len() >= SHARED_SECRET_SIZE);
+    if shared_secret.len() < SHARED_SECRET_SIZE {
+        return Err(Error::InvalidOutputLength);
+    }
+
+    let (ct1, encaps_state, ss) = encapsulate1::<
+        K,
+        CIPHERTEXT_SIZE,
+        C1_SIZE,
+        VECTOR_U_COMPRESSION_FACTOR,
+        VECTOR_U_BLOCK_LEN,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        ETA2,
+        ETA2_RANDOMNESS_SIZE,
+        Vector,
+        Hasher,
+    >(pk1, randomness);
+
+    // Write out the state
+    encaps_state.to_bytes(state)?;
+    shared_secret[..SHARED_SECRET_SIZE].copy_from_slice(&ss);
+
+    // Return the ciphertext
+    Ok(ct1)
+}
+
+/// Check that the pk1 and pk2 parts are consistent.
+#[inline(always)]
+pub(crate) fn validate_pk<
+    const K: usize,
+    const PK_LEN: usize,
+    Hasher: Hash<K>,
+    Vector: Operations,
+>(
+    pk1: &PublicKey1,
+    pk2: &[u8],
+) -> Result<(), Error> {
+    let pk2_len = K * BITS_PER_RING_ELEMENT / 8;
+    if pk2.len() != pk2_len {
+        return Err(Error::InvalidInputLength);
+    }
+
+    validate_pk_parts::<K, PK_LEN, Hasher, Vector>(&pk1.seed, &pk1.hash, pk2)
+}
+
+/// Check that the pk1 and pk2 parts are consistent.
+#[inline(always)]
+pub(crate) fn validate_pk_bytes<
+    const K: usize,
+    const PK_LEN: usize,
+    Hasher: Hash<K>,
+    Vector: Operations,
+>(
+    pk1: &[u8],
+    pk2: &[u8],
+) -> Result<(), Error> {
+    let pk2_len = K * BITS_PER_RING_ELEMENT / 8;
+    if pk1.len() != 64 || pk2.len() != pk2_len {
+        return Err(Error::InvalidInputLength);
+    }
+
+    validate_pk_parts::<K, PK_LEN, Hasher, Vector>(&pk1[0..32], &pk1[32..], pk2)
+}
+
+#[inline(always)]
+fn validate_pk_parts<const K: usize, const PK_LEN: usize, Hasher: Hash<K>, Vector: Operations>(
+    pk1_seed: &[u8],
+    pk1_hash: &[u8],
+    pk2: &[u8],
+) -> Result<(), Error> {
+    // Build the full public key: t || 𝜌
+    let mut pk = [0u8; PK_LEN];
+    let pk2_len = K * BITS_PER_RING_ELEMENT / 8;
+    debug_assert!(pk2_len == pk2.len());
+
+    pk[0..pk2_len].copy_from_slice(&pk2);
+    pk[pk2_len..].copy_from_slice(&pk1_seed);
+
+    let hash = Hasher::H(&pk);
+    if hash != pk1_hash {
+        return Err(Error::InvalidPublicKey);
+    }
+
+    // Check the domain of t
+    if !validate_public_key::<K, PK_LEN, Vector>(&pk) {
+        return Err(Error::InvalidPublicKey);
+    }
+
+    Ok(())
+}
+
+#[inline(always)]
+pub(crate) fn encapsulate2<
+    const K: usize,
+    const PK2_LEN: usize,
+    const C2_SIZE: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    Vector: Operations,
+>(
+    state: &EncapsState<K, Vector>,
+    pk2: &PublicKey2<PK2_LEN>,
+) -> Ciphertext2<C2_SIZE> {
+    let mut ciphertext = [0u8; C2_SIZE];
+    let t_as_ntt = pk2.deserialize();
+
+    ind_cpa::encrypt_c2::<K, VECTOR_V_COMPRESSION_FACTOR, C2_SIZE, Vector>(
+        &t_as_ntt,
+        &state.r_as_ntt,
+        &state.error2,
+        state.randomness,
+        &mut ciphertext,
+    );
+
+    Ciphertext2 { value: ciphertext }
+}
+
+#[inline(always)]
+pub(crate) fn encapsulate2_serialized<
+    const K: usize,
+    const PK2_LEN: usize,
+    const C2_SIZE: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const STATE_LEN: usize,
+    Vector: Operations,
+>(
+    state: &[u8; STATE_LEN],
+    public_key_part: &PublicKey2<PK2_LEN>,
+) -> Ciphertext2<C2_SIZE> {
+    let state = EncapsState::from_bytes(state);
+
+    encapsulate2::<K, PK2_LEN, C2_SIZE, VECTOR_V_COMPRESSION_FACTOR, Vector>(
+        &state,
+        public_key_part,
+    )
+}
+
+#[inline(always)]
+pub(crate) fn decapsulate<
+    const K: usize,
+    const SECRET_KEY_SIZE: usize,
+    const CPA_SECRET_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const C1_BLOCK_SIZE: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+    const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+    Vector: Operations,
+    Hasher: Hash<K>,
+>(
+    private_key: &MlKemKeyPairUnpacked<K, Vector>,
+    ciphertext1: &Ciphertext1<C1_SIZE>,
+    ciphertext2: &Ciphertext2<C2_SIZE>,
+) -> MlKemSharedSecret {
+    let mut ciphertext = [0u8; CIPHERTEXT_SIZE];
+    ciphertext[..C1_SIZE].copy_from_slice(&ciphertext1.value);
+    ciphertext[C1_SIZE..].copy_from_slice(&ciphertext2.value);
+    crate::ind_cca::unpacked::decapsulate::<
+        K,
+        SECRET_KEY_SIZE,
+        CPA_SECRET_KEY_SIZE,
+        PUBLIC_KEY_SIZE,
+        CIPHERTEXT_SIZE,
+        T_AS_NTT_ENCODED_SIZE,
+        C1_SIZE,
+        C2_SIZE,
+        VECTOR_U_COMPRESSION_FACTOR,
+        VECTOR_V_COMPRESSION_FACTOR,
+        C1_BLOCK_SIZE,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        ETA2,
+        ETA2_RANDOMNESS_SIZE,
+        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+        Vector,
+        Hasher,
+    >(private_key, &ciphertext.into())
+}
+
+#[inline(always)]
+pub(crate) fn decapsulate_incremental_key<
+    const K: usize,
+    const PK2_LEN: usize,
+    const SECRET_KEY_SIZE: usize,
+    const CPA_SECRET_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const C1_BLOCK_SIZE: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+    const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+    Vector: Operations,
+    Hasher: Hash<K>,
+>(
+    key: &[u8],
+    ciphertext1: &Ciphertext1<C1_SIZE>,
+    ciphertext2: &Ciphertext2<C2_SIZE>,
+) -> Result<MlKemSharedSecret, Error> {
+    // Build an unpacked key pair from the input bytes.
+    let key_pair: KeyPair<K, PK2_LEN, Vector> = KeyPair::from_bytes(key)?;
+
+    let mut ciphertext = [0u8; CIPHERTEXT_SIZE];
+    ciphertext[..C1_SIZE].copy_from_slice(&ciphertext1.value);
+    ciphertext[C1_SIZE..].copy_from_slice(&ciphertext2.value);
+
+    Ok(crate::ind_cca::unpacked::decapsulate::<
+        K,
+        SECRET_KEY_SIZE,
+        CPA_SECRET_KEY_SIZE,
+        PUBLIC_KEY_SIZE,
+        CIPHERTEXT_SIZE,
+        T_AS_NTT_ENCODED_SIZE,
+        C1_SIZE,
+        C2_SIZE,
+        VECTOR_U_COMPRESSION_FACTOR,
+        VECTOR_V_COMPRESSION_FACTOR,
+        C1_BLOCK_SIZE,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        ETA2,
+        ETA2_RANDOMNESS_SIZE,
+        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+        Vector,
+        Hasher,
+    >(&key_pair.into(), &ciphertext.into()))
+}
+
+#[inline(always)]
+pub(crate) fn decapsulate_compressed_key<
+    const K: usize,
+    const PK2_LEN: usize,
+    const SECRET_KEY_SIZE: usize,
+    const CPA_SECRET_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const C1_BLOCK_SIZE: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+    const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+    Vector: Operations,
+    Hasher: Hash<K>,
+>(
+    private_key: &[u8; SECRET_KEY_SIZE],
+    ciphertext1: &Ciphertext1<C1_SIZE>,
+    ciphertext2: &Ciphertext2<C2_SIZE>,
+) -> MlKemSharedSecret {
+    let mut ciphertext = [0u8; CIPHERTEXT_SIZE];
+    ciphertext[..C1_SIZE].copy_from_slice(&ciphertext1.value);
+    ciphertext[C1_SIZE..].copy_from_slice(&ciphertext2.value);
+
+    crate::ind_cca::decapsulate::<
+        K,
+        SECRET_KEY_SIZE,
+        CPA_SECRET_KEY_SIZE,
+        PUBLIC_KEY_SIZE,
+        CIPHERTEXT_SIZE,
+        T_AS_NTT_ENCODED_SIZE,
+        C1_SIZE,
+        C2_SIZE,
+        VECTOR_U_COMPRESSION_FACTOR,
+        VECTOR_V_COMPRESSION_FACTOR,
+        C1_BLOCK_SIZE,
+        ETA1,
+        ETA1_RANDOMNESS_SIZE,
+        ETA2,
+        ETA2_RANDOMNESS_SIZE,
+        IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+        Vector,
+        Hasher,
+        variant::MlKem,
+    >(&private_key.into(), &ciphertext.into())
+}

--- a/libcrux/libcrux-ml-kem/src/ind_cca/incremental/README.md
+++ b/libcrux/libcrux-ml-kem/src/ind_cca/incremental/README.md
@@ -1,0 +1,63 @@
+# Incremental API
+
+This module implements an incremental API for ML-KEM that allows incremental
+encapsulation.
+
+## Keys
+
+The `generate_keypair` function generates an "unpacked" key pair, which is not
+serialized according to FIP 203.
+Instead, it keeps the unserialized values, which makes decapsulation significantly
+faster.
+The unpacked key pair is defined as follows:
+
+- private key
+  - secret in ntt (vector of rank)
+  - implicit rejection value (32 bytes)
+- public key
+  - t in NTT (vector of rank)
+  - seed for matrix A (32 bytes)
+  - matrix A (rank x rank)
+  - public key hash (32 bytes)
+
+A vector of rank is of the size `512*rank` where rank is 2, 3 or 4, for ML-KEM 512, 768, 1024.
+
+For the incremental API, we split this key up as follows:
+
+- Public key 1
+  - seed for matrix A (32 byte)
+  - public key hash (32 bytes)
+- Public key 2
+  - serialized t (rank * 384)
+- private key (unpacked)
+- matrix A (rank x rank)
+
+### Compressed key bytes
+
+When space is more important than speed, the key pair can be stored with a serialized
+private key, which is `s | (t | ⍴) | H(ek) | z` where `s = dk_PKE` and `(t | ⍴) = ek`.
+This is `2 * ((rank * 3072) / 8) + 3 * 32` bytes, which is 1632, 2400, 3168 bytes for ML-KEM 512, 768, 1024.
+
+## Encapsulation
+
+With these keys, we can now encapsulate in two steps.
+
+### Encapsulate 1
+
+First, the initiator sends the public key 1 to the other party.
+Using this, the other party can generate the first part of the ciphertext c1.
+
+### Encapsulate 2
+
+After receiving the second part of the public key, the other party can generate
+ciphertext c2.
+
+Before performing the second step of the encapsulation, the caller should ensure
+that the public key is valid.
+Because the public key is sent in two steps, `validate_pk` should be used for to
+ensure that the two parts are consistent with each other.
+
+## Decapsulation
+
+After the initiator received both ciphertexts c1 and c2, it can decapsulate
+the shared secret, using the private key.

--- a/libcrux/libcrux-ml-kem/src/ind_cca/incremental/multiplexing.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca/incremental/multiplexing.rs
@@ -1,0 +1,748 @@
+use super::*;
+
+#[cfg(all(feature = "simd256", feature = "alloc"))]
+use avx2::{as_keypair as as_avx2_keypair, as_state as as_avx2_state};
+#[cfg(feature = "simd256")]
+use avx2::{
+    decapsulate as decapsulate_avx2, decapsulate_compressed_key as decapsulate_compressed_key_avx2,
+    decapsulate_incremental_key as decapsulate_incremental_key_avx2,
+    encapsulate1 as encapsulate1_avx2, encapsulate1_serialized as encapsulate1_serialized_avx2,
+    encapsulate2 as encapsulate2_avx2, encapsulate2_serialized as encapsulate2_serialized_avx2,
+    generate_keypair as generate_keypair_avx2,
+    generate_keypair_compressed as generate_keypair_compressed_avx2,
+    generate_keypair_serialized as generate_keypair_serialized_avx2,
+    validate_pk as validate_pk_avx2, validate_pk_bytes as validate_pk_bytes_avx2,
+};
+
+#[cfg(all(feature = "simd128", feature = "alloc"))]
+use neon::{as_keypair as as_neon_keypair, as_state as as_neon_state};
+#[cfg(feature = "simd128")]
+use neon::{
+    decapsulate as decapsulate_neon, decapsulate_compressed_key as decapsulate_compressed_key_neon,
+    decapsulate_incremental_key as decapsulate_incremental_key_neon,
+    encapsulate1 as encapsulate1_neon, encapsulate1_serialized as encapsulate1_serialized_neon,
+    encapsulate2 as encapsulate2_neon, encapsulate2_serialized as encapsulate2_serialized_neon,
+    generate_keypair as generate_keypair_neon,
+    generate_keypair_compressed as generate_keypair_compressed_neon,
+    generate_keypair_serialized as generate_keypair_serialized_neon,
+    validate_pk as validate_pk_neon, validate_pk_bytes as validate_pk_bytes_neon,
+};
+
+#[cfg(all(not(feature = "simd256"), feature = "alloc"))]
+use portable::{as_keypair as as_avx2_keypair, as_state as as_avx2_state};
+#[cfg(not(feature = "simd256"))]
+use portable::{
+    decapsulate as decapsulate_avx2, decapsulate_compressed_key as decapsulate_compressed_key_avx2,
+    decapsulate_incremental_key as decapsulate_incremental_key_avx2,
+    encapsulate1 as encapsulate1_avx2, encapsulate1_serialized as encapsulate1_serialized_avx2,
+    encapsulate2 as encapsulate2_avx2, encapsulate2_serialized as encapsulate2_serialized_avx2,
+    generate_keypair as generate_keypair_avx2,
+    generate_keypair_compressed as generate_keypair_compressed_avx2,
+    generate_keypair_serialized as generate_keypair_serialized_avx2,
+    validate_pk as validate_pk_avx2, validate_pk_bytes as validate_pk_bytes_avx2,
+};
+
+#[cfg(all(not(feature = "simd128"), feature = "alloc"))]
+use portable::{as_keypair as as_neon_keypair, as_state as as_neon_state};
+#[cfg(not(feature = "simd128"))]
+use portable::{
+    decapsulate as decapsulate_neon, decapsulate_compressed_key as decapsulate_compressed_key_neon,
+    decapsulate_incremental_key as decapsulate_incremental_key_neon,
+    encapsulate1 as encapsulate1_neon, encapsulate1_serialized as encapsulate1_serialized_neon,
+    encapsulate2 as encapsulate2_neon, encapsulate2_serialized as encapsulate2_serialized_neon,
+    generate_keypair as generate_keypair_neon,
+    generate_keypair_compressed as generate_keypair_compressed_neon,
+    generate_keypair_serialized as generate_keypair_serialized_neon,
+    validate_pk as validate_pk_neon, validate_pk_bytes as validate_pk_bytes_neon,
+};
+
+/// Functions in this module require an allocator to use [`Box`].
+///
+/// Instead of serializing keys and state, the functions in this module return
+/// the platform dependent keys and state types for immediate use.
+#[cfg(feature = "alloc")]
+pub(crate) mod alloc {
+    use super::*;
+    use crate::ind_cca::incremental::types::alloc::{Keys, State};
+    use ::alloc::boxed::Box;
+
+    #[inline(always)]
+    pub(crate) fn generate_keypair<
+        const K: usize,
+        const CPA_PRIVATE_KEY_SIZE: usize,
+        const PRIVATE_KEY_SIZE: usize,
+        const PUBLIC_KEY_SIZE: usize,
+        const BYTES_PER_RING_ELEMENT: usize,
+        const ETA1: usize,
+        const ETA1_RANDOMNESS_SIZE: usize,
+    >(
+        randomness: [u8; KEY_GENERATION_SEED_SIZE],
+    ) -> Box<dyn Keys> {
+        if libcrux_platform::simd256_support() {
+            // This is only unsafe on avx2 platforms
+            #[allow(unsafe_code, unused_unsafe)]
+            let keys = unsafe {
+                generate_keypair_avx2::<
+                    K,
+                    CPA_PRIVATE_KEY_SIZE,
+                    PRIVATE_KEY_SIZE,
+                    PUBLIC_KEY_SIZE,
+                    BYTES_PER_RING_ELEMENT,
+                    ETA1,
+                    ETA1_RANDOMNESS_SIZE,
+                >(randomness)
+            };
+            Box::new(keys)
+        } else if libcrux_platform::simd128_support() {
+            Box::new(generate_keypair_neon::<
+                K,
+                CPA_PRIVATE_KEY_SIZE,
+                PRIVATE_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                BYTES_PER_RING_ELEMENT,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+            >(randomness))
+        } else {
+            Box::new(portable::generate_keypair::<
+                K,
+                CPA_PRIVATE_KEY_SIZE,
+                PRIVATE_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                BYTES_PER_RING_ELEMENT,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+            >(randomness))
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn encapsulate1<
+        const K: usize,
+        const CIPHERTEXT_SIZE: usize,
+        const C1_SIZE: usize,
+        const VECTOR_U_COMPRESSION_FACTOR: usize,
+        const VECTOR_U_BLOCK_LEN: usize,
+        const ETA1: usize,
+        const ETA1_RANDOMNESS_SIZE: usize,
+        const ETA2: usize,
+        const ETA2_RANDOMNESS_SIZE: usize,
+    >(
+        public_key_part: &PublicKey1,
+        randomness: [u8; SHARED_SECRET_SIZE],
+    ) -> (
+        Ciphertext1<C1_SIZE>,
+        Box<dyn State>,
+        [u8; SHARED_SECRET_SIZE],
+    ) {
+        if libcrux_platform::simd256_support() {
+            // This is only unsafe on avx2 platforms
+            #[allow(unsafe_code, unused_unsafe)]
+            let (c, s, ss) = unsafe {
+                encapsulate1_avx2::<
+                    K,
+                    CIPHERTEXT_SIZE,
+                    C1_SIZE,
+                    VECTOR_U_COMPRESSION_FACTOR,
+                    VECTOR_U_BLOCK_LEN,
+                    ETA1,
+                    ETA1_RANDOMNESS_SIZE,
+                    ETA2,
+                    ETA2_RANDOMNESS_SIZE,
+                >(public_key_part, randomness)
+            };
+            (c, Box::new(s), ss)
+        } else if libcrux_platform::simd128_support() {
+            let (c, s, ss) = encapsulate1_neon::<
+                K,
+                CIPHERTEXT_SIZE,
+                C1_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_U_BLOCK_LEN,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+            >(public_key_part, randomness);
+            (c, Box::new(s), ss)
+        } else {
+            let (c, s, ss) = portable::encapsulate1::<
+                K,
+                CIPHERTEXT_SIZE,
+                C1_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_U_BLOCK_LEN,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+            >(public_key_part, randomness);
+            (c, Box::new(s), ss)
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn encapsulate2<
+        const K: usize,
+        const PK2_LEN: usize,
+        const C2_SIZE: usize,
+        const VECTOR_V_COMPRESSION_FACTOR: usize,
+    >(
+        state: &dyn State,
+        public_key_part: &[u8],
+    ) -> Result<Ciphertext2<C2_SIZE>, Error> {
+        if libcrux_platform::simd256_support() {
+            let as_avx2_state = as_avx2_state(state.as_any());
+            let state = as_avx2_state;
+            let pk2 = PublicKey2::try_from(public_key_part)?;
+
+            // This is only unsafe on avx2 platforms
+            #[allow(unsafe_code, unused_unsafe)]
+            let ct = unsafe {
+                encapsulate2_avx2::<K, PK2_LEN, C2_SIZE, VECTOR_V_COMPRESSION_FACTOR>(state, &pk2)
+            };
+            Ok(ct)
+        } else if libcrux_platform::simd128_support() {
+            let state = as_neon_state(state.as_any());
+            let pk2 = PublicKey2::try_from(public_key_part)?;
+            Ok(encapsulate2_neon::<
+                K,
+                PK2_LEN,
+                C2_SIZE,
+                VECTOR_V_COMPRESSION_FACTOR,
+            >(state, &pk2))
+        } else {
+            let state = portable::as_state(state.as_any());
+            let pk2 = PublicKey2::try_from(public_key_part)?;
+            Ok(portable::encapsulate2::<
+                K,
+                PK2_LEN,
+                C2_SIZE,
+                VECTOR_V_COMPRESSION_FACTOR,
+            >(state, &pk2))
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn decapsulate<
+        const K: usize,
+        const SECRET_KEY_SIZE: usize,
+        const CPA_SECRET_KEY_SIZE: usize,
+        const PUBLIC_KEY_SIZE: usize,
+        const CIPHERTEXT_SIZE: usize,
+        const T_AS_NTT_ENCODED_SIZE: usize,
+        const C1_SIZE: usize,
+        const C2_SIZE: usize,
+        const VECTOR_U_COMPRESSION_FACTOR: usize,
+        const VECTOR_V_COMPRESSION_FACTOR: usize,
+        const C1_BLOCK_SIZE: usize,
+        const ETA1: usize,
+        const ETA1_RANDOMNESS_SIZE: usize,
+        const ETA2: usize,
+        const ETA2_RANDOMNESS_SIZE: usize,
+        const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+    >(
+        private_key: &dyn Keys,
+        ciphertext1: &Ciphertext1<C1_SIZE>,
+        ciphertext2: &Ciphertext2<C2_SIZE>,
+    ) -> MlKemSharedSecret {
+        if libcrux_platform::simd256_support() {
+            let private_key = as_avx2_keypair(private_key.as_any());
+
+            // This is only unsafe on avx2 platforms
+            #[allow(unsafe_code, unused_unsafe)]
+            unsafe {
+                decapsulate_avx2::<
+                    K,
+                    SECRET_KEY_SIZE,
+                    CPA_SECRET_KEY_SIZE,
+                    PUBLIC_KEY_SIZE,
+                    CIPHERTEXT_SIZE,
+                    T_AS_NTT_ENCODED_SIZE,
+                    C1_SIZE,
+                    C2_SIZE,
+                    VECTOR_U_COMPRESSION_FACTOR,
+                    VECTOR_V_COMPRESSION_FACTOR,
+                    C1_BLOCK_SIZE,
+                    ETA1,
+                    ETA1_RANDOMNESS_SIZE,
+                    ETA2,
+                    ETA2_RANDOMNESS_SIZE,
+                    IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+                >(private_key, ciphertext1, ciphertext2)
+            }
+        } else if libcrux_platform::simd128_support() {
+            let private_key = as_neon_keypair(private_key.as_any());
+            decapsulate_neon::<
+                K,
+                SECRET_KEY_SIZE,
+                CPA_SECRET_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                CIPHERTEXT_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                C1_BLOCK_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+            >(private_key, ciphertext1, ciphertext2)
+        } else {
+            let private_key = portable::as_keypair(private_key.as_any());
+            portable::decapsulate::<
+                K,
+                SECRET_KEY_SIZE,
+                CPA_SECRET_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                CIPHERTEXT_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                C1_BLOCK_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+            >(private_key, ciphertext1, ciphertext2)
+        }
+    }
+}
+
+#[inline(always)]
+pub(crate) fn generate_keypair<
+    const K: usize,
+    const PK2_LEN: usize,
+    const CPA_PRIVATE_KEY_SIZE: usize,
+    const PRIVATE_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const BYTES_PER_RING_ELEMENT: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+>(
+    randomness: [u8; KEY_GENERATION_SEED_SIZE],
+    key_pair: &mut [u8],
+) -> Result<(), Error> {
+    if libcrux_platform::simd256_support() {
+        // This is only unsafe on avx2 platforms
+        #[allow(unsafe_code, unused_unsafe)]
+        unsafe {
+            generate_keypair_serialized_avx2::<
+                K,
+                PK2_LEN,
+                CPA_PRIVATE_KEY_SIZE,
+                PRIVATE_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                BYTES_PER_RING_ELEMENT,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+            >(randomness, key_pair)
+        }
+    } else if libcrux_platform::simd128_support() {
+        generate_keypair_serialized_neon::<
+            K,
+            PK2_LEN,
+            CPA_PRIVATE_KEY_SIZE,
+            PRIVATE_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            BYTES_PER_RING_ELEMENT,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+        >(randomness, key_pair)
+    } else {
+        portable::generate_keypair_serialized::<
+            K,
+            PK2_LEN,
+            CPA_PRIVATE_KEY_SIZE,
+            PRIVATE_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            BYTES_PER_RING_ELEMENT,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+        >(randomness, key_pair)
+    }
+}
+
+#[inline(always)]
+pub(crate) fn generate_keypair_compressed<
+    const K: usize,
+    const PK2_LEN: usize,
+    const CPA_PRIVATE_KEY_SIZE: usize,
+    const PRIVATE_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const BYTES_PER_RING_ELEMENT: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const KEYPAIR_LEN: usize,
+>(
+    randomness: [u8; KEY_GENERATION_SEED_SIZE],
+    key_pair: &mut [u8; KEYPAIR_LEN],
+) {
+    if libcrux_platform::simd256_support() {
+        // This is only unsafe on avx2 platforms
+        #[allow(unsafe_code, unused_unsafe)]
+        unsafe {
+            generate_keypair_compressed_avx2::<
+                K,
+                PK2_LEN,
+                CPA_PRIVATE_KEY_SIZE,
+                PRIVATE_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                BYTES_PER_RING_ELEMENT,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                KEYPAIR_LEN,
+            >(randomness, key_pair)
+        }
+    } else if libcrux_platform::simd128_support() {
+        generate_keypair_compressed_neon::<
+            K,
+            PK2_LEN,
+            CPA_PRIVATE_KEY_SIZE,
+            PRIVATE_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            BYTES_PER_RING_ELEMENT,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            KEYPAIR_LEN,
+        >(randomness, key_pair)
+    } else {
+        portable::generate_keypair_compressed::<
+            K,
+            PK2_LEN,
+            CPA_PRIVATE_KEY_SIZE,
+            PRIVATE_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            BYTES_PER_RING_ELEMENT,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            KEYPAIR_LEN,
+        >(randomness, key_pair)
+    }
+}
+
+#[inline(always)]
+pub(crate) fn validate_pk<const K: usize, const PK_LEN: usize>(
+    pk1: &PublicKey1,
+    pk2: &[u8],
+) -> Result<(), Error> {
+    if libcrux_platform::simd256_support() {
+        // This is only unsafe on avx2 platforms
+        #[allow(unsafe_code, unused_unsafe)]
+        unsafe {
+            validate_pk_avx2::<K, PK_LEN>(pk1, pk2)
+        }
+    } else if libcrux_platform::simd128_support() {
+        validate_pk_neon::<K, PK_LEN>(pk1, pk2)
+    } else {
+        portable::validate_pk::<K, PK_LEN>(pk1, pk2)
+    }
+}
+
+#[inline(always)]
+pub(crate) fn validate_pk_bytes<const K: usize, const PK_LEN: usize>(
+    pk1: &[u8],
+    pk2: &[u8],
+) -> Result<(), Error> {
+    if libcrux_platform::simd256_support() {
+        // This is only unsafe on avx2 platforms
+        #[allow(unsafe_code, unused_unsafe)]
+        unsafe {
+            validate_pk_bytes_avx2::<K, PK_LEN>(pk1, pk2)
+        }
+    } else if libcrux_platform::simd128_support() {
+        validate_pk_bytes_neon::<K, PK_LEN>(pk1, pk2)
+    } else {
+        portable::validate_pk_bytes::<K, PK_LEN>(pk1, pk2)
+    }
+}
+
+#[inline(always)]
+pub(crate) fn encapsulate1<
+    const K: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const C1_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_U_BLOCK_LEN: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+>(
+    public_key_part: &PublicKey1,
+    randomness: [u8; SHARED_SECRET_SIZE],
+    state: &mut [u8],
+    shared_secret: &mut [u8],
+) -> Result<Ciphertext1<C1_SIZE>, Error> {
+    if libcrux_platform::simd256_support() {
+        // This is only unsafe on avx2 platforms
+        #[allow(unsafe_code, unused_unsafe)]
+        unsafe {
+            encapsulate1_serialized_avx2::<
+                K,
+                CIPHERTEXT_SIZE,
+                C1_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_U_BLOCK_LEN,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+            >(public_key_part, randomness, state, shared_secret)
+        }
+    } else if libcrux_platform::simd128_support() {
+        encapsulate1_serialized_neon::<
+            K,
+            CIPHERTEXT_SIZE,
+            C1_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_U_BLOCK_LEN,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+        >(public_key_part, randomness, state, shared_secret)
+    } else {
+        portable::encapsulate1_serialized::<
+            K,
+            CIPHERTEXT_SIZE,
+            C1_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_U_BLOCK_LEN,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+        >(public_key_part, randomness, state, shared_secret)
+    }
+}
+
+#[inline(always)]
+pub(crate) fn encapsulate2<
+    const K: usize,
+    const PK2_LEN: usize,
+    const C2_SIZE: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const STATE_LEN: usize,
+>(
+    state: &[u8; STATE_LEN],
+    public_key_part: &[u8; PK2_LEN],
+) -> Ciphertext2<C2_SIZE> {
+    if libcrux_platform::simd256_support() {
+        let pk2 = PublicKey2::from(public_key_part);
+
+        // This is only unsafe on avx2 platforms
+        #[allow(unsafe_code, unused_unsafe)]
+        unsafe {
+            encapsulate2_serialized_avx2::<
+                K,
+                PK2_LEN,
+                C2_SIZE,
+                VECTOR_V_COMPRESSION_FACTOR,
+                STATE_LEN,
+            >(state, &pk2)
+        }
+    } else if libcrux_platform::simd128_support() {
+        let pk2 = PublicKey2::from(public_key_part);
+        encapsulate2_serialized_neon::<K, PK2_LEN, C2_SIZE, VECTOR_V_COMPRESSION_FACTOR, STATE_LEN>(
+            state, &pk2,
+        )
+    } else {
+        let pk2 = PublicKey2::from(public_key_part);
+        portable::encapsulate2_serialized::<
+            K,
+            PK2_LEN,
+            C2_SIZE,
+            VECTOR_V_COMPRESSION_FACTOR,
+            STATE_LEN,
+        >(state, &pk2)
+    }
+}
+
+#[inline(always)]
+pub(crate) fn decapsulate<
+    const K: usize,
+    const PK2_LEN: usize,
+    const SECRET_KEY_SIZE: usize,
+    const CPA_SECRET_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const C1_BLOCK_SIZE: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+    const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+>(
+    private_key: &[u8],
+    ciphertext1: &Ciphertext1<C1_SIZE>,
+    ciphertext2: &Ciphertext2<C2_SIZE>,
+) -> Result<MlKemSharedSecret, Error> {
+    if libcrux_platform::simd256_support() {
+        // This is only unsafe on avx2 platforms
+        #[allow(unsafe_code, unused_unsafe)]
+        unsafe {
+            decapsulate_incremental_key_avx2::<
+                K,
+                PK2_LEN,
+                SECRET_KEY_SIZE,
+                CPA_SECRET_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                CIPHERTEXT_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                C1_BLOCK_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+            >(private_key, ciphertext1, ciphertext2)
+        }
+    } else if libcrux_platform::simd128_support() {
+        decapsulate_incremental_key_neon::<
+            K,
+            PK2_LEN,
+            SECRET_KEY_SIZE,
+            CPA_SECRET_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            CIPHERTEXT_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            C1_BLOCK_SIZE,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+            IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+        >(private_key, ciphertext1, ciphertext2)
+    } else {
+        portable::decapsulate_incremental_key::<
+            K,
+            PK2_LEN,
+            SECRET_KEY_SIZE,
+            CPA_SECRET_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            CIPHERTEXT_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            C1_BLOCK_SIZE,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+            IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+        >(private_key, ciphertext1, ciphertext2)
+    }
+}
+
+#[inline(always)]
+pub(crate) fn decapsulate_compressed<
+    const K: usize,
+    const PK2_LEN: usize,
+    const SECRET_KEY_SIZE: usize,
+    const CPA_SECRET_KEY_SIZE: usize,
+    const PUBLIC_KEY_SIZE: usize,
+    const CIPHERTEXT_SIZE: usize,
+    const T_AS_NTT_ENCODED_SIZE: usize,
+    const C1_SIZE: usize,
+    const C2_SIZE: usize,
+    const VECTOR_U_COMPRESSION_FACTOR: usize,
+    const VECTOR_V_COMPRESSION_FACTOR: usize,
+    const C1_BLOCK_SIZE: usize,
+    const ETA1: usize,
+    const ETA1_RANDOMNESS_SIZE: usize,
+    const ETA2: usize,
+    const ETA2_RANDOMNESS_SIZE: usize,
+    const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+>(
+    private_key: &[u8; SECRET_KEY_SIZE],
+    ciphertext1: &Ciphertext1<C1_SIZE>,
+    ciphertext2: &Ciphertext2<C2_SIZE>,
+) -> MlKemSharedSecret {
+    if libcrux_platform::simd256_support() {
+        // This is only unsafe on avx2 platforms
+        #[allow(unsafe_code, unused_unsafe)]
+        unsafe {
+            decapsulate_compressed_key_avx2::<
+                K,
+                PK2_LEN,
+                SECRET_KEY_SIZE,
+                CPA_SECRET_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                CIPHERTEXT_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                C1_BLOCK_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+            >(private_key, ciphertext1, ciphertext2)
+        }
+    } else if libcrux_platform::simd128_support() {
+        decapsulate_compressed_key_neon::<
+            K,
+            PK2_LEN,
+            SECRET_KEY_SIZE,
+            CPA_SECRET_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            CIPHERTEXT_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            C1_BLOCK_SIZE,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+            IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+        >(private_key, ciphertext1, ciphertext2)
+    } else {
+        portable::decapsulate_compressed_key::<
+            K,
+            PK2_LEN,
+            SECRET_KEY_SIZE,
+            CPA_SECRET_KEY_SIZE,
+            PUBLIC_KEY_SIZE,
+            CIPHERTEXT_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            C1_BLOCK_SIZE,
+            ETA1,
+            ETA1_RANDOMNESS_SIZE,
+            ETA2,
+            ETA2_RANDOMNESS_SIZE,
+            IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+        >(private_key, ciphertext1, ciphertext2)
+    }
+}

--- a/libcrux/libcrux-ml-kem/src/ind_cca/incremental/types.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca/incremental/types.rs
@@ -1,0 +1,473 @@
+use core::array::from_fn;
+
+use ind_cpa::unpacked::IndCpaPublicKeyUnpacked;
+
+use super::*;
+use crate::{
+    ind_cca::unpacked::MlKemKeyPairUnpacked,
+    ind_cpa::{deserialize_vector, serialize_vector},
+    polynomial::{vec_from_bytes, vec_to_bytes},
+};
+
+/// Errors
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Error {
+    /// Invalid input byte length
+    InvalidInputLength,
+
+    /// Invalid output byte length
+    InvalidOutputLength,
+
+    /// The public key is not consistent.
+    InvalidPublicKey,
+
+    /// Insufficient randomness.
+    InsufficientRandomness,
+}
+
+/// Incremental trait for unpacked key pairs.
+//<const K: usize, Vector: Operations>
+pub trait IncrementalKeyPair {
+    /// Get the [`PublicKey1`] from this key pair as bytes.
+    ///
+    /// The output `bytes` have to be at least 64 bytes long.
+    fn pk1_bytes(&self, bytes: &mut [u8]) -> Result<(), Error>;
+
+    /// Get the [`PublicKey2`] from this key pair as bytes.
+    ///
+    /// The output `bytes` have to be at least K * 16 * 32 bytes long.
+    ///
+    /// **PANICS:** if the output `bytes` are too short.
+    fn pk2_bytes(&self, bytes: &mut [u8]);
+}
+
+impl<const K: usize, Vector: Operations> IncrementalKeyPair for MlKemKeyPairUnpacked<K, Vector> {
+    fn pk1_bytes(&self, bytes: &mut [u8]) -> Result<(), Error> {
+        debug_assert!(bytes.len() >= 64);
+        if bytes.len() < 64 {
+            return Err(Error::InvalidOutputLength);
+        }
+
+        bytes[0..32].copy_from_slice(&self.public_key().ind_cpa_public_key.seed_for_A);
+        bytes[32..64].copy_from_slice(&self.public_key().public_key_hash);
+
+        Ok(())
+    }
+
+    fn pk2_bytes(&self, bytes: &mut [u8]) {
+        serialize_vector(&self.public_key.ind_cpa_public_key.t_as_ntt, bytes);
+    }
+}
+
+/// The incremental public key that allows generating [`Ciphertext1`].
+#[derive(Default)]
+pub struct PublicKey1 {
+    pub(super) seed: [u8; 32],
+    pub(super) hash: [u8; 32],
+}
+
+impl PublicKey1 {
+    /// Get the size of the first public key in bytes.
+    pub const fn len() -> usize {
+        32 + 32
+    }
+}
+
+impl TryFrom<&[u8]> for PublicKey1 {
+    type Error = Error;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() < 64 {
+            return Err(Error::InvalidInputLength);
+        }
+
+        let mut seed = [0u8; 32];
+        seed.copy_from_slice(&value[0..32]);
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&value[32..64]);
+        Ok(Self { seed, hash })
+    }
+}
+
+impl From<&[u8; 64]> for PublicKey1 {
+    fn from(value: &[u8; 64]) -> Self {
+        let mut seed = [0u8; 32];
+        seed.copy_from_slice(&value[0..32]);
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&value[32..64]);
+        Self { seed, hash }
+    }
+}
+
+/// The incremental public key that allows generating [`Ciphertext2`].
+///
+/// This public key is serialized to safe bytes on the wire.
+#[repr(transparent)]
+pub struct PublicKey2<const LEN: usize> {
+    pub(super) t_as_ntt: [u8; LEN],
+}
+
+impl<const LEN: usize> PublicKey2<LEN> {
+    /// Get the size of the second public key in bytes.
+    pub const fn len() -> usize {
+        LEN
+    }
+
+    /// Deserialize the public key.
+    pub(crate) fn deserialize<const K: usize, Vector: Operations>(
+        &self,
+    ) -> [PolynomialRingElement<Vector>; K] {
+        deserialize_vector(&self.t_as_ntt)
+    }
+}
+
+#[cfg(feature = "alloc")]
+pub(crate) mod alloc {
+    use super::*;
+    use core::any::Any;
+
+    /// Trait container for multiplexing over platform dependent [`MlKemKeyPairUnpacked`].
+    pub trait Keys: IncrementalKeyPair {
+        fn as_any(&self) -> &dyn Any;
+    }
+    impl<const K: usize, Vector: Operations + 'static> Keys for MlKemKeyPairUnpacked<K, Vector> {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    /// Trait container for multiplexing over platform dependent [`EncapsState`].
+    pub trait State {
+        fn as_any(&self) -> &dyn Any;
+    }
+
+    impl<const K: usize, Vector: Operations + 'static> State for EncapsState<K, Vector> {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+}
+
+/// The partial ciphertext c1 - first part.
+#[repr(transparent)]
+pub struct Ciphertext1<const LEN: usize> {
+    pub value: [u8; LEN],
+}
+
+impl<const LEN: usize> Ciphertext1<LEN> {
+    /// The size of the ciphertext.
+    pub const fn len() -> usize {
+        LEN
+    }
+}
+
+/// The partial ciphertext c2 - second part.
+#[repr(transparent)]
+pub struct Ciphertext2<const LEN: usize> {
+    pub value: [u8; LEN],
+}
+
+impl<const LEN: usize> Ciphertext2<LEN> {
+    /// The size of the ciphertext.
+    pub const fn len() -> usize {
+        LEN
+    }
+}
+
+/// The incremental state for encapsulate.
+pub struct EncapsState<const K: usize, Vector: Operations> {
+    pub(super) r_as_ntt: [PolynomialRingElement<Vector>; K],
+    pub(super) error2: PolynomialRingElement<Vector>,
+    pub(super) randomness: [u8; 32],
+}
+
+impl<const K: usize, Vector: Operations> EncapsState<K, Vector> {
+    /// Get the number of bytes, required for the state.
+    pub const fn num_bytes() -> usize {
+        vec_len_bytes::<K, Vector>() + PolynomialRingElement::<Vector>::num_bytes() + 32
+    }
+
+    /// Get the state as bytes
+    pub fn to_bytes(self, state: &mut [u8]) -> Result<(), Error> {
+        debug_assert!(state.len() >= Self::num_bytes());
+        if state.len() < Self::num_bytes() {
+            return Err(Error::InvalidOutputLength);
+        }
+
+        let mut offset = 0;
+        vec_to_bytes(&self.r_as_ntt, &mut state[offset..]);
+        offset += vec_len_bytes::<K, Vector>();
+
+        self.error2.to_bytes(&mut state[offset..]);
+        offset += PolynomialRingElement::<Vector>::num_bytes();
+
+        state[offset..offset + 32].copy_from_slice(&self.randomness);
+
+        Ok(())
+    }
+
+    /// Build a state from bytes
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        debug_assert!(bytes.len() >= Self::num_bytes());
+        if bytes.len() < Self::num_bytes() {
+            return Err(Error::InvalidInputLength);
+        }
+
+        let mut offset = 0;
+        let mut r_as_ntt = from_fn(|_| PolynomialRingElement::<Vector>::ZERO());
+        vec_from_bytes(&bytes[offset..], &mut r_as_ntt);
+        offset += vec_len_bytes::<K, Vector>();
+
+        let error2 = PolynomialRingElement::<Vector>::from_bytes(&bytes[offset..]);
+        offset += PolynomialRingElement::<Vector>::num_bytes();
+
+        let mut randomness = [0u8; 32];
+        randomness.copy_from_slice(&bytes[offset..offset + 32]);
+
+        Ok(Self {
+            r_as_ntt,
+            error2,
+            randomness,
+        })
+    }
+
+    /// Build a state from bytes
+    pub fn from_bytes<const STATE_LEN: usize>(bytes: &[u8; STATE_LEN]) -> Self {
+        // Unwrapping here is safe because we know it's the correct size.
+        Self::try_from_bytes(bytes).unwrap()
+    }
+}
+
+// === Implementations
+
+/// Convert [`MlKemPublicKeyUnpacked`] to a [`PublicKey1`]
+impl<const K: usize, Vector: Operations> From<&MlKemPublicKeyUnpacked<K, Vector>> for PublicKey1 {
+    fn from(pk: &MlKemPublicKeyUnpacked<K, Vector>) -> Self {
+        Self {
+            seed: pk.ind_cpa_public_key.seed_for_A,
+            hash: pk.public_key_hash,
+        }
+    }
+}
+
+/// Convert [`MlKemPublicKeyUnpacked`] to a [`PublicKey2`].
+impl<const K: usize, const LEN: usize, Vector: Operations> From<&MlKemPublicKeyUnpacked<K, Vector>>
+    for PublicKey2<LEN>
+{
+    fn from(pk: &MlKemPublicKeyUnpacked<K, Vector>) -> Self {
+        let mut out = Self {
+            t_as_ntt: [0u8; LEN],
+        };
+        serialize_vector(&pk.ind_cpa_public_key.t_as_ntt, &mut out.t_as_ntt);
+        out
+    }
+}
+
+/// Convert a byte slice `&[u8]` to a [`PublicKey2`].
+impl<const LEN: usize> TryFrom<&[u8]> for PublicKey2<LEN> {
+    type Error = Error;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() < LEN {
+            return Err(Error::InvalidInputLength);
+        }
+
+        let mut t_as_ntt = [0u8; LEN];
+        t_as_ntt.copy_from_slice(&value[0..LEN]);
+        Ok(Self { t_as_ntt })
+    }
+}
+
+/// Convert bytes `&[u8; LEN]` to a [`PublicKey2`].
+impl<const LEN: usize> From<&[u8; LEN]> for PublicKey2<LEN> {
+    fn from(value: &[u8; LEN]) -> Self {
+        let mut t_as_ntt = [0u8; LEN];
+        t_as_ntt.copy_from_slice(&value[0..LEN]);
+        Self { t_as_ntt }
+    }
+}
+
+// The key pair struct that we (de)serialize.
+pub struct KeyPair<const K: usize, const PK2_LEN: usize, Vector: Operations> {
+    pk1: PublicKey1,
+    pk2: PublicKey2<PK2_LEN>,
+    sk: MlKemPrivateKeyUnpacked<K, Vector>,
+    matrix: [[PolynomialRingElement<Vector>; K]; K],
+}
+
+impl<const K: usize, const PK2_LEN: usize, Vector: Operations> From<MlKemKeyPairUnpacked<K, Vector>>
+    for KeyPair<K, PK2_LEN, Vector>
+{
+    fn from(kp: MlKemKeyPairUnpacked<K, Vector>) -> Self {
+        KeyPair {
+            pk1: PublicKey1::from(kp.public_key()),
+            pk2: PublicKey2::from(kp.public_key()),
+            sk: kp.private_key,
+            matrix: kp.public_key.ind_cpa_public_key.A,
+        }
+    }
+}
+
+impl<const K: usize, const PK2_LEN: usize, Vector: Operations> From<KeyPair<K, PK2_LEN, Vector>>
+    for MlKemKeyPairUnpacked<K, Vector>
+{
+    fn from(value: KeyPair<K, PK2_LEN, Vector>) -> Self {
+        MlKemKeyPairUnpacked {
+            private_key: value.sk,
+            public_key: MlKemPublicKeyUnpacked {
+                ind_cpa_public_key: IndCpaPublicKeyUnpacked {
+                    t_as_ntt: deserialize_vector(&value.pk2.t_as_ntt),
+                    seed_for_A: value.pk1.seed,
+                    A: value.matrix,
+                },
+                public_key_hash: value.pk1.hash,
+            },
+        }
+    }
+}
+
+/// Write `value` into `out` at `offset`.
+#[inline(always)]
+fn write(out: &mut [u8], value: &[u8], offset: &mut usize) {
+    let new_offset = *offset + value.len();
+    out[*offset..new_offset].copy_from_slice(value);
+    *offset = new_offset;
+}
+
+impl<const K: usize, const PK2_LEN: usize, Vector: Operations> KeyPair<K, PK2_LEN, Vector> {
+    /// Get [`PublicKey1`] as bytes.
+    pub fn pk1_bytes(&self, pk1: &mut [u8]) -> Result<(), Error> {
+        debug_assert!(pk1.len() >= PublicKey1::len());
+        if pk1.len() < PublicKey1::len() {
+            return Err(Error::InvalidOutputLength);
+        }
+
+        pk1[0..32].copy_from_slice(&self.pk1.seed);
+        pk1[32..64].copy_from_slice(&self.pk1.hash);
+
+        Ok(())
+    }
+
+    /// Get [`PublicKey2`] as bytes.
+    pub fn pk2_bytes(&self, pk2: &mut [u8]) -> Result<(), Error> {
+        if pk2.len() < PK2_LEN {
+            return Err(Error::InvalidOutputLength);
+        }
+
+        pk2[0..PK2_LEN].copy_from_slice(&self.pk2.t_as_ntt);
+
+        Ok(())
+    }
+
+    /// The byte size of this key pair.
+    pub const fn num_bytes() -> usize {
+        PublicKey1::len() + PublicKey2::<PK2_LEN>::len()
+        // sk length
+        + vec_len_bytes::<K, Vector>() + 32
+        // matrix length
+        + K * vec_len_bytes::<K, Vector>()
+    }
+
+    /// Write this key pair into the `key` bytes.
+    ///
+    /// `key` must be at least of length `num_bytes()`
+    pub fn to_bytes(&self, key: &mut [u8]) -> Result<(), Error> {
+        debug_assert!(key.len() >= Self::num_bytes());
+        if key.len() < Self::num_bytes() {
+            return Err(Error::InvalidInputLength);
+        }
+
+        let mut offset = 0;
+
+        // PK1
+        write(key, &self.pk1.seed, &mut offset);
+        write(key, &self.pk1.hash, &mut offset);
+
+        // PK2
+        write(key, &self.pk2.t_as_ntt, &mut offset);
+
+        // SK
+        vec_to_bytes(
+            &self.sk.ind_cpa_private_key.secret_as_ntt,
+            &mut key[offset..],
+        );
+        offset += vec_len_bytes::<K, Vector>();
+        write(key, &self.sk.implicit_rejection_value, &mut offset);
+
+        // Matrix
+        for i in 0..self.matrix.len() {
+            vec_to_bytes(&self.matrix[i], &mut key[offset..]);
+            offset += vec_len_bytes::<K, Vector>();
+        }
+
+        Ok(())
+    }
+
+    /// Write this key pair into the `key` bytes.
+    /// This is the compressed private key.
+    ///
+    /// `key` must be at least of length secret key size
+    ///
+    /// Layout: dk | ek | H(ek) | z
+    pub fn to_bytes_compressed<const KEY_SIZE: usize, const VEC_SIZE: usize>(
+        &self,
+        key: &mut [u8; KEY_SIZE],
+    ) {
+        // Write the private key.
+        // This is a manual version of serialize_kem_secret_key_mut that skips
+        // the hash.
+        serialize_vector(&self.sk.ind_cpa_private_key.secret_as_ntt, key);
+        let mut offset = VEC_SIZE;
+
+        // ek = t | ⍴
+        write(key, &self.pk2.t_as_ntt, &mut offset);
+        write(key, &self.pk1.seed, &mut offset);
+
+        write(key, &self.pk1.hash, &mut offset);
+        write(key, &self.sk.implicit_rejection_value, &mut offset);
+    }
+
+    /// Read a key pair from the `key` bytes.
+    ///
+    /// `key` must be at least of length `num_bytes()`
+    pub fn from_bytes(key: &[u8]) -> Result<Self, Error> {
+        debug_assert!(key.len() >= Self::num_bytes());
+        if key.len() < Self::num_bytes() {
+            return Err(Error::InvalidInputLength);
+        }
+
+        // PK1
+        let pk1 = PublicKey1::try_from(key)?;
+        let mut offset = PublicKey1::len();
+
+        // PK2
+        let pk2 = PublicKey2::try_from(&key[offset..])?;
+        offset += PublicKey2::<PK2_LEN>::len();
+
+        // SK
+        let implicit_rejection_value = [0u8; 32];
+        let mut sk: MlKemPrivateKeyUnpacked<K, Vector> = MlKemPrivateKeyUnpacked {
+            ind_cpa_private_key: IndCpaPrivateKeyUnpacked::default(),
+            implicit_rejection_value,
+        };
+        vec_from_bytes(&key[offset..], &mut sk.ind_cpa_private_key.secret_as_ntt);
+        offset += vec_len_bytes::<K, Vector>();
+        sk.implicit_rejection_value
+            .copy_from_slice(&key[offset..offset + 32]);
+        offset += sk.implicit_rejection_value.len();
+
+        // Matrix
+        let mut matrix = [[PolynomialRingElement::<Vector>::ZERO(); K]; K];
+        for i in 0..matrix.len() {
+            vec_from_bytes(&key[offset..], &mut matrix[i]);
+            offset += vec_len_bytes::<K, Vector>();
+        }
+
+        Ok(Self {
+            pk1,
+            pk2,
+            sk,
+            matrix,
+        })
+    }
+}

--- a/libcrux/libcrux-ml-kem/src/ind_cca/instantiations.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca/instantiations.rs
@@ -542,9 +542,9 @@ macro_rules! instantiate {
 // Portable generic implementations.
 instantiate! {portable, crate::vector::portable::PortableVector, crate::hash_functions::portable::PortableHash}
 
-// AVX2 generic implementation.
-#[cfg(feature = "simd256")]
-pub mod avx2;
+// // AVX2 generic implementation.
+// #[cfg(feature = "simd256")]
+// pub mod avx2;
 
 // NEON generic implementation.
 #[cfg(feature = "simd128")]

--- a/libcrux/libcrux-ml-kem/src/ind_cca/instantiations.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca/instantiations.rs
@@ -15,6 +15,7 @@ macro_rules! instantiate {
                 $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
             pub(crate) fn generate_keypair<
                 const K: usize,
+                const K_SQUARED: usize,
                 const CPA_PRIVATE_KEY_SIZE: usize,
                 const PRIVATE_KEY_SIZE: usize,
                 const PUBLIC_KEY_SIZE: usize,
@@ -26,6 +27,7 @@ macro_rules! instantiate {
             ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
                 crate::ind_cca::generate_keypair::<
                     K,
+                    K_SQUARED,
                     CPA_PRIVATE_KEY_SIZE,
                     PRIVATE_KEY_SIZE,
                     PUBLIC_KEY_SIZE,
@@ -168,6 +170,7 @@ macro_rules! instantiate {
                 $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#))]
             pub(crate) fn encapsulate<
                 const K: usize,
+                const K_SQUARED: usize,
                 const CIPHERTEXT_SIZE: usize,
                 const PUBLIC_KEY_SIZE: usize,
                 const T_AS_NTT_ENCODED_SIZE: usize,
@@ -188,6 +191,7 @@ macro_rules! instantiate {
             ) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
                 crate::ind_cca::encapsulate::<
                     K,
+                    K_SQUARED,
                     CIPHERTEXT_SIZE,
                     PUBLIC_KEY_SIZE,
                     T_AS_NTT_ENCODED_SIZE,
@@ -273,6 +277,7 @@ macro_rules! instantiate {
                 $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#))]
             pub fn decapsulate<
                 const K: usize,
+                const K_SQUARED: usize,
                 const SECRET_KEY_SIZE: usize,
                 const CPA_SECRET_KEY_SIZE: usize,
                 const PUBLIC_KEY_SIZE: usize,
@@ -296,6 +301,7 @@ macro_rules! instantiate {
             ) -> MlKemSharedSecret {
                 crate::ind_cca::decapsulate::<
                     K,
+                    K_SQUARED,
                     SECRET_KEY_SIZE,
                     CPA_SECRET_KEY_SIZE,
                     PUBLIC_KEY_SIZE,
@@ -323,10 +329,10 @@ macro_rules! instantiate {
             pub(crate) mod unpacked {
                 use super::*;
 
-                pub(crate) type MlKemKeyPairUnpacked<const K: usize> =
-                    crate::ind_cca::unpacked::MlKemKeyPairUnpacked<K, $vector>;
-                pub(crate) type MlKemPublicKeyUnpacked<const K: usize> =
-                    crate::ind_cca::unpacked::MlKemPublicKeyUnpacked<K, $vector>;
+                pub(crate) type MlKemKeyPairUnpacked<const K: usize, const K_SQUARED: usize> =
+                    crate::ind_cca::unpacked::MlKemKeyPairUnpacked<K, K_SQUARED, $vector>;
+                pub(crate) type MlKemPublicKeyUnpacked<const K: usize, const K_SQUARED: usize> =
+                    crate::ind_cca::unpacked::MlKemPublicKeyUnpacked<K, K_SQUARED, $vector>;
 
                 /// Get the unpacked public key.
                 #[hax_lib::requires(
@@ -337,14 +343,16 @@ macro_rules! instantiate {
                 #[inline(always)]
                 pub(crate) fn unpack_public_key<
                     const K: usize,
+                    const K_SQUARED: usize,
                     const T_AS_NTT_ENCODED_SIZE: usize,
                     const PUBLIC_KEY_SIZE: usize,
                 >(
                     public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
-                    unpacked_public_key: &mut MlKemPublicKeyUnpacked<K>,
+                    unpacked_public_key: &mut MlKemPublicKeyUnpacked<K, K_SQUARED>,
                 ) {
                     crate::ind_cca::unpacked::unpack_public_key::<
                         K,
+                        K_SQUARED,
                         T_AS_NTT_ENCODED_SIZE,
                         PUBLIC_KEY_SIZE,
                         $hash,
@@ -362,16 +370,18 @@ macro_rules! instantiate {
                             v_T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K"#))]
                 pub(crate) fn keypair_from_private_key<
                     const K: usize,
+                    const K_SQUARED: usize,
                     const SECRET_KEY_SIZE: usize,
                     const CPA_SECRET_KEY_SIZE: usize,
                     const PUBLIC_KEY_SIZE: usize,
                     const T_AS_NTT_ENCODED_SIZE: usize,
                 >(
                     private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
-                    key_pair: &mut MlKemKeyPairUnpacked<K>,
+                    key_pair: &mut MlKemKeyPairUnpacked<K, K_SQUARED>,
                 ) {
                     crate::ind_cca::unpacked::keys_from_private_key::<
                         K,
+                        K_SQUARED,
                         SECRET_KEY_SIZE,
                         CPA_SECRET_KEY_SIZE,
                         PUBLIC_KEY_SIZE,
@@ -390,6 +400,7 @@ macro_rules! instantiate {
                 #[inline(always)]
                 pub(crate) fn generate_keypair<
                     const K: usize,
+                    const K_SQUARED: usize,
                     const CPA_PRIVATE_KEY_SIZE: usize,
                     const PRIVATE_KEY_SIZE: usize,
                     const PUBLIC_KEY_SIZE: usize,
@@ -398,10 +409,11 @@ macro_rules! instantiate {
                     const PRF_OUTPUT_SIZE1: usize,
                 >(
                     randomness: [u8; KEY_GENERATION_SEED_SIZE],
-                    out: &mut MlKemKeyPairUnpacked<K>,
+                    out: &mut MlKemKeyPairUnpacked<K, K_SQUARED>,
                 ) {
                     crate::ind_cca::unpacked::generate_keypair::<
                         K,
+                        K_SQUARED,
                         CPA_PRIVATE_KEY_SIZE,
                         PRIVATE_KEY_SIZE,
                         PUBLIC_KEY_SIZE,
@@ -431,6 +443,7 @@ macro_rules! instantiate {
                 #[inline(always)]
                 pub(crate) fn encapsulate<
                     const K: usize,
+                    const K_SQUARED: usize,
                     const CIPHERTEXT_SIZE: usize,
                     const PUBLIC_KEY_SIZE: usize,
                     const T_AS_NTT_ENCODED_SIZE: usize,
@@ -446,11 +459,12 @@ macro_rules! instantiate {
                     const PRF_OUTPUT_SIZE1: usize,
                     const PRF_OUTPUT_SIZE2: usize,
                 >(
-                    public_key: &MlKemPublicKeyUnpacked<K>,
+                    public_key: &MlKemPublicKeyUnpacked<K, K_SQUARED>,
                     randomness: [u8; SHARED_SECRET_SIZE],
                 ) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
                     crate::ind_cca::unpacked::encapsulate::<
                         K,
+                        K_SQUARED,
                         CIPHERTEXT_SIZE,
                         PUBLIC_KEY_SIZE,
                         T_AS_NTT_ENCODED_SIZE,
@@ -490,6 +504,7 @@ macro_rules! instantiate {
                 #[inline(always)]
                 pub(crate) fn decapsulate<
                     const K: usize,
+                    const K_SQUARED: usize,
                     const SECRET_KEY_SIZE: usize,
                     const CPA_SECRET_KEY_SIZE: usize,
                     const PUBLIC_KEY_SIZE: usize,
@@ -508,11 +523,12 @@ macro_rules! instantiate {
                     const PRF_OUTPUT_SIZE2: usize,
                     const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
                 >(
-                    key_pair: &MlKemKeyPairUnpacked<K>,
+                    key_pair: &MlKemKeyPairUnpacked<K, K_SQUARED>,
                     ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
                 ) -> MlKemSharedSecret {
                     crate::ind_cca::unpacked::decapsulate::<
                         K,
+                        K_SQUARED,
                         SECRET_KEY_SIZE,
                         CPA_SECRET_KEY_SIZE,
                         PUBLIC_KEY_SIZE,

--- a/libcrux/libcrux-ml-kem/src/ind_cca/instantiations.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca/instantiations.rs
@@ -11,7 +11,6 @@ macro_rules! instantiate {
                 $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
                 $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
                 $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
-                $RANKED_BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
                 $ETA1 == Spec.MLKEM.v_ETA1 $K /\
                 $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
             pub(crate) fn generate_keypair<
@@ -19,9 +18,9 @@ macro_rules! instantiate {
                 const CPA_PRIVATE_KEY_SIZE: usize,
                 const PRIVATE_KEY_SIZE: usize,
                 const PUBLIC_KEY_SIZE: usize,
-                const RANKED_BYTES_PER_RING_ELEMENT: usize,
                 const ETA1: usize,
                 const ETA1_RANDOMNESS_SIZE: usize,
+                const PRF_OUTPUT_SIZE1: usize,
             >(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
@@ -30,9 +29,9 @@ macro_rules! instantiate {
                     CPA_PRIVATE_KEY_SIZE,
                     PRIVATE_KEY_SIZE,
                     PUBLIC_KEY_SIZE,
-                    RANKED_BYTES_PER_RING_ELEMENT,
                     ETA1,
                     ETA1_RANDOMNESS_SIZE,
+                    PRF_OUTPUT_SIZE1,
                     $vector,
                     $hash,
                     crate::variant::MlKem,
@@ -45,9 +44,9 @@ macro_rules! instantiate {
                 const CPA_PRIVATE_KEY_SIZE: usize,
                 const PRIVATE_KEY_SIZE: usize,
                 const PUBLIC_KEY_SIZE: usize,
-                const BYTES_PER_RING_ELEMENT: usize,
                 const ETA1: usize,
                 const ETA1_RANDOMNESS_SIZE: usize,
+                const PRF_OUTPUT_SIZE1: usize,
             >(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
@@ -56,9 +55,9 @@ macro_rules! instantiate {
                     CPA_PRIVATE_KEY_SIZE,
                     PRIVATE_KEY_SIZE,
                     PUBLIC_KEY_SIZE,
-                    BYTES_PER_RING_ELEMENT,
                     ETA1,
                     ETA1_RANDOMNESS_SIZE,
+                    PRF_OUTPUT_SIZE1,
                     $vector,
                     $hash,
                     crate::variant::Kyber,
@@ -68,18 +67,15 @@ macro_rules! instantiate {
             /// Public key validation
             #[inline(always)]
             #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
-                $RANKED_BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
                 $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#))]
             pub(crate) fn validate_public_key<
                 const K: usize,
-                const RANKED_BYTES_PER_RING_ELEMENT: usize,
                 const PUBLIC_KEY_SIZE: usize,
             >(
                 public_key: &[u8; PUBLIC_KEY_SIZE],
             ) -> bool {
                 crate::ind_cca::validate_public_key::<
                     K,
-                    RANKED_BYTES_PER_RING_ELEMENT,
                     PUBLIC_KEY_SIZE,
                     $vector,
                 >(public_key)
@@ -184,6 +180,8 @@ macro_rules! instantiate {
                 const ETA1_RANDOMNESS_SIZE: usize,
                 const ETA2: usize,
                 const ETA2_RANDOMNESS_SIZE: usize,
+                const PRF_OUTPUT_SIZE1: usize,
+                const PRF_OUTPUT_SIZE2: usize,
             >(
                 public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
                 randomness: [u8; SHARED_SECRET_SIZE],
@@ -202,6 +200,8 @@ macro_rules! instantiate {
                     ETA1_RANDOMNESS_SIZE,
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
+                    PRF_OUTPUT_SIZE1,
+                    PRF_OUTPUT_SIZE2,
                     $vector,
                     $hash,
                     crate::variant::MlKem,
@@ -287,6 +287,8 @@ macro_rules! instantiate {
                 const ETA1_RANDOMNESS_SIZE: usize,
                 const ETA2: usize,
                 const ETA2_RANDOMNESS_SIZE: usize,
+                const PRF_OUTPUT_SIZE1: usize,
+                const PRF_OUTPUT_SIZE2: usize,
                 const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
             >(
                 private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
@@ -308,6 +310,8 @@ macro_rules! instantiate {
                     ETA1_RANDOMNESS_SIZE,
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
+                    PRF_OUTPUT_SIZE1,
+                    PRF_OUTPUT_SIZE2,
                     IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                     $vector,
                     $hash,
@@ -334,7 +338,6 @@ macro_rules! instantiate {
                 pub(crate) fn unpack_public_key<
                     const K: usize,
                     const T_AS_NTT_ENCODED_SIZE: usize,
-                    const RANKED_BYTES_PER_RING_ELEMENT: usize,
                     const PUBLIC_KEY_SIZE: usize,
                 >(
                     public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
@@ -343,7 +346,6 @@ macro_rules! instantiate {
                     crate::ind_cca::unpacked::unpack_public_key::<
                         K,
                         T_AS_NTT_ENCODED_SIZE,
-                        RANKED_BYTES_PER_RING_ELEMENT,
                         PUBLIC_KEY_SIZE,
                         $hash,
                         $vector,
@@ -357,14 +359,12 @@ macro_rules! instantiate {
                             v_SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE v_K /\
                             v_CPA_SECRET_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE v_K /\
                             v_PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE v_K /\
-                            v_BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT v_K /\
                             v_T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K"#))]
                 pub(crate) fn keypair_from_private_key<
                     const K: usize,
                     const SECRET_KEY_SIZE: usize,
                     const CPA_SECRET_KEY_SIZE: usize,
                     const PUBLIC_KEY_SIZE: usize,
-                    const BYTES_PER_RING_ELEMENT: usize,
                     const T_AS_NTT_ENCODED_SIZE: usize,
                 >(
                     private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
@@ -375,7 +375,6 @@ macro_rules! instantiate {
                         SECRET_KEY_SIZE,
                         CPA_SECRET_KEY_SIZE,
                         PUBLIC_KEY_SIZE,
-                        BYTES_PER_RING_ELEMENT,
                         T_AS_NTT_ENCODED_SIZE,
                         $vector,
                     >(private_key, key_pair);
@@ -386,7 +385,6 @@ macro_rules! instantiate {
                     $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
                     $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
                     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
-                    $BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
                     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
                     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
                 #[inline(always)]
@@ -395,9 +393,9 @@ macro_rules! instantiate {
                     const CPA_PRIVATE_KEY_SIZE: usize,
                     const PRIVATE_KEY_SIZE: usize,
                     const PUBLIC_KEY_SIZE: usize,
-                    const BYTES_PER_RING_ELEMENT: usize,
                     const ETA1: usize,
                     const ETA1_RANDOMNESS_SIZE: usize,
+                    const PRF_OUTPUT_SIZE1: usize,
                 >(
                     randomness: [u8; KEY_GENERATION_SEED_SIZE],
                     out: &mut MlKemKeyPairUnpacked<K>,
@@ -407,9 +405,9 @@ macro_rules! instantiate {
                         CPA_PRIVATE_KEY_SIZE,
                         PRIVATE_KEY_SIZE,
                         PUBLIC_KEY_SIZE,
-                        BYTES_PER_RING_ELEMENT,
                         ETA1,
                         ETA1_RANDOMNESS_SIZE,
+                        PRF_OUTPUT_SIZE1,
                         $vector,
                         $hash,
                         crate::variant::MlKem,
@@ -445,6 +443,8 @@ macro_rules! instantiate {
                     const ETA1_RANDOMNESS_SIZE: usize,
                     const ETA2: usize,
                     const ETA2_RANDOMNESS_SIZE: usize,
+                    const PRF_OUTPUT_SIZE1: usize,
+                    const PRF_OUTPUT_SIZE2: usize,
                 >(
                     public_key: &MlKemPublicKeyUnpacked<K>,
                     randomness: [u8; SHARED_SECRET_SIZE],
@@ -463,6 +463,8 @@ macro_rules! instantiate {
                         ETA1_RANDOMNESS_SIZE,
                         ETA2,
                         ETA2_RANDOMNESS_SIZE,
+                        PRF_OUTPUT_SIZE1,
+                        PRF_OUTPUT_SIZE2,
                         $vector,
                         $hash,
                     >(public_key, randomness)
@@ -502,6 +504,8 @@ macro_rules! instantiate {
                     const ETA1_RANDOMNESS_SIZE: usize,
                     const ETA2: usize,
                     const ETA2_RANDOMNESS_SIZE: usize,
+                    const PRF_OUTPUT_SIZE1: usize,
+                    const PRF_OUTPUT_SIZE2: usize,
                     const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
                 >(
                     key_pair: &MlKemKeyPairUnpacked<K>,
@@ -523,6 +527,8 @@ macro_rules! instantiate {
                         ETA1_RANDOMNESS_SIZE,
                         ETA2,
                         ETA2_RANDOMNESS_SIZE,
+                        PRF_OUTPUT_SIZE1,
+                        PRF_OUTPUT_SIZE2,
                         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                         $vector,
                         $hash,
@@ -534,7 +540,7 @@ macro_rules! instantiate {
 }
 
 // Portable generic implementations.
-instantiate! {portable, crate::vector::portable::PortableVector, crate::hash_functions::portable::PortableHash<K>}
+instantiate! {portable, crate::vector::portable::PortableVector, crate::hash_functions::portable::PortableHash}
 
 // AVX2 generic implementation.
 #[cfg(feature = "simd256")]

--- a/libcrux/libcrux-ml-kem/src/ind_cca/instantiations/avx2.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca/instantiations/avx2.rs
@@ -10,7 +10,6 @@ use crate::{
     $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
-    $BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
 unsafe fn generate_keypair_avx2<
@@ -18,9 +17,9 @@ unsafe fn generate_keypair_avx2<
     const CPA_PRIVATE_KEY_SIZE: usize,
     const PRIVATE_KEY_SIZE: usize,
     const PUBLIC_KEY_SIZE: usize,
-    const BYTES_PER_RING_ELEMENT: usize,
     const ETA1: usize,
     const ETA1_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
 >(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
 ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
@@ -29,9 +28,9 @@ unsafe fn generate_keypair_avx2<
         CPA_PRIVATE_KEY_SIZE,
         PRIVATE_KEY_SIZE,
         PUBLIC_KEY_SIZE,
-        BYTES_PER_RING_ELEMENT,
         ETA1,
         ETA1_RANDOMNESS_SIZE,
+        PRF_OUTPUT_SIZE1,
         crate::vector::SIMD256Vector,
         crate::hash_functions::avx2::Simd256Hash,
         crate::variant::MlKem,
@@ -43,7 +42,6 @@ unsafe fn generate_keypair_avx2<
     $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
-    $BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
 pub(crate) fn generate_keypair<
@@ -51,9 +49,9 @@ pub(crate) fn generate_keypair<
     const CPA_PRIVATE_KEY_SIZE: usize,
     const PRIVATE_KEY_SIZE: usize,
     const PUBLIC_KEY_SIZE: usize,
-    const BYTES_PER_RING_ELEMENT: usize,
     const ETA1: usize,
     const ETA1_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
 >(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
 ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
@@ -63,9 +61,9 @@ pub(crate) fn generate_keypair<
             CPA_PRIVATE_KEY_SIZE,
             PRIVATE_KEY_SIZE,
             PUBLIC_KEY_SIZE,
-            BYTES_PER_RING_ELEMENT,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
         >(randomness)
     }
 }
@@ -78,9 +76,9 @@ unsafe fn kyber_generate_keypair_avx2<
     const CPA_PRIVATE_KEY_SIZE: usize,
     const PRIVATE_KEY_SIZE: usize,
     const PUBLIC_KEY_SIZE: usize,
-    const BYTES_PER_RING_ELEMENT: usize,
     const ETA1: usize,
     const ETA1_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
 >(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
 ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
@@ -89,9 +87,9 @@ unsafe fn kyber_generate_keypair_avx2<
         CPA_PRIVATE_KEY_SIZE,
         PRIVATE_KEY_SIZE,
         PUBLIC_KEY_SIZE,
-        BYTES_PER_RING_ELEMENT,
         ETA1,
         ETA1_RANDOMNESS_SIZE,
+        PRF_OUTPUT_SIZE1,
         crate::vector::SIMD256Vector,
         crate::hash_functions::avx2::Simd256Hash,
         crate::variant::Kyber,
@@ -105,9 +103,9 @@ pub(crate) fn kyber_generate_keypair<
     const CPA_PRIVATE_KEY_SIZE: usize,
     const PRIVATE_KEY_SIZE: usize,
     const PUBLIC_KEY_SIZE: usize,
-    const BYTES_PER_RING_ELEMENT: usize,
     const ETA1: usize,
     const ETA1_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
 >(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
 ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
@@ -117,9 +115,9 @@ pub(crate) fn kyber_generate_keypair<
             CPA_PRIVATE_KEY_SIZE,
             PRIVATE_KEY_SIZE,
             PUBLIC_KEY_SIZE,
-            BYTES_PER_RING_ELEMENT,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
         >(randomness)
     }
 }
@@ -127,37 +125,22 @@ pub(crate) fn kyber_generate_keypair<
 #[allow(unsafe_code)]
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
-    $RANKED_BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#))]
-unsafe fn validate_public_key_avx2<
-    const K: usize,
-    const RANKED_BYTES_PER_RING_ELEMENT: usize,
-    const PUBLIC_KEY_SIZE: usize,
->(
+unsafe fn validate_public_key_avx2<const K: usize, const PUBLIC_KEY_SIZE: usize>(
     public_key: &[u8; PUBLIC_KEY_SIZE],
 ) -> bool {
-    crate::ind_cca::validate_public_key::<
-        K,
-        RANKED_BYTES_PER_RING_ELEMENT,
-        PUBLIC_KEY_SIZE,
-        crate::vector::SIMD256Vector,
-    >(public_key)
+    crate::ind_cca::validate_public_key::<K, PUBLIC_KEY_SIZE, crate::vector::SIMD256Vector>(
+        public_key,
+    )
 }
 
 #[allow(unsafe_code)]
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
-    $RANKED_BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#))]
-pub(crate) fn validate_public_key<
-    const K: usize,
-    const RANKED_BYTES_PER_RING_ELEMENT: usize,
-    const PUBLIC_KEY_SIZE: usize,
->(
+pub(crate) fn validate_public_key<const K: usize, const PUBLIC_KEY_SIZE: usize>(
     public_key: &[u8; PUBLIC_KEY_SIZE],
 ) -> bool {
-    unsafe {
-        validate_public_key_avx2::<K, RANKED_BYTES_PER_RING_ELEMENT, PUBLIC_KEY_SIZE>(public_key)
-    }
+    unsafe { validate_public_key_avx2::<K, PUBLIC_KEY_SIZE>(public_key) }
 }
 
 #[allow(unsafe_code)]
@@ -229,6 +212,8 @@ unsafe fn kyber_encapsulate_avx2<
     const ETA1_RANDOMNESS_SIZE: usize,
     const ETA2: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
+    const PRF_OUTPUT_SIZE2: usize,
 >(
     public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
     randomness: [u8; SHARED_SECRET_SIZE],
@@ -247,6 +232,8 @@ unsafe fn kyber_encapsulate_avx2<
         ETA1_RANDOMNESS_SIZE,
         ETA2,
         ETA2_RANDOMNESS_SIZE,
+        PRF_OUTPUT_SIZE1,
+        PRF_OUTPUT_SIZE2,
         crate::vector::SIMD256Vector,
         crate::hash_functions::avx2::Simd256Hash,
         crate::variant::Kyber,
@@ -269,6 +256,8 @@ pub(crate) fn kyber_encapsulate<
     const ETA1_RANDOMNESS_SIZE: usize,
     const ETA2: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
+    const PRF_OUTPUT_SIZE2: usize,
 >(
     public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
     randomness: [u8; SHARED_SECRET_SIZE],
@@ -288,6 +277,8 @@ pub(crate) fn kyber_encapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
         >(public_key, randomness)
     }
 }
@@ -321,6 +312,8 @@ unsafe fn encapsulate_avx2<
     const ETA1_RANDOMNESS_SIZE: usize,
     const ETA2: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
+    const PRF_OUTPUT_SIZE2: usize,
 >(
     public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
     randomness: [u8; SHARED_SECRET_SIZE],
@@ -339,6 +332,8 @@ unsafe fn encapsulate_avx2<
         ETA1_RANDOMNESS_SIZE,
         ETA2,
         ETA2_RANDOMNESS_SIZE,
+        PRF_OUTPUT_SIZE1,
+        PRF_OUTPUT_SIZE2,
         crate::vector::SIMD256Vector,
         crate::hash_functions::avx2::Simd256Hash,
         crate::variant::MlKem,
@@ -373,6 +368,8 @@ pub(crate) fn encapsulate<
     const ETA1_RANDOMNESS_SIZE: usize,
     const ETA2: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
+    const PRF_OUTPUT_SIZE2: usize,
 >(
     public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
     randomness: [u8; SHARED_SECRET_SIZE],
@@ -392,6 +389,8 @@ pub(crate) fn encapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
         >(public_key, randomness)
     }
 }
@@ -415,6 +414,8 @@ unsafe fn kyber_decapsulate_avx2<
     const ETA1_RANDOMNESS_SIZE: usize,
     const ETA2: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
+    const PRF_OUTPUT_SIZE2: usize,
     const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
 >(
     private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
@@ -436,6 +437,8 @@ unsafe fn kyber_decapsulate_avx2<
         ETA1_RANDOMNESS_SIZE,
         ETA2,
         ETA2_RANDOMNESS_SIZE,
+        PRF_OUTPUT_SIZE1,
+        PRF_OUTPUT_SIZE2,
         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
         crate::vector::SIMD256Vector,
         crate::hash_functions::avx2::Simd256Hash,
@@ -461,6 +464,8 @@ pub fn kyber_decapsulate<
     const ETA1_RANDOMNESS_SIZE: usize,
     const ETA2: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
+    const PRF_OUTPUT_SIZE2: usize,
     const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
 >(
     private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
@@ -483,6 +488,8 @@ pub fn kyber_decapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
             IMPLICIT_REJECTION_HASH_INPUT_SIZE,
         >(private_key, ciphertext)
     }
@@ -522,6 +529,8 @@ unsafe fn decapsulate_avx2<
     const ETA1_RANDOMNESS_SIZE: usize,
     const ETA2: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
+    const PRF_OUTPUT_SIZE2: usize,
     const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
 >(
     private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
@@ -543,6 +552,8 @@ unsafe fn decapsulate_avx2<
         ETA1_RANDOMNESS_SIZE,
         ETA2,
         ETA2_RANDOMNESS_SIZE,
+        PRF_OUTPUT_SIZE1,
+        PRF_OUTPUT_SIZE2,
         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
         crate::vector::SIMD256Vector,
         crate::hash_functions::avx2::Simd256Hash,
@@ -583,6 +594,8 @@ pub fn decapsulate<
     const ETA1_RANDOMNESS_SIZE: usize,
     const ETA2: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
+    const PRF_OUTPUT_SIZE2: usize,
     const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
 >(
     private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
@@ -605,6 +618,8 @@ pub fn decapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
             IMPLICIT_REJECTION_HASH_INPUT_SIZE,
         >(private_key, ciphertext)
     }
@@ -630,7 +645,6 @@ pub(crate) mod unpacked {
     unsafe fn unpack_public_key_avx2<
         const K: usize,
         const T_AS_NTT_ENCODED_SIZE: usize,
-        const RANKED_BYTES_PER_RING_ELEMENT: usize,
         const PUBLIC_KEY_SIZE: usize,
     >(
         public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
@@ -639,7 +653,6 @@ pub(crate) mod unpacked {
         crate::ind_cca::unpacked::unpack_public_key::<
             K,
             T_AS_NTT_ENCODED_SIZE,
-            RANKED_BYTES_PER_RING_ELEMENT,
             PUBLIC_KEY_SIZE,
             crate::hash_functions::avx2::Simd256Hash,
             crate::vector::SIMD256Vector,
@@ -656,19 +669,16 @@ pub(crate) mod unpacked {
     pub(crate) fn unpack_public_key<
         const K: usize,
         const T_AS_NTT_ENCODED_SIZE: usize,
-        const RANKED_BYTES_PER_RING_ELEMENT: usize,
         const PUBLIC_KEY_SIZE: usize,
     >(
         public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
         unpacked_public_key: &mut MlKemPublicKeyUnpacked<K>,
     ) {
         unsafe {
-            unpack_public_key_avx2::<
-                K,
-                T_AS_NTT_ENCODED_SIZE,
-                RANKED_BYTES_PER_RING_ELEMENT,
-                PUBLIC_KEY_SIZE,
-            >(public_key, unpacked_public_key)
+            unpack_public_key_avx2::<K, T_AS_NTT_ENCODED_SIZE, PUBLIC_KEY_SIZE>(
+                public_key,
+                unpacked_public_key,
+            )
         }
     }
 
@@ -679,14 +689,12 @@ pub(crate) mod unpacked {
                 v_SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE v_K /\
                 v_CPA_SECRET_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE v_K /\
                 v_PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE v_K /\
-                v_BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT v_K /\
                 v_T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K"#))]
     pub(crate) fn keypair_from_private_key<
         const K: usize,
         const SECRET_KEY_SIZE: usize,
         const CPA_SECRET_KEY_SIZE: usize,
         const PUBLIC_KEY_SIZE: usize,
-        const BYTES_PER_RING_ELEMENT: usize,
         const T_AS_NTT_ENCODED_SIZE: usize,
     >(
         private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
@@ -697,7 +705,6 @@ pub(crate) mod unpacked {
             SECRET_KEY_SIZE,
             CPA_SECRET_KEY_SIZE,
             PUBLIC_KEY_SIZE,
-            BYTES_PER_RING_ELEMENT,
             T_AS_NTT_ENCODED_SIZE,
             crate::vector::SIMD256Vector,
         >(private_key, key_pair);
@@ -708,16 +715,15 @@ pub(crate) mod unpacked {
     #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
-        $BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
         $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#))]
     unsafe fn generate_keypair_avx2<
         const K: usize,
         const CPA_PRIVATE_KEY_SIZE: usize,
         const PRIVATE_KEY_SIZE: usize,
         const PUBLIC_KEY_SIZE: usize,
-        const BYTES_PER_RING_ELEMENT: usize,
         const ETA1: usize,
         const ETA1_RANDOMNESS_SIZE: usize,
+        const PRF_OUTPUT_SIZE1: usize,
     >(
         randomness: [u8; KEY_GENERATION_SEED_SIZE],
         out: &mut MlKemKeyPairUnpacked<K>,
@@ -727,9 +733,9 @@ pub(crate) mod unpacked {
             CPA_PRIVATE_KEY_SIZE,
             PRIVATE_KEY_SIZE,
             PUBLIC_KEY_SIZE,
-            BYTES_PER_RING_ELEMENT,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
             crate::vector::SIMD256Vector,
             crate::hash_functions::avx2::Simd256Hash,
             crate::variant::MlKem,
@@ -741,16 +747,15 @@ pub(crate) mod unpacked {
     #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
-        $BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
         $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#))]
     pub(crate) fn generate_keypair<
         const K: usize,
         const CPA_PRIVATE_KEY_SIZE: usize,
         const PRIVATE_KEY_SIZE: usize,
         const PUBLIC_KEY_SIZE: usize,
-        const BYTES_PER_RING_ELEMENT: usize,
         const ETA1: usize,
         const ETA1_RANDOMNESS_SIZE: usize,
+        const PRF_OUTPUT_SIZE1: usize,
     >(
         randomness: [u8; KEY_GENERATION_SEED_SIZE],
         out: &mut MlKemKeyPairUnpacked<K>,
@@ -761,9 +766,9 @@ pub(crate) mod unpacked {
                 CPA_PRIVATE_KEY_SIZE,
                 PRIVATE_KEY_SIZE,
                 PUBLIC_KEY_SIZE,
-                BYTES_PER_RING_ELEMENT,
                 ETA1,
                 ETA1_RANDOMNESS_SIZE,
+                PRF_OUTPUT_SIZE1,
             >(randomness, out)
         }
     }
@@ -795,6 +800,8 @@ pub(crate) mod unpacked {
         const ETA1_RANDOMNESS_SIZE: usize,
         const ETA2: usize,
         const ETA2_RANDOMNESS_SIZE: usize,
+        const PRF_OUTPUT_SIZE1: usize,
+        const PRF_OUTPUT_SIZE2: usize,
     >(
         public_key: &MlKemPublicKeyUnpacked<K>,
         randomness: [u8; SHARED_SECRET_SIZE],
@@ -813,6 +820,8 @@ pub(crate) mod unpacked {
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
             crate::vector::SIMD256Vector,
             crate::hash_functions::avx2::Simd256Hash,
         >(public_key, randomness)
@@ -845,6 +854,8 @@ pub(crate) mod unpacked {
         const ETA1_RANDOMNESS_SIZE: usize,
         const ETA2: usize,
         const ETA2_RANDOMNESS_SIZE: usize,
+        const PRF_OUTPUT_SIZE1: usize,
+        const PRF_OUTPUT_SIZE2: usize,
     >(
         public_key: &MlKemPublicKeyUnpacked<K>,
         randomness: [u8; SHARED_SECRET_SIZE],
@@ -864,6 +875,8 @@ pub(crate) mod unpacked {
                 ETA1_RANDOMNESS_SIZE,
                 ETA2,
                 ETA2_RANDOMNESS_SIZE,
+                PRF_OUTPUT_SIZE1,
+                PRF_OUTPUT_SIZE2,
             >(public_key, randomness)
         }
     }
@@ -898,6 +911,8 @@ pub(crate) mod unpacked {
         const ETA1_RANDOMNESS_SIZE: usize,
         const ETA2: usize,
         const ETA2_RANDOMNESS_SIZE: usize,
+        const PRF_OUTPUT_SIZE1: usize,
+        const PRF_OUTPUT_SIZE2: usize,
         const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
     >(
         key_pair: &MlKemKeyPairUnpacked<K>,
@@ -919,6 +934,8 @@ pub(crate) mod unpacked {
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
             IMPLICIT_REJECTION_HASH_INPUT_SIZE,
             crate::vector::SIMD256Vector,
             crate::hash_functions::avx2::Simd256Hash,
@@ -955,6 +972,8 @@ pub(crate) mod unpacked {
         const ETA1_RANDOMNESS_SIZE: usize,
         const ETA2: usize,
         const ETA2_RANDOMNESS_SIZE: usize,
+        const PRF_OUTPUT_SIZE1: usize,
+        const PRF_OUTPUT_SIZE2: usize,
         const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
     >(
         key_pair: &MlKemKeyPairUnpacked<K>,
@@ -977,6 +996,8 @@ pub(crate) mod unpacked {
                 ETA1_RANDOMNESS_SIZE,
                 ETA2,
                 ETA2_RANDOMNESS_SIZE,
+                PRF_OUTPUT_SIZE1,
+                PRF_OUTPUT_SIZE2,
                 IMPLICIT_REJECTION_HASH_INPUT_SIZE,
             >(key_pair, ciphertext)
         }

--- a/libcrux/libcrux-ml-kem/src/ind_cca/multiplexing.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca/multiplexing.rs
@@ -4,11 +4,11 @@ use super::*;
 // have a CPU that has it and thus tries to call the simd128/simd256 version,
 // we fall back to the portable version in this case.
 
-#[cfg(feature = "simd256")]
-use instantiations::avx2::{
-    decapsulate as decapsulate_avx2, encapsulate as encapsulate_avx2,
-    generate_keypair as generate_keypair_avx2,
-};
+// #[cfg(feature = "simd256")]
+// use instantiations::avx2::{
+//     decapsulate as decapsulate_avx2, encapsulate as encapsulate_avx2,
+//     generate_keypair as generate_keypair_avx2,
+// };
 
 #[cfg(feature = "simd128")]
 use instantiations::neon::{
@@ -28,11 +28,11 @@ use instantiations::portable::{
     generate_keypair as generate_keypair_neon,
 };
 
-#[cfg(all(feature = "simd256", feature = "kyber"))]
-use instantiations::avx2::{
-    kyber_decapsulate as kyber_decapsulate_avx2, kyber_encapsulate as kyber_encapsulate_avx2,
-    kyber_generate_keypair as kyber_generate_keypair_avx2,
-};
+// #[cfg(all(feature = "simd256", feature = "kyber"))]
+// use instantiations::avx2::{
+//     kyber_decapsulate as kyber_decapsulate_avx2, kyber_encapsulate as kyber_encapsulate_avx2,
+//     kyber_generate_keypair as kyber_generate_keypair_avx2,
+// };
 
 #[cfg(all(feature = "simd128", feature = "kyber"))]
 use instantiations::neon::{
@@ -143,17 +143,18 @@ pub(crate) fn generate_keypair<
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
 ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
     // Runtime feature detection.
-    if libcrux_platform::simd256_support() {
-        generate_keypair_avx2::<
-            K,
-            CPA_PRIVATE_KEY_SIZE,
-            PRIVATE_KEY_SIZE,
-            PUBLIC_KEY_SIZE,
-            ETA1,
-            ETA1_RANDOMNESS_SIZE,
-            PRF_OUTPUT_SIZE1,
-        >(randomness)
-    } else if libcrux_platform::simd128_support() {
+    // if libcrux_platform::simd256_support() {
+    //     generate_keypair_avx2::<
+    //         K,
+    //         CPA_PRIVATE_KEY_SIZE,
+    //         PRIVATE_KEY_SIZE,
+    //         PUBLIC_KEY_SIZE,
+    //         ETA1,
+    //         ETA1_RANDOMNESS_SIZE,
+    //         PRF_OUTPUT_SIZE1,
+    //     >(randomness)
+// } else
+ if libcrux_platform::simd128_support() {
         generate_keypair_neon::<
             K,
             CPA_PRIVATE_KEY_SIZE,
@@ -287,25 +288,26 @@ pub(crate) fn encapsulate<
     public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
     randomness: [u8; SHARED_SECRET_SIZE],
 ) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
-    if libcrux_platform::simd256_support() {
-        encapsulate_avx2::<
-            K,
-            CIPHERTEXT_SIZE,
-            PUBLIC_KEY_SIZE,
-            T_AS_NTT_ENCODED_SIZE,
-            C1_SIZE,
-            C2_SIZE,
-            VECTOR_U_COMPRESSION_FACTOR,
-            VECTOR_V_COMPRESSION_FACTOR,
-            C1_BLOCK_SIZE,
-            ETA1,
-            ETA1_RANDOMNESS_SIZE,
-            ETA2,
-            ETA2_RANDOMNESS_SIZE,
-            PRF_OUTPUT_SIZE1,
-            PRF_OUTPUT_SIZE2,
-        >(public_key, randomness)
-    } else if libcrux_platform::simd128_support() {
+    // if libcrux_platform::simd256_support() {
+    //     encapsulate_avx2::<
+    //         K,
+    //         CIPHERTEXT_SIZE,
+    //         PUBLIC_KEY_SIZE,
+    //         T_AS_NTT_ENCODED_SIZE,
+    //         C1_SIZE,
+    //         C2_SIZE,
+    //         VECTOR_U_COMPRESSION_FACTOR,
+    //         VECTOR_V_COMPRESSION_FACTOR,
+    //         C1_BLOCK_SIZE,
+    //         ETA1,
+    //         ETA1_RANDOMNESS_SIZE,
+    //         ETA2,
+    //         ETA2_RANDOMNESS_SIZE,
+    //         PRF_OUTPUT_SIZE1,
+    //         PRF_OUTPUT_SIZE2,
+    //     >(public_key, randomness)
+    // } else
+if libcrux_platform::simd128_support() {
         encapsulate_neon::<
             K,
             CIPHERTEXT_SIZE,
@@ -473,28 +475,29 @@ pub(crate) fn decapsulate<
     private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
     ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
 ) -> MlKemSharedSecret {
-    if libcrux_platform::simd256_support() {
-        decapsulate_avx2::<
-            K,
-            SECRET_KEY_SIZE,
-            CPA_SECRET_KEY_SIZE,
-            PUBLIC_KEY_SIZE,
-            CIPHERTEXT_SIZE,
-            T_AS_NTT_ENCODED_SIZE,
-            C1_SIZE,
-            C2_SIZE,
-            VECTOR_U_COMPRESSION_FACTOR,
-            VECTOR_V_COMPRESSION_FACTOR,
-            C1_BLOCK_SIZE,
-            ETA1,
-            ETA1_RANDOMNESS_SIZE,
-            ETA2,
-            ETA2_RANDOMNESS_SIZE,
-            PRF_OUTPUT_SIZE1,
-            PRF_OUTPUT_SIZE2,
-            IMPLICIT_REJECTION_HASH_INPUT_SIZE,
-        >(private_key, ciphertext)
-    } else if libcrux_platform::simd128_support() {
+    // if libcrux_platform::simd256_support() {
+    //     decapsulate_avx2::<
+    //         K,
+    //         SECRET_KEY_SIZE,
+    //         CPA_SECRET_KEY_SIZE,
+    //         PUBLIC_KEY_SIZE,
+    //         CIPHERTEXT_SIZE,
+    //         T_AS_NTT_ENCODED_SIZE,
+    //         C1_SIZE,
+    //         C2_SIZE,
+    //         VECTOR_U_COMPRESSION_FACTOR,
+    //         VECTOR_V_COMPRESSION_FACTOR,
+    //         C1_BLOCK_SIZE,
+    //         ETA1,
+    //         ETA1_RANDOMNESS_SIZE,
+    //         ETA2,
+    //         ETA2_RANDOMNESS_SIZE,
+    //         PRF_OUTPUT_SIZE1,
+    //         PRF_OUTPUT_SIZE2,
+    //         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+    //     >(private_key, ciphertext)
+    // } else
+ if libcrux_platform::simd128_support() {
         decapsulate_neon::<
             K,
             SECRET_KEY_SIZE,

--- a/libcrux/libcrux-ml-kem/src/ind_cca/multiplexing.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca/multiplexing.rs
@@ -133,6 +133,7 @@ pub(crate) fn kyber_generate_keypair<
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
 pub(crate) fn generate_keypair<
     const K: usize,
+    const K_SQUARED: usize,
     const CPA_PRIVATE_KEY_SIZE: usize,
     const PRIVATE_KEY_SIZE: usize,
     const PUBLIC_KEY_SIZE: usize,
@@ -153,10 +154,11 @@ pub(crate) fn generate_keypair<
     //         ETA1_RANDOMNESS_SIZE,
     //         PRF_OUTPUT_SIZE1,
     //     >(randomness)
-// } else
- if libcrux_platform::simd128_support() {
+    // } else
+    if libcrux_platform::simd128_support() {
         generate_keypair_neon::<
             K,
+            K_SQUARED,
             CPA_PRIVATE_KEY_SIZE,
             PRIVATE_KEY_SIZE,
             PUBLIC_KEY_SIZE,
@@ -167,6 +169,7 @@ pub(crate) fn generate_keypair<
     } else {
         instantiations::portable::generate_keypair::<
             K,
+            K_SQUARED,
             CPA_PRIVATE_KEY_SIZE,
             PRIVATE_KEY_SIZE,
             PUBLIC_KEY_SIZE,
@@ -270,6 +273,7 @@ pub(crate) fn kyber_encapsulate<
     $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#))]
 pub(crate) fn encapsulate<
     const K: usize,
+    const K_SQUARED: usize,
     const CIPHERTEXT_SIZE: usize,
     const PUBLIC_KEY_SIZE: usize,
     const T_AS_NTT_ENCODED_SIZE: usize,
@@ -307,9 +311,10 @@ pub(crate) fn encapsulate<
     //         PRF_OUTPUT_SIZE2,
     //     >(public_key, randomness)
     // } else
-if libcrux_platform::simd128_support() {
+    if libcrux_platform::simd128_support() {
         encapsulate_neon::<
             K,
+            K_SQUARED,
             CIPHERTEXT_SIZE,
             PUBLIC_KEY_SIZE,
             T_AS_NTT_ENCODED_SIZE,
@@ -328,6 +333,7 @@ if libcrux_platform::simd128_support() {
     } else {
         instantiations::portable::encapsulate::<
             K,
+            K_SQUARED,
             CIPHERTEXT_SIZE,
             PUBLIC_KEY_SIZE,
             T_AS_NTT_ENCODED_SIZE,
@@ -454,6 +460,7 @@ pub(crate) fn kyber_decapsulate<
     $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#))]
 pub(crate) fn decapsulate<
     const K: usize,
+    const K_SQUARED: usize,
     const SECRET_KEY_SIZE: usize,
     const CPA_SECRET_KEY_SIZE: usize,
     const PUBLIC_KEY_SIZE: usize,
@@ -497,9 +504,10 @@ pub(crate) fn decapsulate<
     //         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
     //     >(private_key, ciphertext)
     // } else
- if libcrux_platform::simd128_support() {
+    if libcrux_platform::simd128_support() {
         decapsulate_neon::<
             K,
+            K_SQUARED,
             SECRET_KEY_SIZE,
             CPA_SECRET_KEY_SIZE,
             PUBLIC_KEY_SIZE,
@@ -521,6 +529,7 @@ pub(crate) fn decapsulate<
     } else {
         instantiations::portable::decapsulate::<
             K,
+            K_SQUARED,
             SECRET_KEY_SIZE,
             CPA_SECRET_KEY_SIZE,
             PUBLIC_KEY_SIZE,

--- a/libcrux/libcrux-ml-kem/src/ind_cca/multiplexing.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca/multiplexing.rs
@@ -53,19 +53,12 @@ use instantiations::portable::{
 };
 
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
-    $RANKED_BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#))]
 #[inline(always)]
-pub(crate) fn validate_public_key<
-    const K: usize,
-    const RANKED_BYTES_PER_RING_ELEMENT: usize,
-    const PUBLIC_KEY_SIZE: usize,
->(
+pub(crate) fn validate_public_key<const K: usize, const PUBLIC_KEY_SIZE: usize>(
     public_key: &[u8; PUBLIC_KEY_SIZE],
 ) -> bool {
-    instantiations::portable::validate_public_key::<K, RANKED_BYTES_PER_RING_ELEMENT, PUBLIC_KEY_SIZE>(
-        public_key,
-    )
+    instantiations::portable::validate_public_key::<K, PUBLIC_KEY_SIZE>(public_key)
 }
 
 #[inline(always)]
@@ -92,9 +85,9 @@ pub(crate) fn kyber_generate_keypair<
     const CPA_PRIVATE_KEY_SIZE: usize,
     const PRIVATE_KEY_SIZE: usize,
     const PUBLIC_KEY_SIZE: usize,
-    const BYTES_PER_RING_ELEMENT: usize,
     const ETA1: usize,
     const ETA1_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
 >(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
 ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
@@ -105,9 +98,9 @@ pub(crate) fn kyber_generate_keypair<
             CPA_PRIVATE_KEY_SIZE,
             PRIVATE_KEY_SIZE,
             PUBLIC_KEY_SIZE,
-            BYTES_PER_RING_ELEMENT,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
         >(randomness)
     } else if libcrux_platform::simd128_support() {
         kyber_generate_keypair_neon::<
@@ -115,9 +108,9 @@ pub(crate) fn kyber_generate_keypair<
             CPA_PRIVATE_KEY_SIZE,
             PRIVATE_KEY_SIZE,
             PUBLIC_KEY_SIZE,
-            BYTES_PER_RING_ELEMENT,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
         >(randomness)
     } else {
         instantiations::portable::kyber_generate_keypair::<
@@ -125,9 +118,9 @@ pub(crate) fn kyber_generate_keypair<
             CPA_PRIVATE_KEY_SIZE,
             PRIVATE_KEY_SIZE,
             PUBLIC_KEY_SIZE,
-            BYTES_PER_RING_ELEMENT,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
         >(randomness)
     }
 }
@@ -136,7 +129,6 @@ pub(crate) fn kyber_generate_keypair<
     $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
-    $RANKED_BYTES_PER_RING_ELEMENT == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
 pub(crate) fn generate_keypair<
@@ -144,9 +136,9 @@ pub(crate) fn generate_keypair<
     const CPA_PRIVATE_KEY_SIZE: usize,
     const PRIVATE_KEY_SIZE: usize,
     const PUBLIC_KEY_SIZE: usize,
-    const RANKED_BYTES_PER_RING_ELEMENT: usize,
     const ETA1: usize,
     const ETA1_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
 >(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
 ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
@@ -157,9 +149,9 @@ pub(crate) fn generate_keypair<
             CPA_PRIVATE_KEY_SIZE,
             PRIVATE_KEY_SIZE,
             PUBLIC_KEY_SIZE,
-            RANKED_BYTES_PER_RING_ELEMENT,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
         >(randomness)
     } else if libcrux_platform::simd128_support() {
         generate_keypair_neon::<
@@ -167,9 +159,9 @@ pub(crate) fn generate_keypair<
             CPA_PRIVATE_KEY_SIZE,
             PRIVATE_KEY_SIZE,
             PUBLIC_KEY_SIZE,
-            RANKED_BYTES_PER_RING_ELEMENT,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
         >(randomness)
     } else {
         instantiations::portable::generate_keypair::<
@@ -177,9 +169,9 @@ pub(crate) fn generate_keypair<
             CPA_PRIVATE_KEY_SIZE,
             PRIVATE_KEY_SIZE,
             PUBLIC_KEY_SIZE,
-            RANKED_BYTES_PER_RING_ELEMENT,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
         >(randomness)
     }
 }
@@ -199,6 +191,8 @@ pub(crate) fn kyber_encapsulate<
     const ETA1_RANDOMNESS_SIZE: usize,
     const ETA2: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
+    const PRF_OUTPUT_SIZE2: usize,
 >(
     public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
     randomness: [u8; SHARED_SECRET_SIZE],
@@ -218,6 +212,8 @@ pub(crate) fn kyber_encapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
         >(public_key, randomness)
     } else if libcrux_platform::simd128_support() {
         kyber_encapsulate_neon::<
@@ -234,6 +230,8 @@ pub(crate) fn kyber_encapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
         >(public_key, randomness)
     } else {
         instantiations::portable::kyber_encapsulate::<
@@ -250,6 +248,8 @@ pub(crate) fn kyber_encapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
         >(public_key, randomness)
     }
 }
@@ -281,6 +281,8 @@ pub(crate) fn encapsulate<
     const ETA1_RANDOMNESS_SIZE: usize,
     const ETA2: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
+    const PRF_OUTPUT_SIZE2: usize,
 >(
     public_key: &MlKemPublicKey<PUBLIC_KEY_SIZE>,
     randomness: [u8; SHARED_SECRET_SIZE],
@@ -300,6 +302,8 @@ pub(crate) fn encapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
         >(public_key, randomness)
     } else if libcrux_platform::simd128_support() {
         encapsulate_neon::<
@@ -316,6 +320,8 @@ pub(crate) fn encapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
         >(public_key, randomness)
     } else {
         instantiations::portable::encapsulate::<
@@ -332,6 +338,8 @@ pub(crate) fn encapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
         >(public_key, randomness)
     }
 }
@@ -353,6 +361,8 @@ pub(crate) fn kyber_decapsulate<
     const ETA1_RANDOMNESS_SIZE: usize,
     const ETA2: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
+    const PRF_OUTPUT_SIZE2: usize,
     const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
 >(
     private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
@@ -375,6 +385,8 @@ pub(crate) fn kyber_decapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
             IMPLICIT_REJECTION_HASH_INPUT_SIZE,
         >(private_key, ciphertext)
     } else if libcrux_platform::simd128_support() {
@@ -394,6 +406,8 @@ pub(crate) fn kyber_decapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
             IMPLICIT_REJECTION_HASH_INPUT_SIZE,
         >(private_key, ciphertext)
     } else {
@@ -413,6 +427,8 @@ pub(crate) fn kyber_decapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
             IMPLICIT_REJECTION_HASH_INPUT_SIZE,
         >(private_key, ciphertext)
     }
@@ -450,6 +466,8 @@ pub(crate) fn decapsulate<
     const ETA1_RANDOMNESS_SIZE: usize,
     const ETA2: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
+    const PRF_OUTPUT_SIZE1: usize,
+    const PRF_OUTPUT_SIZE2: usize,
     const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
 >(
     private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
@@ -472,6 +490,8 @@ pub(crate) fn decapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
             IMPLICIT_REJECTION_HASH_INPUT_SIZE,
         >(private_key, ciphertext)
     } else if libcrux_platform::simd128_support() {
@@ -491,6 +511,8 @@ pub(crate) fn decapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
             IMPLICIT_REJECTION_HASH_INPUT_SIZE,
         >(private_key, ciphertext)
     } else {
@@ -510,6 +532,8 @@ pub(crate) fn decapsulate<
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
             IMPLICIT_REJECTION_HASH_INPUT_SIZE,
         >(private_key, ciphertext)
     }

--- a/libcrux/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cpa.rs
@@ -34,6 +34,7 @@ pub(crate) mod unpacked {
     }
 
     impl<const K: usize, Vector: Operations> Default for IndCpaPrivateKeyUnpacked<K, Vector> {
+        #[inline(always)]
         fn default() -> Self {
             Self {
                 secret_as_ntt: [PolynomialRingElement::<Vector>::ZERO(); K],
@@ -56,6 +57,7 @@ pub(crate) mod unpacked {
     impl<const K: usize, const K_SQUARED: usize, Vector: Operations> Default
         for IndCpaPublicKeyUnpacked<K, K_SQUARED, Vector>
     {
+        #[inline(always)]
         fn default() -> Self {
             Self {
                 t_as_ntt: [PolynomialRingElement::<Vector>::ZERO(); K],
@@ -602,6 +604,7 @@ pub(crate) fn generate_keypair<
 
 /// Serialize the secret key from the unpacked key pair generation.
 #[hax_lib::fstar::verification_status(lax)]
+#[inline(always)]
 pub(crate) fn serialize_unpacked_secret_key<
     const K: usize,
     const K_SQUARED: usize,

--- a/libcrux/libcrux-ml-kem/src/invert_ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/invert_ntt.rs
@@ -35,8 +35,6 @@ pub(crate) fn invert_ntt_at_layer_1<Vector: Operations>(
     hax_lib::fstar!(r#"reveal_opaque (`%invert_ntt_re_range_1) (invert_ntt_re_range_1 #$:Vector)"#);
     hax_lib::fstar!(r#"reveal_opaque (`%invert_ntt_re_range_2) (invert_ntt_re_range_2 #$:Vector)"#);
     let _zeta_i_init = *zeta_i;
-    // The semicolon and parentheses at the end of loop are a workaround
-    // for the following bug https://github.com/hacspec/hax/issues/720
     for round in 0..16 {
         hax_lib::loop_invariant!(|round: usize| {
             fstar!(
@@ -72,7 +70,6 @@ pub(crate) fn invert_ntt_at_layer_1<Vector: Operations>(
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ $round ])))"
         );
     }
-    ()
 }
 
 #[inline(always)]
@@ -87,8 +84,6 @@ pub(crate) fn invert_ntt_at_layer_2<Vector: Operations>(
 ) {
     hax_lib::fstar!(r#"reveal_opaque (`%invert_ntt_re_range_2) (invert_ntt_re_range_2 #$:Vector)"#);
     let _zeta_i_init = *zeta_i;
-    // The semicolon and parentheses at the end of loop are a workaround
-    // for the following bug https://github.com/hacspec/hax/issues/720
     for round in 0..16 {
         hax_lib::loop_invariant!(|round: usize| {
             fstar!(
@@ -119,7 +114,6 @@ pub(crate) fn invert_ntt_at_layer_2<Vector: Operations>(
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ $round ])))"
         );
     }
-    ()
 }
 
 #[inline(always)]
@@ -134,8 +128,6 @@ pub(crate) fn invert_ntt_at_layer_3<Vector: Operations>(
 ) {
     hax_lib::fstar!(r#"reveal_opaque (`%invert_ntt_re_range_2) (invert_ntt_re_range_2 #$:Vector)"#);
     let _zeta_i_init = *zeta_i;
-    // The semicolon and parentheses at the end of loop are a workaround
-    // for the following bug https://github.com/hacspec/hax/issues/720
     for round in 0..16 {
         hax_lib::loop_invariant!(|round: usize| {
             fstar!(
@@ -165,7 +157,6 @@ pub(crate) fn invert_ntt_at_layer_3<Vector: Operations>(
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ $round ])))"
         );
     }
-    ()
 }
 
 #[inline(always)]
@@ -201,8 +192,6 @@ pub(crate) fn invert_ntt_at_layer_4_plus<Vector: Operations>(
 ) {
     let step = 1 << layer;
 
-    // The semicolon and parentheses at the end of loop are a workaround
-    // for the following bug https://github.com/hacspec/hax/issues/720
     for round in 0..(128 >> layer) {
         *zeta_i -= 1;
 
@@ -220,7 +209,6 @@ pub(crate) fn invert_ntt_at_layer_4_plus<Vector: Operations>(
             re.coefficients[j + step_vec] = y;
         }
     }
-    ()
 }
 
 #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/invert_ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/invert_ntt.rs
@@ -52,8 +52,8 @@ pub(crate) fn invert_ntt_at_layer_1<Vector: Operations>(
                         (Spec.Utils.is_i16b_array_opaque (4*3328) 
                         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"#
         );
-        re.coefficients[round] = Vector::inv_ntt_layer_1_step(
-            re.coefficients[round],
+        Vector::inv_ntt_layer_1_step(
+            &mut re.coefficients[round],
             zeta(*zeta_i),
             zeta(*zeta_i - 1),
             zeta(*zeta_i - 2),
@@ -101,8 +101,12 @@ pub(crate) fn invert_ntt_at_layer_2<Vector: Operations>(
                         (Spec.Utils.is_i16b_array_opaque 3328 
                         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"#
         );
-        re.coefficients[round] =
-            Vector::inv_ntt_layer_2_step(re.coefficients[round], zeta(*zeta_i), zeta(*zeta_i - 1));
+
+        Vector::inv_ntt_layer_2_step(
+            &mut re.coefficients[round],
+            zeta(*zeta_i),
+            zeta(*zeta_i - 1),
+        );
         *zeta_i -= 1;
         hax_lib::fstar!(
             r#"reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
@@ -145,8 +149,7 @@ pub(crate) fn invert_ntt_at_layer_3<Vector: Operations>(
                         (Spec.Utils.is_i16b_array_opaque 3328 
                         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"#
         );
-        re.coefficients[round] =
-            Vector::inv_ntt_layer_3_step(re.coefficients[round], zeta(*zeta_i));
+        Vector::inv_ntt_layer_3_step(&mut re.coefficients[round], zeta(*zeta_i));
         hax_lib::fstar!(
             "reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
             (Spec.Utils.is_i16b_array_opaque 3328 
@@ -172,14 +175,17 @@ pub(crate) fn invert_ntt_at_layer_3<Vector: Operations>(
     Spec.Utils.is_i16b_array 28296 (Libcrux_ml_kem.Vector.Traits.f_to_i16_array
         (Libcrux_ml_kem.Vector.Traits.f_add $a $b))"#))]
 pub(crate) fn inv_ntt_layer_int_vec_step_reduce<Vector: Operations>(
-    mut a: Vector,
-    mut b: Vector,
+    a: &mut Vector,
+    b: &mut Vector,
+    scratch: &mut Vector,
     zeta_r: i16,
-) -> (Vector, Vector) {
-    let a_minus_b = Vector::sub(b, &a);
-    a = Vector::barrett_reduce(Vector::add(a, &b));
-    b = montgomery_multiply_fe::<Vector>(a_minus_b, zeta_r);
-    (a, b)
+) {
+    *scratch = b.clone();
+    Vector::sub(scratch, &a);
+    Vector::add(a, b);
+    Vector::barrett_reduce(a);
+    montgomery_multiply_fe::<Vector>(scratch, zeta_r);
+    *b = scratch.clone();
 }
 
 #[inline(always)]
@@ -189,24 +195,22 @@ pub(crate) fn invert_ntt_at_layer_4_plus<Vector: Operations>(
     zeta_i: &mut usize,
     re: &mut PolynomialRingElement<Vector>,
     layer: usize,
+    scratch: &mut Vector,
 ) {
     let step = 1 << layer;
+    let step_vec = step / FIELD_ELEMENTS_IN_VECTOR;
 
-    for round in 0..(128 >> layer) {
+    // For every round, split off two `step_vec` sized slices from the front.
+    let mut remaining_elements = &mut re.coefficients[..];
+    for _round in 0..(128 >> layer) {
         *zeta_i -= 1;
 
-        let offset = round * step * 2;
-        let offset_vec = offset / FIELD_ELEMENTS_IN_VECTOR;
-        let step_vec = step / FIELD_ELEMENTS_IN_VECTOR;
-
-        for j in offset_vec..offset_vec + step_vec {
-            let (x, y) = inv_ntt_layer_int_vec_step_reduce(
-                re.coefficients[j],
-                re.coefficients[j + step_vec],
-                zeta(*zeta_i),
-            );
-            re.coefficients[j] = x;
-            re.coefficients[j + step_vec] = y;
+        // XXX: split_at_mut this
+        let (a, rest) = remaining_elements.split_at_mut(step_vec);
+        let (b, rest) = rest.split_at_mut(step_vec);
+        remaining_elements = rest;
+        for j in 0..step_vec {
+            inv_ntt_layer_int_vec_step_reduce(&mut a[j], &mut b[j], scratch, zeta(*zeta_i));
         }
     }
 }
@@ -215,6 +219,7 @@ pub(crate) fn invert_ntt_at_layer_4_plus<Vector: Operations>(
 #[hax_lib::requires(fstar!(r#"invert_ntt_re_range_1 $re"#))]
 pub(crate) fn invert_ntt_montgomery<const K: usize, Vector: Operations>(
     re: &mut PolynomialRingElement<Vector>,
+    scratch: &mut Vector,
 ) {
     // We only ever call this function after matrix/vector multiplication
     hax_debug_assert!(to_i16_array(re)
@@ -226,10 +231,10 @@ pub(crate) fn invert_ntt_montgomery<const K: usize, Vector: Operations>(
     invert_ntt_at_layer_1(&mut zeta_i, re);
     invert_ntt_at_layer_2(&mut zeta_i, re);
     invert_ntt_at_layer_3(&mut zeta_i, re);
-    invert_ntt_at_layer_4_plus(&mut zeta_i, re, 4);
-    invert_ntt_at_layer_4_plus(&mut zeta_i, re, 5);
-    invert_ntt_at_layer_4_plus(&mut zeta_i, re, 6);
-    invert_ntt_at_layer_4_plus(&mut zeta_i, re, 7);
+    invert_ntt_at_layer_4_plus(&mut zeta_i, re, 4, scratch);
+    invert_ntt_at_layer_4_plus(&mut zeta_i, re, 5, scratch);
+    invert_ntt_at_layer_4_plus(&mut zeta_i, re, 6, scratch);
+    invert_ntt_at_layer_4_plus(&mut zeta_i, re, 7, scratch);
 
     hax_debug_assert!(
         to_i16_array(re)[0].abs() < 128 * (K as i16) * FIELD_MODULUS

--- a/libcrux/libcrux-ml-kem/src/lib.rs
+++ b/libcrux/libcrux-ml-kem/src/lib.rs
@@ -16,7 +16,7 @@
     feature = "mlkem768",
     doc = r##"
 ```
- use rand::{rngs::OsRng, RngCore};
+ use rand::{rngs::OsRng, TryRngCore};
 
  // Ensure you use good randomness.
  // It is not recommended to use OsRng directly!
@@ -90,6 +90,9 @@ pub(crate) mod hax_utils;
 // This is being tracked in https://github.com/hacspec/hacspec-v2/issues/27
 pub(crate) mod constants;
 
+#[cfg(all(feature = "alloc", feature = "incremental"))]
+extern crate alloc;
+
 /// Helpers for verification and extraction
 mod helper;
 
@@ -99,6 +102,7 @@ mod ind_cca;
 mod ind_cpa;
 mod invert_ntt;
 mod matrix;
+mod mlkem;
 mod ntt;
 mod polynomial;
 mod sampling;

--- a/libcrux/libcrux-ml-kem/src/matrix.rs
+++ b/libcrux/libcrux-ml-kem/src/matrix.rs
@@ -3,6 +3,7 @@ use crate::{
     polynomial::PolynomialRingElement, sampling::sample_from_xof, vector::Operations,
 };
 
+#[inline(always)]
 pub(crate) fn entry<const K: usize, Vector: Operations>(
     matrix: &[PolynomialRingElement<Vector>],
     i: usize,
@@ -14,6 +15,7 @@ pub(crate) fn entry<const K: usize, Vector: Operations>(
     &matrix[i * K + j]
 }
 
+#[inline(always)]
 pub(crate) fn entry_mut<const K: usize, Vector: Operations>(
     matrix: &mut [PolynomialRingElement<Vector>],
     i: usize,

--- a/libcrux/libcrux-ml-kem/src/matrix.rs
+++ b/libcrux/libcrux-ml-kem/src/matrix.rs
@@ -62,15 +62,16 @@ pub(crate) fn compute_message<const K: usize, Vector: Operations>(
     v: &PolynomialRingElement<Vector>,
     secret_as_ntt: &[PolynomialRingElement<Vector>; K],
     u_as_ntt: &[PolynomialRingElement<Vector>; K],
-    result: &mut PolynomialRingElement<Vector>
+    result: &mut PolynomialRingElement<Vector>,
+    scratch: &mut PolynomialRingElement<Vector>
 ) {
     for i in 0..K {
-        let product = secret_as_ntt[i].ntt_multiply(&u_as_ntt[i]);
-        result.add_to_ring_element::<K>(&product);
+        secret_as_ntt[i].ntt_multiply(&u_as_ntt[i], scratch);
+        result.add_to_ring_element::<K>(scratch);
     }
 
-    invert_ntt_montgomery::<K, Vector>(result);
-    *result = v.subtract_reduce(*result);
+    invert_ntt_montgomery::<K, Vector>(result, &mut scratch.coefficients[0]);
+    v.subtract_reduce(result);
 }
 
 /// Compute InverseNTT(tᵀ ◦ r̂) + e₂ + message
@@ -92,15 +93,16 @@ pub(crate) fn compute_ring_element_v<const K: usize, Vector: Operations>(
     r_as_ntt: &[PolynomialRingElement<Vector>],
     error_2: &PolynomialRingElement<Vector>,
     message: &PolynomialRingElement<Vector>,
-    result: &mut PolynomialRingElement<Vector>
+    result: &mut PolynomialRingElement<Vector>,
+    scratch: &mut PolynomialRingElement<Vector>
 ) {
     for i in 0..K {
-        let product = t_as_ntt[i].ntt_multiply(&r_as_ntt[i]);
-        result.add_to_ring_element::<K>(&product);
+        t_as_ntt[i].ntt_multiply(&r_as_ntt[i], scratch);
+        result.add_to_ring_element::<K>(&scratch);
     }
 
-    invert_ntt_montgomery::<K, Vector>(result);
-    error_2.add_message_error_reduce(message, result);
+    invert_ntt_montgomery::<K, Vector>(result, &mut scratch.coefficients[0]);
+    error_2.add_message_error_reduce(message, result, &mut scratch.coefficients[0]);
 }
 
 /// Compute u := InvertNTT(Aᵀ ◦ r̂) + e₁
@@ -121,7 +123,8 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations>(
     a_as_ntt: &[[PolynomialRingElement<Vector>; K]; K],
     r_as_ntt: &[PolynomialRingElement<Vector>],
     error_1: &[PolynomialRingElement<Vector>; K],
-    result: &mut [PolynomialRingElement<Vector>]
+    result: &mut [PolynomialRingElement<Vector>],
+    scratch: &mut PolynomialRingElement<Vector>
 ) {
 
 
@@ -129,12 +132,12 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations>(
         for (i, row) in a_as_ntt.iter().enumerate() {
             cloop! {
                 for (j, a_element) in row.iter().enumerate() {
-                    let product = a_element.ntt_multiply(&r_as_ntt[j]);
-                    result[i].add_to_ring_element::<K>(&product);
+                    a_element.ntt_multiply(&r_as_ntt[j], scratch);
+                    result[i].add_to_ring_element::<K>(scratch);
                 }
             }
 
-            invert_ntt_montgomery::<K, Vector>(&mut result[i]);
+            invert_ntt_montgomery::<K, Vector>(&mut result[i], &mut scratch.coefficients[0]);
             result[i].add_error_reduce(&error_1[i]);
         }
     }
@@ -160,6 +163,7 @@ pub(crate) fn compute_As_plus_e<const K: usize, Vector: Operations>(
     matrix_A: &[[PolynomialRingElement<Vector>; K]; K],
     s_as_ntt: &[PolynomialRingElement<Vector>; K],
     error_as_ntt: &[PolynomialRingElement<Vector>; K],
+    scratch: &mut PolynomialRingElement<Vector>
 ) {
     cloop! {
         for (i, row) in matrix_A.iter().enumerate() {
@@ -168,8 +172,8 @@ pub(crate) fn compute_As_plus_e<const K: usize, Vector: Operations>(
             t_as_ntt[i] = PolynomialRingElement::<Vector>::ZERO();
             cloop! {
                 for (j, matrix_element) in row.iter().enumerate() {
-                    let product = matrix_element.ntt_multiply(&s_as_ntt[j]);
-                    t_as_ntt[i].add_to_ring_element::<K>(&product);
+                    matrix_element.ntt_multiply(&s_as_ntt[j], scratch);
+                    t_as_ntt[i].add_to_ring_element::<K>(scratch);
                 }
             }
             t_as_ntt[i].add_standard_error_reduce(&error_as_ntt[i]);

--- a/libcrux/libcrux-ml-kem/src/mlkem.rs
+++ b/libcrux/libcrux-ml-kem/src/mlkem.rs
@@ -1,0 +1,831 @@
+#![cfg(feature = "incremental")]
+
+//! Top level entry points for ML-KEM
+//!
+//! For now this is only used for the incremental API.
+
+// This should be replaced with a nicer proc macro later.
+
+macro_rules! impl_incr_key_size {
+    () => {
+        use crate::ind_cca::incremental::multiplexing;
+
+        use self::incremental::types::{self, Error};
+        pub use self::incremental::types::{PublicKey1, PublicKey2};
+
+        use super::*;
+        use ind_cca::incremental;
+
+        /// Ciphertext 1
+        pub type Ciphertext1 = types::Ciphertext1<C1_SIZE>;
+
+        /// Ciphertext 2
+        pub type Ciphertext2 = types::Ciphertext2<C2_SIZE>;
+
+        /// Get the size of the first public key in bytes.
+        pub const fn pk1_len() -> usize {
+            PublicKey1::len()
+        }
+
+        /// Get the size of the second public key in bytes.
+        pub const fn pk2_len() -> usize {
+            RANKED_BYTES_PER_RING_ELEMENT
+        }
+
+        /// The size of a compressed key pair in bytes.
+        pub const COMPRESSED_KEYPAIR_LEN: usize = SECRET_KEY_SIZE;
+
+        /// The size of the key pair in bytes.
+        pub const fn key_pair_len() -> usize {
+            // Because const generics are too limited, we compute it here from scratch.
+
+            // PK1
+            pk1_len()
+            // PK2
+            + pk2_len()
+            // SK
+            + RANK * 16 * 32 + 32
+            // Matrix
+            + RANK * RANK * 16 * 32
+        }
+
+
+        /// The size of the compressed key pair in bytes.
+        pub const fn key_pair_compressed_len() -> usize {
+            COMPRESSED_KEYPAIR_LEN
+        }
+
+        /// The size of the encaps state in bytes.
+        pub const fn encaps_state_len() -> usize {
+            // Because const generics are too limited, we compute it here from scratch.
+
+            // r_as_ntt
+            RANK * 16 * 32
+            // error2
+            + 16 * 32
+            // randomness
+            + 32
+        }
+
+        /// The size of the shared secret.
+        pub const fn shared_secret_size() -> usize {
+            SHARED_SECRET_SIZE
+        }
+
+        /// Functions in this module require an allocator to use [`Box`].
+        ///
+        /// Instead of serializing keys and state, the functions in this module return
+        /// the platform dependent keys and state types for immediate use.
+        #[cfg(feature = "alloc")]
+        pub mod alloc {
+            use super::*;
+            use super::incremental::types::alloc::{State, Keys};
+            use ::alloc::boxed::Box;
+
+            /// Generate a new key pair for incremental encapsulation.
+            pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> Box<dyn Keys> {
+                multiplexing::alloc::generate_keypair::<
+                    RANK,
+                    CPA_PKE_SECRET_KEY_SIZE,
+                    SECRET_KEY_SIZE,
+                    CPA_PKE_PUBLIC_KEY_SIZE,
+                    RANKED_BYTES_PER_RING_ELEMENT,
+                    ETA1,
+                    ETA1_RANDOMNESS_SIZE,
+                >(randomness)
+            }
+
+            /// Encapsulate the first part of the ciphertext.
+            pub fn encapsulate1(
+                public_key_part: &PublicKey1,
+                randomness: [u8; SHARED_SECRET_SIZE],
+            ) -> (Ciphertext1, Box<dyn State>, [u8; SHARED_SECRET_SIZE]) {
+                multiplexing::alloc::encapsulate1::<
+                    RANK,
+                    CPA_PKE_CIPHERTEXT_SIZE,
+                    C1_SIZE,
+                    VECTOR_U_COMPRESSION_FACTOR,
+                    C1_BLOCK_SIZE,
+                    ETA1,
+                    ETA1_RANDOMNESS_SIZE,
+                    ETA2,
+                    ETA2_RANDOMNESS_SIZE,
+                >(public_key_part, randomness)
+            }
+
+            /// Encapsulate the second part of the ciphertext.
+            ///
+            /// The second part of the public key is passed in as byte slice.
+            /// [`Error::InvalidInputLength`] is returned if `public_key_part` is too
+            /// short.
+            pub fn encapsulate2(state: &dyn State, public_key_part: &[u8]) -> Result<Ciphertext2, Error> {
+                multiplexing::alloc::encapsulate2::<RANK, RANKED_BYTES_PER_RING_ELEMENT, C2_SIZE, VECTOR_V_COMPRESSION_FACTOR>(
+                    state,
+                    public_key_part,
+                )
+            }
+
+            /// Decapsulate incremental ciphertexts.
+            pub fn decapsulate(
+                private_key: &dyn Keys,
+                ciphertext1: &Ciphertext1,
+                ciphertext2: &Ciphertext2,
+            ) -> MlKemSharedSecret {
+                multiplexing::alloc::decapsulate::<
+                    RANK,
+                    SECRET_KEY_SIZE,
+                    CPA_PKE_SECRET_KEY_SIZE,
+                    CPA_PKE_PUBLIC_KEY_SIZE,
+                    CPA_PKE_CIPHERTEXT_SIZE,
+                    T_AS_NTT_ENCODED_SIZE,
+                    C1_SIZE,
+                    C2_SIZE,
+                    VECTOR_U_COMPRESSION_FACTOR,
+                    VECTOR_V_COMPRESSION_FACTOR,
+                    C1_BLOCK_SIZE,
+                    ETA1,
+                    ETA1_RANDOMNESS_SIZE,
+                    ETA2,
+                    ETA2_RANDOMNESS_SIZE,
+                    IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+                >(private_key, ciphertext1, ciphertext2)
+            }
+        }
+
+        /// An encoded, incremental key pair.
+        pub struct KeyPairBytes {
+            value: [u8; key_pair_len()]
+        }
+
+        #[cfg(all(not(eurydice), feature = "rand"))]
+        use ::rand::{CryptoRng, RngCore};
+
+        impl KeyPairBytes {
+            /// Generate a new key pair.
+            /// This uses unpacked keys and does not compress the keys.
+            pub fn from_seed(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> Self {
+                let mut out = Self {
+                    value: [0u8; key_pair_len()]
+                };
+                generate_key_pair(randomness, &mut out.value).unwrap();
+                out
+            }
+
+            /// Generate a new key pair.
+            /// This uses unpacked keys and does not compress the keys.
+            #[cfg(all(not(eurydice), feature = "rand"))]
+            pub fn generate(rng: &mut (impl RngCore + CryptoRng)) -> Self {
+                let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
+                rng.fill_bytes(&mut randomness);
+                let mut out = Self {
+                    value: [0u8; key_pair_len()]
+                };
+                generate_key_pair(randomness, &mut out.value).unwrap();
+                out
+            }
+
+            /// Get the raw bytes.
+            pub fn to_bytes(self) -> [u8; key_pair_len()] {
+                self.value
+            }
+
+            /// Get the PK1 bytes from the serialized key pair bytes
+            pub fn pk1(&self) -> &[u8; pk1_len()] {
+                // The unwrap here is ok because that's exactly what we take
+                // and we know that `self.value` is long enough.
+                <&[u8; pk1_len()]>::try_from(&self.value[0..pk1_len()]).unwrap()
+            }
+
+            /// Get the PK2 bytes from the serialized key pair bytes
+            pub fn pk2(&self) -> &[u8; pk2_len()] {
+                // The unwrap here is ok because that's exactly what we take
+                // and we know that `self.value` is long enough.
+                <&[u8; pk2_len()]>::try_from(&self.value[pk1_len()..pk1_len() + pk2_len()]).unwrap()
+            }
+        }
+
+        impl AsRef<[u8]> for KeyPairBytes {
+            fn as_ref(&self) -> &[u8] {
+                &self.value
+            }
+        }
+
+        /// Generate a key pair and write it into `key_pair`.
+        /// This uses unpacked keys and does not compress the keys.
+        ///
+        /// `key_pair.len()` must be of size `key_pair_len()`.
+        /// The function returns an error if this is not the case.
+        pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE], key_pair: &mut [u8]) -> Result<(), Error> {
+            multiplexing::generate_keypair::<
+                RANK,
+                RANKED_BYTES_PER_RING_ELEMENT,
+                CPA_PKE_SECRET_KEY_SIZE,
+                SECRET_KEY_SIZE,
+                CPA_PKE_PUBLIC_KEY_SIZE,
+                RANKED_BYTES_PER_RING_ELEMENT,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+            >(randomness, key_pair)
+        }
+        /// An encoded, compressed, incremental key pair.
+        ///
+        /// Layout: dk | (t | ⍴) | H(ek) | z
+        pub struct KeyPairCompressedBytes {
+            value: [u8; key_pair_compressed_len()]
+        }
+
+        impl KeyPairCompressedBytes {
+            /// Generate a new key pair.
+            /// This uses unpacked keys and does not compress the keys.
+            pub fn from_seed(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> Self {
+                let mut out = Self {
+                    value: [0u8; key_pair_compressed_len()]
+                };
+                generate_key_pair_compressed(randomness, &mut out.value);
+                out
+            }
+
+            /// Generate a new key pair.
+            /// This uses unpacked keys and does not compress the keys.
+            #[cfg(all(not(eurydice), feature = "rand"))]
+            pub fn generate(rng: &mut (impl RngCore + CryptoRng)) -> Self {
+                let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
+                rng.fill_bytes(&mut randomness);
+                let mut out = Self {
+                    value: [0u8; key_pair_compressed_len()]
+                };
+                generate_key_pair_compressed(randomness, &mut out.value);
+                out
+            }
+
+            /// Get the raw bytes.
+            pub fn to_bytes(self) -> [u8; key_pair_compressed_len()] {
+                self.value
+            }
+
+            /// Get the PK1 bytes from the serialized key pair bytes
+            pub fn pk1(&self) -> &[u8; pk1_len()] {
+                // The unwrap here is ok because that's exactly what we take
+                // and we know that `self.value` is long enough.
+                const START: usize = 2 *  RANKED_BYTES_PER_RING_ELEMENT;
+                <&[u8; pk1_len()]>::try_from(&self.value[START..START + pk1_len()]).unwrap()
+            }
+
+            /// Get the PK2 bytes from the serialized key pair bytes
+            pub fn pk2(&self) -> &[u8; pk2_len()] {
+                // The unwrap here is ok because that's exactly what we take
+                // and we know that `self.value` is long enough.
+                const START: usize = RANKED_BYTES_PER_RING_ELEMENT;
+                <&[u8; pk2_len()]>::try_from(&self.value[START..START + pk2_len()]).unwrap()
+            }
+
+            /// Get the serialized private for decapsulation.
+            pub fn sk(&self) -> &[u8; SECRET_KEY_SIZE] {
+                &self.value
+            }
+        }
+
+        impl AsRef<[u8]> for KeyPairCompressedBytes {
+            fn as_ref(&self) -> &[u8] {
+                &self.value
+            }
+        }
+
+        /// Generate a key pair and write it into `key_pair`.
+        /// This compresses the keys.
+        pub fn generate_key_pair_compressed(randomness: [u8; KEY_GENERATION_SEED_SIZE], key_pair: &mut [u8; COMPRESSED_KEYPAIR_LEN]) {
+            multiplexing::generate_keypair_compressed::<
+                RANK,
+                RANKED_BYTES_PER_RING_ELEMENT,
+                CPA_PKE_SECRET_KEY_SIZE,
+                SECRET_KEY_SIZE,
+                CPA_PKE_PUBLIC_KEY_SIZE,
+                RANKED_BYTES_PER_RING_ELEMENT,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                COMPRESSED_KEYPAIR_LEN,
+            >(randomness, key_pair)
+        }
+
+        /// Get the PK1 bytes from the serialized key pair bytes
+        pub fn pk1(
+            keypair: &[u8; key_pair_len()],
+        ) -> &[u8] {
+            &keypair[0..pk1_len()]
+        }
+
+        /// Get the PK2 bytes from the serialized key pair bytes
+        pub fn pk2(
+            keypair: &[u8; key_pair_len()],
+        ) -> &[u8] {
+            &keypair[pk1_len()..pk1_len() + pk2_len()]
+        }
+
+        /// Validate that the two parts `pk1` and `pk2` are consistent.
+        pub fn validate_pk(
+            pk1: &PublicKey1,
+            pk2: &[u8],
+        ) -> Result<(), Error> {
+            multiplexing::validate_pk::<RANK,  CPA_PKE_PUBLIC_KEY_SIZE>(pk1, pk2)
+        }
+
+        /// Validate that the two parts `pk1` and `pk2` are consistent.
+        pub fn validate_pk_bytes(
+            pk1: &[u8],
+            pk2: &[u8],
+        ) -> Result<(), Error> {
+            multiplexing::validate_pk_bytes::<RANK,  CPA_PKE_PUBLIC_KEY_SIZE>(pk1, pk2)
+        }
+
+        /// Encapsulate the first part of the ciphertext.
+        ///
+        /// Returns an [`Error`] if the provided input or output don't have
+        /// the appropriate sizes.
+        pub fn encapsulate1(
+            pk1: &[u8],
+            randomness: [u8; SHARED_SECRET_SIZE],
+            state: &mut [u8],
+            shared_secret: &mut [u8],
+        ) -> Result<Ciphertext1, Error> {
+            let public_key_part = PublicKey1::try_from(&pk1 as &[u8])?;
+
+            multiplexing::encapsulate1::<
+                RANK,
+                CPA_PKE_CIPHERTEXT_SIZE,
+                C1_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                C1_BLOCK_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+            >(&public_key_part, randomness, state, shared_secret)
+        }
+
+        /// Encapsulate the first part of the ciphertext.
+        ///
+        /// Returns an [`Error`] if the provided input or output don't have
+        /// the appropriate sizes.
+        #[cfg(feature = "rand")]
+        pub mod rand {
+            use super::*;
+            use ::rand::TryRngCore;
+
+            /// Encapsulate the first part of the ciphertext.
+            ///
+            /// Returns an [`Error`] if the provided input or output don't have
+            /// the appropriate sizes.
+            pub fn encapsulate1(
+                pk1: &[u8],
+                rng: &mut impl CryptoRng,
+                state: &mut [u8],
+                shared_secret: &mut [u8],
+            ) -> Result<Ciphertext1, Error> {
+                let public_key_part = PublicKey1::try_from(&pk1 as &[u8])?;
+                let mut randomness = [0u8; SHARED_SECRET_SIZE];
+                rng.try_fill_bytes(&mut randomness).map_err(|_| Error::InsufficientRandomness)?;
+
+                multiplexing::encapsulate1::<
+                    RANK,
+                    CPA_PKE_CIPHERTEXT_SIZE,
+                    C1_SIZE,
+                    VECTOR_U_COMPRESSION_FACTOR,
+                    C1_BLOCK_SIZE,
+                    ETA1,
+                    ETA1_RANDOMNESS_SIZE,
+                    ETA2,
+                    ETA2_RANDOMNESS_SIZE,
+                >(&public_key_part, randomness, state, shared_secret)
+            }
+        }
+
+        /// Encapsulate the second part of the ciphertext.
+        ///
+        /// The second part of the public key is passed in as byte slice.
+        /// [`Error::InvalidInputLength`] is returned if `public_key_part` is too
+        /// short.
+        pub fn encapsulate2(state: &[u8; encaps_state_len()], public_key_part: &[u8; pk2_len()]) -> Ciphertext2 {
+            multiplexing::encapsulate2::<RANK, RANKED_BYTES_PER_RING_ELEMENT, C2_SIZE, VECTOR_V_COMPRESSION_FACTOR, {encaps_state_len()}>(state, public_key_part)
+        }
+
+        /// Decapsulate incremental ciphertexts.
+        pub fn decapsulate_incremental_key(
+            private_key: &[u8],
+            ciphertext1: &Ciphertext1,
+            ciphertext2: &Ciphertext2,
+        ) -> Result<MlKemSharedSecret, Error> {
+            multiplexing::decapsulate::<
+                RANK,
+                RANKED_BYTES_PER_RING_ELEMENT,
+                SECRET_KEY_SIZE,
+                CPA_PKE_SECRET_KEY_SIZE,
+                CPA_PKE_PUBLIC_KEY_SIZE,
+                CPA_PKE_CIPHERTEXT_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                C1_BLOCK_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+            >(private_key, ciphertext1, ciphertext2)
+        }
+
+        /// Decapsulate incremental ciphertexts.
+        pub fn decapsulate_compressed_key(
+            private_key: &[u8; SECRET_KEY_SIZE],
+            ciphertext1: &Ciphertext1,
+            ciphertext2: &Ciphertext2,
+        ) -> MlKemSharedSecret {
+            multiplexing::decapsulate_compressed::<
+                RANK,
+                RANKED_BYTES_PER_RING_ELEMENT,
+                SECRET_KEY_SIZE,
+                CPA_PKE_SECRET_KEY_SIZE,
+                CPA_PKE_PUBLIC_KEY_SIZE,
+                CPA_PKE_CIPHERTEXT_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                C1_BLOCK_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+            >(private_key, ciphertext1, ciphertext2)
+        }
+    };
+}
+pub(crate) use impl_incr_key_size;
+
+macro_rules! impl_incr_platform {
+    ($vector:path, $hash:path $(, $unsafe:ident)? $(, #[$meta:meta])*) => {
+        /// Downcast [`Keys`] to a platform dependent [`MlKemKeyPairUnpacked`].
+        ///
+        /// **PANICS** is the cast fails
+        #[cfg(feature = "alloc")]
+        pub(super) fn as_keypair<const K: usize>(
+            k: &dyn core::any::Any,
+        ) -> &MlKemKeyPairUnpacked<K, $vector> {
+            k.downcast_ref().unwrap()
+        }
+
+        /// Downcast [`State`] to a  platform dependent [`EncapsState`].
+        ///
+        /// **PANICS** is the cast fails
+        #[cfg(feature = "alloc")]
+        pub(super) fn as_state<const K: usize>(s: &dyn core::any::Any) -> &EncapsState<K, $vector> {
+            s.downcast_ref().unwrap()
+        }
+
+        $(#[$meta])*
+        pub(crate) $($unsafe)? fn generate_keypair<
+            const K: usize,
+            const CPA_PRIVATE_KEY_SIZE: usize,
+            const PRIVATE_KEY_SIZE: usize,
+            const PUBLIC_KEY_SIZE: usize,
+            const BYTES_PER_RING_ELEMENT: usize,
+            const ETA1: usize,
+            const ETA1_RANDOMNESS_SIZE: usize,
+        >(
+            randomness: [u8; KEY_GENERATION_SEED_SIZE],
+        ) -> MlKemKeyPairUnpacked<K, $vector> {
+            super::generate_keypair::<
+                K,
+                CPA_PRIVATE_KEY_SIZE,
+                PRIVATE_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                $vector,
+                $hash,
+            >(randomness)
+        }
+
+        $(#[$meta])*
+        pub(crate) $($unsafe)? fn generate_keypair_serialized<
+            const K: usize,
+            const PK2_LEN: usize,
+            const CPA_PRIVATE_KEY_SIZE: usize,
+            const PRIVATE_KEY_SIZE: usize,
+            const PUBLIC_KEY_SIZE: usize,
+            const BYTES_PER_RING_ELEMENT: usize,
+            const ETA1: usize,
+            const ETA1_RANDOMNESS_SIZE: usize,
+        >(
+            randomness: [u8; KEY_GENERATION_SEED_SIZE],
+            key_pair: &mut [u8],
+        ) -> Result<(), Error> {
+            if key_pair.len() < KeyPair::<K, PK2_LEN, $vector>::num_bytes() {
+                return Err(Error::InvalidOutputLength);
+            }
+
+            super::generate_keypair_serialized::<
+                K,
+                PK2_LEN,
+                CPA_PRIVATE_KEY_SIZE,
+                PRIVATE_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                $vector,
+                $hash,
+            >(randomness, key_pair)
+        }
+
+        $(#[$meta])*
+        pub(crate) $($unsafe)? fn generate_keypair_compressed<
+            const K: usize,
+            const PK2_LEN: usize,
+            const CPA_PRIVATE_KEY_SIZE: usize,
+            const PRIVATE_KEY_SIZE: usize,
+            const PUBLIC_KEY_SIZE: usize,
+            const BYTES_PER_RING_ELEMENT: usize,
+            const ETA1: usize,
+            const ETA1_RANDOMNESS_SIZE: usize,
+            const COMPRESSED_KEYPAIR_LEN: usize,
+        >(
+            randomness: [u8; KEY_GENERATION_SEED_SIZE],
+            key_pair: &mut [u8; COMPRESSED_KEYPAIR_LEN],
+        ) {
+            super::generate_keypair_compressed::<
+                K,
+                PK2_LEN,
+                CPA_PRIVATE_KEY_SIZE,
+                PRIVATE_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                COMPRESSED_KEYPAIR_LEN,
+                $vector,
+                $hash,
+            >(randomness, key_pair)
+        }
+
+        $(#[$meta])*
+        pub(crate) $($unsafe)? fn validate_pk<const K: usize, const PK_LEN: usize>(
+            pk1: &PublicKey1,
+            pk2: &[u8],
+        ) -> Result<(), Error> {
+            super::validate_pk::<K, PK_LEN, $hash, $vector>(pk1, pk2)
+        }
+
+        $(#[$meta])*
+        pub(crate) $($unsafe)? fn validate_pk_bytes<const K: usize, const PK_LEN: usize>(
+            pk1: &[u8],
+            pk2: &[u8],
+        ) -> Result<(), Error> {
+            super::validate_pk_bytes::<K, PK_LEN, $hash, $vector>(pk1, pk2)
+        }
+
+        $(#[$meta])*
+        pub(crate) $($unsafe)? fn encapsulate1<
+            const K: usize,
+            const CIPHERTEXT_SIZE: usize,
+            const C1_SIZE: usize,
+            const VECTOR_U_COMPRESSION_FACTOR: usize,
+            const VECTOR_U_BLOCK_LEN: usize,
+            const ETA1: usize,
+            const ETA1_RANDOMNESS_SIZE: usize,
+            const ETA2: usize,
+            const ETA2_RANDOMNESS_SIZE: usize,
+        >(
+            public_key_part: &PublicKey1,
+            randomness: [u8; SHARED_SECRET_SIZE],
+        ) -> (
+            Ciphertext1<C1_SIZE>,
+            EncapsState<K, $vector>,
+            [u8; SHARED_SECRET_SIZE],
+        ) {
+            super::encapsulate1::<
+                K,
+                CIPHERTEXT_SIZE,
+                C1_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_U_BLOCK_LEN,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                $vector,
+                $hash,
+            >(public_key_part, randomness)
+        }
+
+        $(#[$meta])*
+        pub(crate) $($unsafe)? fn encapsulate1_serialized<
+            const K: usize,
+            const CIPHERTEXT_SIZE: usize,
+            const C1_SIZE: usize,
+            const VECTOR_U_COMPRESSION_FACTOR: usize,
+            const VECTOR_U_BLOCK_LEN: usize,
+            const ETA1: usize,
+            const ETA1_RANDOMNESS_SIZE: usize,
+            const ETA2: usize,
+            const ETA2_RANDOMNESS_SIZE: usize,
+        >(
+            public_key_part: &PublicKey1,
+            randomness: [u8; SHARED_SECRET_SIZE],
+            state: &mut [u8],
+            shared_secret: &mut [u8],
+        ) -> Result<Ciphertext1<C1_SIZE>, Error> {
+            super::encapsulate1_serialized::<
+                K,
+                CIPHERTEXT_SIZE,
+                C1_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_U_BLOCK_LEN,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                $vector,
+                $hash,
+            >(public_key_part, randomness, state, shared_secret)
+        }
+
+        $(#[$meta])*
+        pub(crate) $($unsafe)? fn encapsulate2<
+            const K: usize,
+            const PK2_LEN: usize,
+            const C2_SIZE: usize,
+            const VECTOR_V_COMPRESSION_FACTOR: usize,
+        >(
+            state: &EncapsState<K, $vector>,
+            public_key_part: &PublicKey2<PK2_LEN>,
+        ) -> Ciphertext2<C2_SIZE> {
+            super::encapsulate2::<K, PK2_LEN, C2_SIZE, VECTOR_V_COMPRESSION_FACTOR, $vector>(
+                state,
+                public_key_part,
+            )
+        }
+
+        $(#[$meta])*
+        pub(crate) $($unsafe)? fn encapsulate2_serialized<
+            const K: usize,
+            const PK2_LEN: usize,
+            const C2_SIZE: usize,
+            const VECTOR_V_COMPRESSION_FACTOR: usize,
+            const STATE_LEN: usize,
+        >(
+            state: &[u8; STATE_LEN],
+            public_key_part: &PublicKey2<PK2_LEN>,
+        ) -> Ciphertext2<C2_SIZE> {
+            super::encapsulate2_serialized::<
+                K,
+                PK2_LEN,
+                C2_SIZE,
+                VECTOR_V_COMPRESSION_FACTOR,
+                STATE_LEN,
+                $vector,
+            >(state, public_key_part)
+        }
+
+        $(#[$meta])*
+        pub(crate) $($unsafe)? fn decapsulate<
+            const K: usize,
+            const SECRET_KEY_SIZE: usize,
+            const CPA_SECRET_KEY_SIZE: usize,
+            const PUBLIC_KEY_SIZE: usize,
+            const CIPHERTEXT_SIZE: usize,
+            const T_AS_NTT_ENCODED_SIZE: usize,
+            const C1_SIZE: usize,
+            const C2_SIZE: usize,
+            const VECTOR_U_COMPRESSION_FACTOR: usize,
+            const VECTOR_V_COMPRESSION_FACTOR: usize,
+            const C1_BLOCK_SIZE: usize,
+            const ETA1: usize,
+            const ETA1_RANDOMNESS_SIZE: usize,
+            const ETA2: usize,
+            const ETA2_RANDOMNESS_SIZE: usize,
+            const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+        >(
+            private_key: &MlKemKeyPairUnpacked<K, $vector>,
+            ciphertext1: &Ciphertext1<C1_SIZE>,
+            ciphertext2: &Ciphertext2<C2_SIZE>,
+        ) -> MlKemSharedSecret {
+            super::decapsulate::<
+                K,
+                SECRET_KEY_SIZE,
+                CPA_SECRET_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                CIPHERTEXT_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                C1_BLOCK_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+                $vector,
+                $hash,
+            >(private_key, ciphertext1, ciphertext2)
+        }
+
+        $(#[$meta])*
+        pub(crate) $($unsafe)? fn decapsulate_incremental_key<
+            const K: usize,
+            const PK2_LEN: usize,
+            const SECRET_KEY_SIZE: usize,
+            const CPA_SECRET_KEY_SIZE: usize,
+            const PUBLIC_KEY_SIZE: usize,
+            const CIPHERTEXT_SIZE: usize,
+            const T_AS_NTT_ENCODED_SIZE: usize,
+            const C1_SIZE: usize,
+            const C2_SIZE: usize,
+            const VECTOR_U_COMPRESSION_FACTOR: usize,
+            const VECTOR_V_COMPRESSION_FACTOR: usize,
+            const C1_BLOCK_SIZE: usize,
+            const ETA1: usize,
+            const ETA1_RANDOMNESS_SIZE: usize,
+            const ETA2: usize,
+            const ETA2_RANDOMNESS_SIZE: usize,
+            const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+        >(
+            private_key: &[u8],
+            ciphertext1: &Ciphertext1<C1_SIZE>,
+            ciphertext2: &Ciphertext2<C2_SIZE>,
+        ) -> Result<MlKemSharedSecret, Error> {
+            super::decapsulate_incremental_key::<
+                K,
+                PK2_LEN,
+                SECRET_KEY_SIZE,
+                CPA_SECRET_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                CIPHERTEXT_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                C1_BLOCK_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+                $vector,
+                $hash,
+            >(private_key, ciphertext1, ciphertext2)
+        }
+
+        $(#[$meta])*
+        pub(crate) $($unsafe)? fn decapsulate_compressed_key<
+            const K: usize,
+            const PK2_LEN: usize,
+            const SECRET_KEY_SIZE: usize,
+            const CPA_SECRET_KEY_SIZE: usize,
+            const PUBLIC_KEY_SIZE: usize,
+            const CIPHERTEXT_SIZE: usize,
+            const T_AS_NTT_ENCODED_SIZE: usize,
+            const C1_SIZE: usize,
+            const C2_SIZE: usize,
+            const VECTOR_U_COMPRESSION_FACTOR: usize,
+            const VECTOR_V_COMPRESSION_FACTOR: usize,
+            const C1_BLOCK_SIZE: usize,
+            const ETA1: usize,
+            const ETA1_RANDOMNESS_SIZE: usize,
+            const ETA2: usize,
+            const ETA2_RANDOMNESS_SIZE: usize,
+            const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize,
+        >(
+            private_key: &[u8; SECRET_KEY_SIZE],
+            ciphertext1: &Ciphertext1<C1_SIZE>,
+            ciphertext2: &Ciphertext2<C2_SIZE>,
+        ) -> MlKemSharedSecret {
+            super::decapsulate_compressed_key::<
+                K,
+                PK2_LEN,
+                SECRET_KEY_SIZE,
+                CPA_SECRET_KEY_SIZE,
+                PUBLIC_KEY_SIZE,
+                CIPHERTEXT_SIZE,
+                T_AS_NTT_ENCODED_SIZE,
+                C1_SIZE,
+                C2_SIZE,
+                VECTOR_U_COMPRESSION_FACTOR,
+                VECTOR_V_COMPRESSION_FACTOR,
+                C1_BLOCK_SIZE,
+                ETA1,
+                ETA1_RANDOMNESS_SIZE,
+                ETA2,
+                ETA2_RANDOMNESS_SIZE,
+                IMPLICIT_REJECTION_HASH_INPUT_SIZE,
+                $vector,
+                $hash,
+            >(private_key, ciphertext1, ciphertext2)
+        }
+    };
+}
+pub(crate) use impl_incr_platform;

--- a/libcrux/libcrux-ml-kem/src/mlkem1024.rs
+++ b/libcrux/libcrux-ml-kem/src/mlkem1024.rs
@@ -434,8 +434,8 @@ macro_rules! instantiate {
 // Instantiations
 
 instantiate! {portable, ind_cca::instantiations::portable, vector::portable::PortableVector, "Portable ML-KEM 1024"}
-#[cfg(feature = "simd256")]
-instantiate! {avx2, ind_cca::instantiations::avx2, vector::SIMD256Vector, "AVX2 Optimised ML-KEM 1024"}
+// #[cfg(feature = "simd256")]
+// instantiate! {avx2, ind_cca::instantiations::avx2, vector::SIMD256Vector, "AVX2 Optimised ML-KEM 1024"}
 #[cfg(feature = "simd128")]
 instantiate! {neon, ind_cca::instantiations::neon, vector::SIMD128Vector, "Neon Optimised ML-KEM 1024"}
 

--- a/libcrux/libcrux-ml-kem/src/mlkem1024.rs
+++ b/libcrux/libcrux-ml-kem/src/mlkem1024.rs
@@ -2,6 +2,7 @@
 use super::{constants::*, ind_cca::*, types::*, *};
 
 const RANK: usize = 4;
+const RANK_SQUARED: usize = RANK * RANK;
 #[cfg(any(feature = "incremental", eurydice))]
 const RANKED_BYTES_PER_RING_ELEMENT: usize = RANK * BITS_PER_RING_ELEMENT / 8;
 const T_AS_NTT_ENCODED_SIZE: usize =
@@ -112,7 +113,8 @@ macro_rules! instantiate {
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem1024KeyPair {
                     p::generate_keypair::<
-                        RANK,
+                RANK,
+                RANK_SQUARED,
                         CPA_PKE_SECRET_KEY_SIZE,
                         SECRET_KEY_SIZE,
                         CPA_PKE_PUBLIC_KEY_SIZE,
@@ -133,7 +135,8 @@ macro_rules! instantiate {
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem1024Ciphertext, MlKemSharedSecret) {
                     p::encapsulate::<
-                        RANK,
+                RANK,
+                RANK_SQUARED,
                         CPA_PKE_CIPHERTEXT_SIZE,
                         CPA_PKE_PUBLIC_KEY_SIZE,
                         T_AS_NTT_ENCODED_SIZE,
@@ -164,7 +167,8 @@ macro_rules! instantiate {
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem1024Ciphertext, MlKemSharedSecret) {
                     p::kyber_encapsulate::<
-                        RANK,
+                RANK,
+                RANK_SQUARED,
                         CPA_PKE_CIPHERTEXT_SIZE,
                         CPA_PKE_PUBLIC_KEY_SIZE,
                         T_AS_NTT_ENCODED_SIZE,
@@ -192,7 +196,8 @@ macro_rules! instantiate {
                 ciphertext: &MlKem1024Ciphertext,
             ) -> MlKemSharedSecret {
                     p::decapsulate::<
-                        RANK,
+                RANK,
+                RANK_SQUARED,
                         SECRET_KEY_SIZE,
                         CPA_PKE_SECRET_KEY_SIZE,
                         CPA_PKE_PUBLIC_KEY_SIZE,
@@ -253,10 +258,10 @@ macro_rules! instantiate {
 
                 /// An Unpacked ML-KEM 1024 Public key
                 pub type MlKem1024PublicKeyUnpacked =
-                    p::unpacked::MlKemPublicKeyUnpacked<RANK>;
+                    p::unpacked::MlKemPublicKeyUnpacked<RANK, RANK_SQUARED>;
 
                 /// Am Unpacked ML-KEM 1024 Key pair
-                pub type MlKem1024KeyPairUnpacked = p::unpacked::MlKemKeyPairUnpacked<RANK>;
+                pub type MlKem1024KeyPairUnpacked = p::unpacked::MlKemKeyPairUnpacked<RANK, RANK_SQUARED>;
 
                 /// Create a new, empty unpacked key.
                 pub fn init_key_pair() -> MlKem1024KeyPairUnpacked {
@@ -309,7 +314,7 @@ macro_rules! instantiate {
 
                 /// Get an unpacked key from a private key.
                 pub fn key_pair_from_private_mut(private_key: &MlKem1024PrivateKey, key_pair: &mut MlKem1024KeyPairUnpacked) {
-                    p::unpacked::keypair_from_private_key::<RANK, SECRET_KEY_SIZE, CPA_PKE_SECRET_KEY_SIZE, CPA_PKE_PUBLIC_KEY_SIZE, T_AS_NTT_ENCODED_SIZE>(private_key, key_pair);
+                    p::unpacked::keypair_from_private_key::<RANK, RANK_SQUARED, SECRET_KEY_SIZE, CPA_PKE_SECRET_KEY_SIZE, CPA_PKE_PUBLIC_KEY_SIZE, T_AS_NTT_ENCODED_SIZE>(private_key, key_pair);
                 }
 
                 /// Get the unpacked public key.
@@ -318,7 +323,8 @@ macro_rules! instantiate {
                     unpacked_public_key: &mut MlKem1024PublicKeyUnpacked,
                 ) {
                         p::unpacked::unpack_public_key::<
-                            RANK,
+                    RANK,
+                    RANK_SQUARED,
                             T_AS_NTT_ENCODED_SIZE,
                             CPA_PKE_PUBLIC_KEY_SIZE,
                         >(public_key, unpacked_public_key)
@@ -340,7 +346,8 @@ macro_rules! instantiate {
                     key_pair: &mut MlKem1024KeyPairUnpacked,
                 ) {
                         p::unpacked::generate_keypair::<
-                            RANK,
+                    RANK,
+                    RANK_SQUARED,
                             CPA_PKE_SECRET_KEY_SIZE,
                             SECRET_KEY_SIZE,
                             CPA_PKE_PUBLIC_KEY_SIZE,
@@ -376,7 +383,8 @@ macro_rules! instantiate {
                     randomness: [u8; SHARED_SECRET_SIZE],
                 ) -> (MlKem1024Ciphertext, MlKemSharedSecret) {
                         p::unpacked::encapsulate::<
-                            RANK,
+                    RANK,
+                    RANK_SQUARED,
                             CPA_PKE_CIPHERTEXT_SIZE,
                             CPA_PKE_PUBLIC_KEY_SIZE,
                             T_AS_NTT_ENCODED_SIZE,
@@ -405,7 +413,8 @@ macro_rules! instantiate {
                     ciphertext: &MlKem1024Ciphertext,
                 ) -> MlKemSharedSecret {
                         p::unpacked::decapsulate::<
-                            RANK,
+                    RANK,
+                    RANK_SQUARED,
                             SECRET_KEY_SIZE,
                             CPA_PKE_SECRET_KEY_SIZE,
                             CPA_PKE_PUBLIC_KEY_SIZE,
@@ -478,6 +487,7 @@ pub fn generate_key_pair(
 ) -> MlKemKeyPair<SECRET_KEY_SIZE, CPA_PKE_PUBLIC_KEY_SIZE> {
     multiplexing::generate_keypair::<
         RANK,
+        RANK_SQUARED,
         CPA_PKE_SECRET_KEY_SIZE,
         SECRET_KEY_SIZE,
         CPA_PKE_PUBLIC_KEY_SIZE,
@@ -505,6 +515,7 @@ pub fn encapsulate(
 ) -> (MlKem1024Ciphertext, MlKemSharedSecret) {
     multiplexing::encapsulate::<
         RANK,
+        RANK_SQUARED,
         CPA_PKE_CIPHERTEXT_SIZE,
         CPA_PKE_PUBLIC_KEY_SIZE,
         T_AS_NTT_ENCODED_SIZE,
@@ -538,6 +549,7 @@ pub fn decapsulate(
 ) -> MlKemSharedSecret {
     multiplexing::decapsulate::<
         RANK,
+        RANK_SQUARED,
         SECRET_KEY_SIZE,
         CPA_PKE_SECRET_KEY_SIZE,
         CPA_PKE_PUBLIC_KEY_SIZE,

--- a/libcrux/libcrux-ml-kem/src/mlkem512.rs
+++ b/libcrux/libcrux-ml-kem/src/mlkem512.rs
@@ -425,8 +425,8 @@ macro_rules! instantiate {
 // Instantiations
 
 instantiate! {portable, ind_cca::instantiations::portable, vector::portable::PortableVector, "Portable ML-KEM 512"}
-#[cfg(feature = "simd256")]
-instantiate! {avx2, ind_cca::instantiations::avx2, vector::SIMD256Vector, "AVX2 Optimised ML-KEM 512"}
+// #[cfg(feature = "simd256")]
+// instantiate! {avx2, ind_cca::instantiations::avx2, vector::SIMD256Vector, "AVX2 Optimised ML-KEM 512"}
 #[cfg(feature = "simd128")]
 instantiate! {neon, ind_cca::instantiations::neon, vector::SIMD128Vector, "Neon Optimised ML-KEM 512"}
 

--- a/libcrux/libcrux-ml-kem/src/mlkem512.rs
+++ b/libcrux/libcrux-ml-kem/src/mlkem512.rs
@@ -2,6 +2,7 @@
 use super::{constants::*, ind_cca::*, types::*, *};
 
 const RANK: usize = 2;
+const RANK_SQUARED: usize = RANK * RANK;
 #[cfg(any(feature = "incremental", eurydice))]
 const RANKED_BYTES_PER_RING_ELEMENT: usize = RANK * BITS_PER_RING_ELEMENT / 8;
 const T_AS_NTT_ENCODED_SIZE: usize =
@@ -89,7 +90,8 @@ macro_rules! instantiate {
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem512KeyPair {
                     p::generate_keypair::<
-                        RANK,
+                RANK,
+                RANK_SQUARED,
                         CPA_PKE_SECRET_KEY_SIZE,
                         SECRET_KEY_SIZE,
                         CPA_PKE_PUBLIC_KEY_SIZE,
@@ -106,8 +108,9 @@ macro_rules! instantiate {
             pub fn kyber_generate_key_pair(
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem512KeyPair {
-                    p::kyber_generate_keypair::<
-                        RANK,
+                p::kyber_generate_keypair::<
+                                RANK,
+                RANK_SQUARED,
                         CPA_PKE_SECRET_KEY_SIZE,
                         SECRET_KEY_SIZE,
                         CPA_PKE_PUBLIC_KEY_SIZE,
@@ -128,7 +131,8 @@ macro_rules! instantiate {
 
 
                     p::encapsulate::<
-                        RANK,
+                RANK,
+                RANK_SQUARED,
                         CPA_PKE_CIPHERTEXT_SIZE,
                         CPA_PKE_PUBLIC_KEY_SIZE,
                         T_AS_NTT_ENCODED_SIZE,
@@ -187,6 +191,7 @@ macro_rules! instantiate {
             ) -> MlKemSharedSecret {
                     p::decapsulate::<
                         RANK,
+                        RANK_SQUARED,
                         SECRET_KEY_SIZE,
                         CPA_PKE_SECRET_KEY_SIZE,
                         CPA_PKE_PUBLIC_KEY_SIZE,
@@ -220,6 +225,7 @@ macro_rules! instantiate {
             ) -> MlKemSharedSecret {
                 p::kyber_decapsulate::<
                     RANK,
+                    RANK_SQUARED,
                     SECRET_KEY_SIZE,
                     CPA_PKE_SECRET_KEY_SIZE,
                     CPA_PKE_PUBLIC_KEY_SIZE,
@@ -245,10 +251,10 @@ macro_rules! instantiate {
                 use super::*;
 
                 /// An Unpacked ML-KEM 512 Public key
-                pub type MlKem512PublicKeyUnpacked = p::unpacked::MlKemPublicKeyUnpacked<RANK>;
+                pub type MlKem512PublicKeyUnpacked = p::unpacked::MlKemPublicKeyUnpacked<RANK, RANK_SQUARED>;
 
                 /// Am Unpacked ML-KEM 512 Key pair
-                pub type MlKem512KeyPairUnpacked = p::unpacked::MlKemKeyPairUnpacked<RANK>;
+                pub type MlKem512KeyPairUnpacked = p::unpacked::MlKemKeyPairUnpacked<RANK, RANK_SQUARED>;
 
                 /// Create a new, empty unpacked key.
                 pub fn init_key_pair() -> MlKem512KeyPairUnpacked {
@@ -301,7 +307,7 @@ macro_rules! instantiate {
 
                 /// Get an unpacked key from a private key.
                 pub fn key_pair_from_private_mut(private_key: &MlKem512PrivateKey, key_pair: &mut MlKem512KeyPairUnpacked) {
-                    p::unpacked::keypair_from_private_key::<RANK, SECRET_KEY_SIZE, CPA_PKE_SECRET_KEY_SIZE, CPA_PKE_PUBLIC_KEY_SIZE, T_AS_NTT_ENCODED_SIZE>(private_key, key_pair);
+                    p::unpacked::keypair_from_private_key::<RANK, RANK_SQUARED, SECRET_KEY_SIZE, CPA_PKE_SECRET_KEY_SIZE, CPA_PKE_PUBLIC_KEY_SIZE, T_AS_NTT_ENCODED_SIZE>(private_key, key_pair);
                 }
 
                 /// Get the unpacked public key.
@@ -310,7 +316,8 @@ macro_rules! instantiate {
                     unpacked_public_key: &mut MlKem512PublicKeyUnpacked,
                 ) {
                         p::unpacked::unpack_public_key::<
-                            RANK,
+                    RANK,
+                    RANK_SQUARED,
                             T_AS_NTT_ENCODED_SIZE,
                             CPA_PKE_PUBLIC_KEY_SIZE,
                         >(public_key, unpacked_public_key)
@@ -330,14 +337,15 @@ macro_rules! instantiate {
                     randomness: [u8; KEY_GENERATION_SEED_SIZE],
                     key_pair: &mut MlKem512KeyPairUnpacked,
                 ) {
-                        p::unpacked::generate_keypair::<
-                            RANK,
-                            CPA_PKE_SECRET_KEY_SIZE,
-                            SECRET_KEY_SIZE,
-                            CPA_PKE_PUBLIC_KEY_SIZE,
-                            ETA1,
-                            ETA1_RANDOMNESS_SIZE,
-                            PRF_OUTPUT_SIZE1,
+                    p::unpacked::generate_keypair::<
+                                            RANK,
+RANK_SQUARED,
+                        CPA_PKE_SECRET_KEY_SIZE,
+                        SECRET_KEY_SIZE,
+                        CPA_PKE_PUBLIC_KEY_SIZE,
+                        ETA1,
+                        ETA1_RANDOMNESS_SIZE,
+                        PRF_OUTPUT_SIZE1,
                         >(randomness, key_pair);
 
                 }
@@ -367,7 +375,8 @@ macro_rules! instantiate {
 
 
                         p::unpacked::encapsulate::<
-                            RANK,
+                    RANK,
+                    RANK_SQUARED,
                             CPA_PKE_CIPHERTEXT_SIZE,
                             CPA_PKE_PUBLIC_KEY_SIZE,
                             T_AS_NTT_ENCODED_SIZE,
@@ -397,6 +406,7 @@ macro_rules! instantiate {
                 ) -> MlKemSharedSecret {
                         p::unpacked::decapsulate::<
                             RANK,
+                            RANK_SQUARED,
                             SECRET_KEY_SIZE,
                             CPA_PKE_SECRET_KEY_SIZE,
                             CPA_PKE_PUBLIC_KEY_SIZE,
@@ -467,12 +477,13 @@ pub fn validate_private_key(
 pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> MlKem512KeyPair {
     multiplexing::generate_keypair::<
         RANK,
+        RANK_SQUARED,
         CPA_PKE_SECRET_KEY_SIZE,
         SECRET_KEY_SIZE,
         CPA_PKE_PUBLIC_KEY_SIZE,
         ETA1,
         ETA1_RANDOMNESS_SIZE,
-        PRF_OUTPUT_SIZE1
+        PRF_OUTPUT_SIZE1,
     >(randomness)
 }
 
@@ -494,6 +505,7 @@ pub fn encapsulate(
 ) -> (MlKem512Ciphertext, MlKemSharedSecret) {
     multiplexing::encapsulate::<
         RANK,
+        RANK_SQUARED,
         CPA_PKE_CIPHERTEXT_SIZE,
         CPA_PKE_PUBLIC_KEY_SIZE,
         T_AS_NTT_ENCODED_SIZE,
@@ -507,7 +519,7 @@ pub fn encapsulate(
         ETA2,
         ETA2_RANDOMNESS_SIZE,
         PRF_OUTPUT_SIZE1,
-        PRF_OUTPUT_SIZE2
+        PRF_OUTPUT_SIZE2,
     >(public_key, randomness)
 }
 
@@ -527,6 +539,7 @@ pub fn decapsulate(
 ) -> MlKemSharedSecret {
     multiplexing::decapsulate::<
         RANK,
+        RANK_SQUARED,
         SECRET_KEY_SIZE,
         CPA_PKE_SECRET_KEY_SIZE,
         CPA_PKE_PUBLIC_KEY_SIZE,
@@ -605,12 +618,13 @@ pub(crate) mod kyber {
     pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> MlKem512KeyPair {
         multiplexing::kyber_generate_keypair::<
             RANK,
+            CPA_PKE_RANK_SQUARED,
             CPA_PKE_SECRET_KEY_SIZE,
             SECRET_KEY_SIZE,
             CPA_PKE_PUBLIC_KEY_SIZE,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
-            PRF_OUTPUT_SIZE1
+            PRF_OUTPUT_SIZE1,
         >(randomness)
     }
 
@@ -638,7 +652,7 @@ pub(crate) mod kyber {
             ETA2,
             ETA2_RANDOMNESS_SIZE,
             PRF_OUTPUT_SIZE1,
-            PRF_OUTPUT_SIZE2
+            PRF_OUTPUT_SIZE2,
         >(public_key, randomness)
     }
 
@@ -653,6 +667,7 @@ pub(crate) mod kyber {
     ) -> MlKemSharedSecret {
         multiplexing::kyber_decapsulate::<
             RANK,
+            RANK_SQUARED,
             SECRET_KEY_SIZE,
             CPA_PKE_SECRET_KEY_SIZE,
             CPA_PKE_PUBLIC_KEY_SIZE,

--- a/libcrux/libcrux-ml-kem/src/mlkem768.rs
+++ b/libcrux/libcrux-ml-kem/src/mlkem768.rs
@@ -421,8 +421,8 @@ macro_rules! instantiate {
 // Instantiations
 
 instantiate! {portable, ind_cca::instantiations::portable, "Portable ML-KEM 768"}
-#[cfg(feature = "simd256")]
-instantiate! {avx2, ind_cca::instantiations::avx2, "AVX2 Optimised ML-KEM 768"}
+// #[cfg(feature = "simd256")]
+// instantiate! {avx2, ind_cca::instantiations::avx2, "AVX2 Optimised ML-KEM 768"}
 #[cfg(feature = "simd128")]
 instantiate! {neon, ind_cca::instantiations::neon, "Neon Optimised ML-KEM 768"}
 

--- a/libcrux/libcrux-ml-kem/src/mlkem768.rs
+++ b/libcrux/libcrux-ml-kem/src/mlkem768.rs
@@ -3,6 +3,7 @@
 use super::{constants::*, ind_cca::*, types::*, *};
 
 const RANK: usize = 3;
+const RANK_SQUARED: usize = RANK * RANK;
 #[cfg(any(feature = "incremental", eurydice))]
 const RANKED_BYTES_PER_RING_ELEMENT: usize = RANK * BITS_PER_RING_ELEMENT / 8;
 const T_AS_NTT_ENCODED_SIZE: usize =
@@ -95,6 +96,7 @@ macro_rules! instantiate {
             ) -> MlKem768KeyPair {
                 p::generate_keypair::<
                     RANK,
+RANK_SQUARED,
                     CPA_PKE_SECRET_KEY_SIZE,
                     SECRET_KEY_SIZE,
                     CPA_PKE_PUBLIC_KEY_SIZE,
@@ -112,6 +114,7 @@ macro_rules! instantiate {
             ) -> MlKem768KeyPair {
                 p::kyber_generate_keypair::<
                     RANK,
+RANK_SQUARED,
                     CPA_PKE_SECRET_KEY_SIZE,
                     SECRET_KEY_SIZE,
                     CPA_PKE_PUBLIC_KEY_SIZE,
@@ -132,6 +135,7 @@ macro_rules! instantiate {
             ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
                 p::encapsulate::<
                     RANK,
+RANK_SQUARED,
                     CPA_PKE_CIPHERTEXT_SIZE,
                     CPA_PKE_PUBLIC_KEY_SIZE,
                     T_AS_NTT_ENCODED_SIZE,
@@ -162,6 +166,7 @@ macro_rules! instantiate {
             ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
                 p::kyber_encapsulate::<
                     RANK,
+RANK_SQUARED,
                     CPA_PKE_CIPHERTEXT_SIZE,
                     CPA_PKE_PUBLIC_KEY_SIZE,
                     T_AS_NTT_ENCODED_SIZE,
@@ -189,6 +194,7 @@ macro_rules! instantiate {
             ) -> MlKemSharedSecret {
                 p::decapsulate::<
                     RANK,
+RANK_SQUARED,
                     SECRET_KEY_SIZE,
                     CPA_PKE_SECRET_KEY_SIZE,
                     CPA_PKE_PUBLIC_KEY_SIZE,
@@ -221,6 +227,7 @@ macro_rules! instantiate {
             ) -> MlKemSharedSecret {
                 p::kyber_decapsulate::<
                     RANK,
+RANK_SQUARED,
                     SECRET_KEY_SIZE,
                     CPA_PKE_SECRET_KEY_SIZE,
                     CPA_PKE_PUBLIC_KEY_SIZE,
@@ -246,10 +253,10 @@ macro_rules! instantiate {
                 use super::*;
 
                 /// An Unpacked ML-KEM 768 Public key
-                pub type MlKem768PublicKeyUnpacked = p::unpacked::MlKemPublicKeyUnpacked<RANK>;
+                pub type MlKem768PublicKeyUnpacked = p::unpacked::MlKemPublicKeyUnpacked<RANK, RANK_SQUARED>;
 
                 /// Am Unpacked ML-KEM 768 Key pair
-                pub type MlKem768KeyPairUnpacked = p::unpacked::MlKemKeyPairUnpacked<RANK>;
+                pub type MlKem768KeyPairUnpacked = p::unpacked::MlKemKeyPairUnpacked<RANK, RANK_SQUARED>;
 
                 /// Create a new, empty unpacked key.
                 pub fn init_key_pair() -> MlKem768KeyPairUnpacked {
@@ -297,7 +304,7 @@ macro_rules! instantiate {
 
                 /// Get an unpacked key from a private key.
                 pub fn key_pair_from_private_mut(private_key: &MlKem768PrivateKey, key_pair: &mut MlKem768KeyPairUnpacked) {
-                    p::unpacked::keypair_from_private_key::<RANK, SECRET_KEY_SIZE, CPA_PKE_SECRET_KEY_SIZE, CPA_PKE_PUBLIC_KEY_SIZE, T_AS_NTT_ENCODED_SIZE>(private_key, key_pair);
+                    p::unpacked::keypair_from_private_key::<RANK, RANK_SQUARED, SECRET_KEY_SIZE, CPA_PKE_SECRET_KEY_SIZE, CPA_PKE_PUBLIC_KEY_SIZE, T_AS_NTT_ENCODED_SIZE>(private_key, key_pair);
                 }
 
                 /// Get the unpacked public key.
@@ -311,7 +318,8 @@ macro_rules! instantiate {
                     unpacked_public_key: &mut MlKem768PublicKeyUnpacked
                 ) {
                     p::unpacked::unpack_public_key::<
-                        RANK,
+                    RANK,
+                    RANK_SQUARED,
                         T_AS_NTT_ENCODED_SIZE,
                         CPA_PKE_PUBLIC_KEY_SIZE,
                     >(public_key, unpacked_public_key)
@@ -333,6 +341,7 @@ macro_rules! instantiate {
                 ) {
                     p::unpacked::generate_keypair::<
                         RANK,
+RANK_SQUARED,
                         CPA_PKE_SECRET_KEY_SIZE,
                         SECRET_KEY_SIZE,
                         CPA_PKE_PUBLIC_KEY_SIZE,
@@ -366,6 +375,7 @@ macro_rules! instantiate {
                 ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
                     p::unpacked::encapsulate::<
                         RANK,
+RANK_SQUARED,
                         CPA_PKE_CIPHERTEXT_SIZE,
                         CPA_PKE_PUBLIC_KEY_SIZE,
                         T_AS_NTT_ENCODED_SIZE,
@@ -394,6 +404,7 @@ macro_rules! instantiate {
                 ) -> MlKemSharedSecret {
                     p::unpacked::decapsulate::<
                         RANK,
+RANK_SQUARED,
                         SECRET_KEY_SIZE,
                         CPA_PKE_SECRET_KEY_SIZE,
                         CPA_PKE_PUBLIC_KEY_SIZE,
@@ -463,12 +474,13 @@ pub fn validate_private_key(
 pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> MlKem768KeyPair {
     multiplexing::generate_keypair::<
         RANK,
+        RANK_SQUARED,
         CPA_PKE_SECRET_KEY_SIZE,
         SECRET_KEY_SIZE,
         CPA_PKE_PUBLIC_KEY_SIZE,
         ETA1,
         ETA1_RANDOMNESS_SIZE,
-        PRF_OUTPUT_SIZE1
+        PRF_OUTPUT_SIZE1,
     >(randomness)
 }
 
@@ -490,6 +502,7 @@ pub fn encapsulate(
 ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
     multiplexing::encapsulate::<
         RANK,
+        RANK_SQUARED,
         CPA_PKE_CIPHERTEXT_SIZE,
         CPA_PKE_PUBLIC_KEY_SIZE,
         T_AS_NTT_ENCODED_SIZE,
@@ -502,8 +515,8 @@ pub fn encapsulate(
         ETA1_RANDOMNESS_SIZE,
         ETA2,
         ETA2_RANDOMNESS_SIZE,
-            PRF_OUTPUT_SIZE1,
-            PRF_OUTPUT_SIZE2,
+        PRF_OUTPUT_SIZE1,
+        PRF_OUTPUT_SIZE2,
     >(public_key, randomness)
 }
 
@@ -523,6 +536,7 @@ pub fn decapsulate(
 ) -> MlKemSharedSecret {
     multiplexing::decapsulate::<
         RANK,
+        RANK_SQUARED,
         SECRET_KEY_SIZE,
         CPA_PKE_SECRET_KEY_SIZE,
         CPA_PKE_PUBLIC_KEY_SIZE,
@@ -537,8 +551,8 @@ pub fn decapsulate(
         ETA1_RANDOMNESS_SIZE,
         ETA2,
         ETA2_RANDOMNESS_SIZE,
-            PRF_OUTPUT_SIZE1,
-            PRF_OUTPUT_SIZE2,
+        PRF_OUTPUT_SIZE1,
+        PRF_OUTPUT_SIZE2,
         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
     >(private_key, ciphertext)
 }
@@ -601,12 +615,13 @@ pub(crate) mod kyber {
     pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> MlKem768KeyPair {
         multiplexing::kyber_generate_keypair::<
             RANK,
+            RANK_SQUARED,
             CPA_PKE_SECRET_KEY_SIZE,
             SECRET_KEY_SIZE,
             CPA_PKE_PUBLIC_KEY_SIZE,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
-            PRF_OUTPUT_SIZE1
+            PRF_OUTPUT_SIZE1,
         >(randomness)
     }
 
@@ -621,6 +636,7 @@ pub(crate) mod kyber {
     ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
         multiplexing::kyber_encapsulate::<
             RANK,
+            RANK_SQUARED,
             CPA_PKE_CIPHERTEXT_SIZE,
             CPA_PKE_PUBLIC_KEY_SIZE,
             T_AS_NTT_ENCODED_SIZE,
@@ -648,6 +664,7 @@ pub(crate) mod kyber {
     ) -> MlKemSharedSecret {
         multiplexing::kyber_decapsulate::<
             RANK,
+            RANK_SQUARED,
             SECRET_KEY_SIZE,
             CPA_PKE_SECRET_KEY_SIZE,
             CPA_PKE_PUBLIC_KEY_SIZE,

--- a/libcrux/libcrux-ml-kem/src/mlkem768.rs
+++ b/libcrux/libcrux-ml-kem/src/mlkem768.rs
@@ -2,47 +2,48 @@
 
 use super::{constants::*, ind_cca::*, types::*, *};
 
-// Kyber 768 parameters
-const RANK_768: usize = 3;
-const RANKED_BYTES_PER_RING_ELEMENT_768: usize = RANK_768 * BITS_PER_RING_ELEMENT / 8;
-const T_AS_NTT_ENCODED_SIZE_768: usize =
-    (RANK_768 * COEFFICIENTS_IN_RING_ELEMENT * BITS_PER_COEFFICIENT) / 8;
-const VECTOR_U_COMPRESSION_FACTOR_768: usize = 10;
+const RANK: usize = 3;
+#[cfg(any(feature = "incremental", eurydice))]
+const RANKED_BYTES_PER_RING_ELEMENT: usize = RANK * BITS_PER_RING_ELEMENT / 8;
+const T_AS_NTT_ENCODED_SIZE: usize =
+    (RANK * COEFFICIENTS_IN_RING_ELEMENT * BITS_PER_COEFFICIENT) / 8;
+const VECTOR_U_COMPRESSION_FACTOR: usize = 10;
 // [hax]: hacspec/hacspec-v2#27 stealing error
-// block_len::<VECTOR_U_COMPRESSION_FACTOR_768>()
-const C1_BLOCK_SIZE_768: usize =
-    (COEFFICIENTS_IN_RING_ELEMENT * VECTOR_U_COMPRESSION_FACTOR_768) / 8;
+// block_len::<VECTOR_U_COMPRESSION_FACTOR>()
+const C1_BLOCK_SIZE: usize = (COEFFICIENTS_IN_RING_ELEMENT * VECTOR_U_COMPRESSION_FACTOR) / 8;
 // [hax]: hacspec/hacspec-v2#27 stealing error
-//  serialized_len::<RANK_768, C1_BLOCK_SIZE_768>();
-const C1_SIZE_768: usize = C1_BLOCK_SIZE_768 * RANK_768;
-const VECTOR_V_COMPRESSION_FACTOR_768: usize = 4;
+//  serialized_len::<RANK, C1_BLOCK_SIZE>();
+const C1_SIZE: usize = C1_BLOCK_SIZE * RANK;
+const VECTOR_V_COMPRESSION_FACTOR: usize = 4;
 // [hax]: hacspec/hacspec-v2#27 stealing error
-//  block_len::<VECTOR_V_COMPRESSION_FACTOR_768>()
-const C2_SIZE_768: usize = (COEFFICIENTS_IN_RING_ELEMENT * VECTOR_V_COMPRESSION_FACTOR_768) / 8;
-const CPA_PKE_SECRET_KEY_SIZE_768: usize =
-    (RANK_768 * COEFFICIENTS_IN_RING_ELEMENT * BITS_PER_COEFFICIENT) / 8;
-pub(crate) const CPA_PKE_PUBLIC_KEY_SIZE_768: usize = T_AS_NTT_ENCODED_SIZE_768 + 32;
+//  block_len::<VECTOR_V_COMPRESSION_FACTOR>()
+const C2_SIZE: usize = (COEFFICIENTS_IN_RING_ELEMENT * VECTOR_V_COMPRESSION_FACTOR) / 8;
+const CPA_PKE_SECRET_KEY_SIZE: usize =
+    (RANK * COEFFICIENTS_IN_RING_ELEMENT * BITS_PER_COEFFICIENT) / 8;
+pub(crate) const CPA_PKE_PUBLIC_KEY_SIZE: usize = T_AS_NTT_ENCODED_SIZE + 32;
 // These two are used in the hybrid kem. This could probably be improved.
-const CPA_PKE_CIPHERTEXT_SIZE_768: usize = C1_SIZE_768 + C2_SIZE_768;
-const SECRET_KEY_SIZE_768: usize =
-    CPA_PKE_SECRET_KEY_SIZE_768 + CPA_PKE_PUBLIC_KEY_SIZE_768 + H_DIGEST_SIZE + SHARED_SECRET_SIZE;
+const CPA_PKE_CIPHERTEXT_SIZE: usize = C1_SIZE + C2_SIZE;
+const SECRET_KEY_SIZE: usize =
+    CPA_PKE_SECRET_KEY_SIZE + CPA_PKE_PUBLIC_KEY_SIZE + H_DIGEST_SIZE + SHARED_SECRET_SIZE;
 
 const ETA1: usize = 2;
 const ETA1_RANDOMNESS_SIZE: usize = ETA1 * 64;
 const ETA2: usize = 2;
 const ETA2_RANDOMNESS_SIZE: usize = ETA2 * 64;
 
-const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize = SHARED_SECRET_SIZE + CPA_PKE_CIPHERTEXT_SIZE_768;
+const PRF_OUTPUT_SIZE1: usize = ETA1_RANDOMNESS_SIZE * RANK;
+const PRF_OUTPUT_SIZE2: usize = ETA2_RANDOMNESS_SIZE * RANK;
 
-// Kyber 768 types
+const IMPLICIT_REJECTION_HASH_INPUT_SIZE: usize = SHARED_SECRET_SIZE + CPA_PKE_CIPHERTEXT_SIZE;
+
 /// An ML-KEM 768 Ciphertext
-pub type MlKem768Ciphertext = MlKemCiphertext<CPA_PKE_CIPHERTEXT_SIZE_768>;
+pub type MlKem768Ciphertext = MlKemCiphertext<CPA_PKE_CIPHERTEXT_SIZE>;
 /// An ML-KEM 768 Private key
-pub type MlKem768PrivateKey = MlKemPrivateKey<SECRET_KEY_SIZE_768>;
+pub type MlKem768PrivateKey = MlKemPrivateKey<SECRET_KEY_SIZE>;
 /// An ML-KEM 768 Public key
-pub type MlKem768PublicKey = MlKemPublicKey<CPA_PKE_PUBLIC_KEY_SIZE_768>;
+pub type MlKem768PublicKey = MlKemPublicKey<CPA_PKE_PUBLIC_KEY_SIZE>;
 /// An ML-KEM 768 Key pair
-pub type MlKem768KeyPair = MlKemKeyPair<SECRET_KEY_SIZE_768, CPA_PKE_PUBLIC_KEY_SIZE_768>;
+pub type MlKem768KeyPair = MlKemKeyPair<SECRET_KEY_SIZE, CPA_PKE_PUBLIC_KEY_SIZE>;
 
 // Instantiate the different functions.
 macro_rules! instantiate {
@@ -57,9 +58,8 @@ macro_rules! instantiate {
             /// Returns `true` if valid, and `false` otherwise.
             pub fn validate_public_key(public_key: &MlKem768PublicKey) -> bool {
                 p::validate_public_key::<
-                    RANK_768,
-                    RANKED_BYTES_PER_RING_ELEMENT_768,
-                    CPA_PKE_PUBLIC_KEY_SIZE_768,
+                    RANK,
+                    CPA_PKE_PUBLIC_KEY_SIZE,
                 >(&public_key.value)
             }
 
@@ -71,9 +71,9 @@ macro_rules! instantiate {
                 ciphertext: &MlKem768Ciphertext,
             ) -> bool {
                 p::validate_private_key::<
-                    RANK_768,
-                    SECRET_KEY_SIZE_768,
-                    CPA_PKE_CIPHERTEXT_SIZE_768,
+                    RANK,
+                    SECRET_KEY_SIZE,
+                    CPA_PKE_CIPHERTEXT_SIZE,
                 >(private_key, ciphertext)
             }
 
@@ -84,8 +84,8 @@ macro_rules! instantiate {
                 private_key: &MlKem768PrivateKey,
             ) -> bool {
                 p::validate_private_key_only::<
-                    RANK_768,
-                    SECRET_KEY_SIZE_768,
+                    RANK,
+                    SECRET_KEY_SIZE,
                 >(private_key)
             }
 
@@ -94,13 +94,13 @@ macro_rules! instantiate {
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem768KeyPair {
                 p::generate_keypair::<
-                    RANK_768,
-                    CPA_PKE_SECRET_KEY_SIZE_768,
-                    SECRET_KEY_SIZE_768,
-                    CPA_PKE_PUBLIC_KEY_SIZE_768,
-                    RANKED_BYTES_PER_RING_ELEMENT_768,
+                    RANK,
+                    CPA_PKE_SECRET_KEY_SIZE,
+                    SECRET_KEY_SIZE,
+                    CPA_PKE_PUBLIC_KEY_SIZE,
                     ETA1,
                     ETA1_RANDOMNESS_SIZE,
+                    PRF_OUTPUT_SIZE1,
                 >(randomness)
             }
 
@@ -111,13 +111,13 @@ macro_rules! instantiate {
                 randomness: [u8; KEY_GENERATION_SEED_SIZE],
             ) -> MlKem768KeyPair {
                 p::kyber_generate_keypair::<
-                    RANK_768,
-                    CPA_PKE_SECRET_KEY_SIZE_768,
-                    SECRET_KEY_SIZE_768,
-                    CPA_PKE_PUBLIC_KEY_SIZE_768,
-                    RANKED_BYTES_PER_RING_ELEMENT_768,
+                    RANK,
+                    CPA_PKE_SECRET_KEY_SIZE,
+                    SECRET_KEY_SIZE,
+                    CPA_PKE_PUBLIC_KEY_SIZE,
                     ETA1,
                     ETA1_RANDOMNESS_SIZE,
+                    PRF_OUTPUT_SIZE1,
                 >(randomness)
             }
 
@@ -131,19 +131,21 @@ macro_rules! instantiate {
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
                 p::encapsulate::<
-                    RANK_768,
-                    CPA_PKE_CIPHERTEXT_SIZE_768,
-                    CPA_PKE_PUBLIC_KEY_SIZE_768,
-                    T_AS_NTT_ENCODED_SIZE_768,
-                    C1_SIZE_768,
-                    C2_SIZE_768,
-                    VECTOR_U_COMPRESSION_FACTOR_768,
-                    VECTOR_V_COMPRESSION_FACTOR_768,
-                    C1_BLOCK_SIZE_768,
+                    RANK,
+                    CPA_PKE_CIPHERTEXT_SIZE,
+                    CPA_PKE_PUBLIC_KEY_SIZE,
+                    T_AS_NTT_ENCODED_SIZE,
+                    C1_SIZE,
+                    C2_SIZE,
+                    VECTOR_U_COMPRESSION_FACTOR,
+                    VECTOR_V_COMPRESSION_FACTOR,
+                    C1_BLOCK_SIZE,
                     ETA1,
                     ETA1_RANDOMNESS_SIZE,
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
+                    PRF_OUTPUT_SIZE1,
+                    PRF_OUTPUT_SIZE2,
                 >(public_key, randomness)
             }
 
@@ -159,19 +161,21 @@ macro_rules! instantiate {
                 randomness: [u8; SHARED_SECRET_SIZE],
             ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
                 p::kyber_encapsulate::<
-                    RANK_768,
-                    CPA_PKE_CIPHERTEXT_SIZE_768,
-                    CPA_PKE_PUBLIC_KEY_SIZE_768,
-                    T_AS_NTT_ENCODED_SIZE_768,
-                    C1_SIZE_768,
-                    C2_SIZE_768,
-                    VECTOR_U_COMPRESSION_FACTOR_768,
-                    VECTOR_V_COMPRESSION_FACTOR_768,
-                    C1_BLOCK_SIZE_768,
+                    RANK,
+                    CPA_PKE_CIPHERTEXT_SIZE,
+                    CPA_PKE_PUBLIC_KEY_SIZE,
+                    T_AS_NTT_ENCODED_SIZE,
+                    C1_SIZE,
+                    C2_SIZE,
+                    VECTOR_U_COMPRESSION_FACTOR,
+                    VECTOR_V_COMPRESSION_FACTOR,
+                    C1_BLOCK_SIZE,
                     ETA1,
                     ETA1_RANDOMNESS_SIZE,
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
+                    PRF_OUTPUT_SIZE1,
+                    PRF_OUTPUT_SIZE2,
                 >(public_key, randomness)
             }
 
@@ -184,21 +188,23 @@ macro_rules! instantiate {
                 ciphertext: &MlKem768Ciphertext,
             ) -> MlKemSharedSecret {
                 p::decapsulate::<
-                    RANK_768,
-                    SECRET_KEY_SIZE_768,
-                    CPA_PKE_SECRET_KEY_SIZE_768,
-                    CPA_PKE_PUBLIC_KEY_SIZE_768,
-                    CPA_PKE_CIPHERTEXT_SIZE_768,
-                    T_AS_NTT_ENCODED_SIZE_768,
-                    C1_SIZE_768,
-                    C2_SIZE_768,
-                    VECTOR_U_COMPRESSION_FACTOR_768,
-                    VECTOR_V_COMPRESSION_FACTOR_768,
-                    C1_BLOCK_SIZE_768,
+                    RANK,
+                    SECRET_KEY_SIZE,
+                    CPA_PKE_SECRET_KEY_SIZE,
+                    CPA_PKE_PUBLIC_KEY_SIZE,
+                    CPA_PKE_CIPHERTEXT_SIZE,
+                    T_AS_NTT_ENCODED_SIZE,
+                    C1_SIZE,
+                    C2_SIZE,
+                    VECTOR_U_COMPRESSION_FACTOR,
+                    VECTOR_V_COMPRESSION_FACTOR,
+                    C1_BLOCK_SIZE,
                     ETA1,
                     ETA1_RANDOMNESS_SIZE,
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
+                    PRF_OUTPUT_SIZE1,
+                    PRF_OUTPUT_SIZE2,
                     IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                 >(private_key, ciphertext)
             }
@@ -214,21 +220,23 @@ macro_rules! instantiate {
                 ciphertext: &MlKem768Ciphertext,
             ) -> MlKemSharedSecret {
                 p::kyber_decapsulate::<
-                    RANK_768,
-                    SECRET_KEY_SIZE_768,
-                    CPA_PKE_SECRET_KEY_SIZE_768,
-                    CPA_PKE_PUBLIC_KEY_SIZE_768,
-                    CPA_PKE_CIPHERTEXT_SIZE_768,
-                    T_AS_NTT_ENCODED_SIZE_768,
-                    C1_SIZE_768,
-                    C2_SIZE_768,
-                    VECTOR_U_COMPRESSION_FACTOR_768,
-                    VECTOR_V_COMPRESSION_FACTOR_768,
-                    C1_BLOCK_SIZE_768,
+                    RANK,
+                    SECRET_KEY_SIZE,
+                    CPA_PKE_SECRET_KEY_SIZE,
+                    CPA_PKE_PUBLIC_KEY_SIZE,
+                    CPA_PKE_CIPHERTEXT_SIZE,
+                    T_AS_NTT_ENCODED_SIZE,
+                    C1_SIZE,
+                    C2_SIZE,
+                    VECTOR_U_COMPRESSION_FACTOR,
+                    VECTOR_V_COMPRESSION_FACTOR,
+                    C1_BLOCK_SIZE,
                     ETA1,
                     ETA1_RANDOMNESS_SIZE,
                     ETA2,
                     ETA2_RANDOMNESS_SIZE,
+                    PRF_OUTPUT_SIZE1,
+                    PRF_OUTPUT_SIZE2,
                     IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                 >(private_key, ciphertext)
             }
@@ -238,10 +246,10 @@ macro_rules! instantiate {
                 use super::*;
 
                 /// An Unpacked ML-KEM 768 Public key
-                pub type MlKem768PublicKeyUnpacked = p::unpacked::MlKemPublicKeyUnpacked<RANK_768>;
+                pub type MlKem768PublicKeyUnpacked = p::unpacked::MlKemPublicKeyUnpacked<RANK>;
 
                 /// Am Unpacked ML-KEM 768 Key pair
-                pub type MlKem768KeyPairUnpacked = p::unpacked::MlKemKeyPairUnpacked<RANK_768>;
+                pub type MlKem768KeyPairUnpacked = p::unpacked::MlKemKeyPairUnpacked<RANK>;
 
                 /// Create a new, empty unpacked key.
                 pub fn init_key_pair() -> MlKem768KeyPairUnpacked {
@@ -256,40 +264,40 @@ macro_rules! instantiate {
                 /// Get the serialized public key.
                 #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 3 ==>
                     Libcrux_ml_kem.Serialize.coefficients_field_modulus_range (Seq.index 
-                        ${public_key}.f_ind_cpa_public_key.f_t_as_ntt i)"#))]
+                        ${public_key.ind_cpa_public_key.t_as_ntt} i)"#))]
                 pub fn serialized_public_key(public_key: &MlKem768PublicKeyUnpacked, serialized : &mut MlKem768PublicKey) {
-                    public_key.serialized_mut::<RANKED_BYTES_PER_RING_ELEMENT_768, CPA_PKE_PUBLIC_KEY_SIZE_768>(serialized);
+                    public_key.serialized_mut::<CPA_PKE_PUBLIC_KEY_SIZE>(serialized);
                 }
 
                 /// Get the serialized private key.
                 pub fn key_pair_serialized_private_key(key_pair: &MlKem768KeyPairUnpacked) -> MlKem768PrivateKey {
-                    key_pair.serialized_private_key::<CPA_PKE_SECRET_KEY_SIZE_768, SECRET_KEY_SIZE_768, CPA_PKE_PUBLIC_KEY_SIZE_768, RANKED_BYTES_PER_RING_ELEMENT_768>()
+                    key_pair.serialized_private_key::<CPA_PKE_SECRET_KEY_SIZE, SECRET_KEY_SIZE, CPA_PKE_PUBLIC_KEY_SIZE>()
                 }
 
                 /// Get the serialized private key.
                 pub fn key_pair_serialized_private_key_mut(key_pair: &MlKem768KeyPairUnpacked, serialized: &mut MlKem768PrivateKey) {
-                    key_pair.serialized_private_key_mut::<CPA_PKE_SECRET_KEY_SIZE_768, SECRET_KEY_SIZE_768, CPA_PKE_PUBLIC_KEY_SIZE_768, RANKED_BYTES_PER_RING_ELEMENT_768>(serialized);
+                    key_pair.serialized_private_key_mut::<CPA_PKE_SECRET_KEY_SIZE, SECRET_KEY_SIZE, CPA_PKE_PUBLIC_KEY_SIZE>(serialized);
                 }
 
                 /// Get the serialized public key.
                 #[hax_lib::requires(fstar!(r#"(forall (i:nat). i < 3 ==>
                         Libcrux_ml_kem.Serialize.coefficients_field_modulus_range (Seq.index 
-                            ${key_pair}.f_public_key.f_ind_cpa_public_key.f_t_as_ntt i))"#))]
+                            ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i))"#))]
                 pub fn key_pair_serialized_public_key_mut(key_pair: &MlKem768KeyPairUnpacked, serialized: &mut MlKem768PublicKey) {
-                    key_pair.serialized_public_key_mut::<RANKED_BYTES_PER_RING_ELEMENT_768, CPA_PKE_PUBLIC_KEY_SIZE_768>(serialized);
+                    key_pair.serialized_public_key_mut::<CPA_PKE_PUBLIC_KEY_SIZE>(serialized);
                 }
 
                 /// Get the serialized public key.
                 #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 3 ==>
                     Libcrux_ml_kem.Serialize.coefficients_field_modulus_range (Seq.index 
-                        ${key_pair}.f_public_key.f_ind_cpa_public_key.f_t_as_ntt i)"#))]
+                        ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i)"#))]
                 pub fn key_pair_serialized_public_key(key_pair: &MlKem768KeyPairUnpacked) ->MlKem768PublicKey {
-                    key_pair.serialized_public_key::<RANKED_BYTES_PER_RING_ELEMENT_768, CPA_PKE_PUBLIC_KEY_SIZE_768>()
+                    key_pair.serialized_public_key::<CPA_PKE_PUBLIC_KEY_SIZE>()
                 }
 
                 /// Get an unpacked key from a private key.
                 pub fn key_pair_from_private_mut(private_key: &MlKem768PrivateKey, key_pair: &mut MlKem768KeyPairUnpacked) {
-                    p::unpacked::keypair_from_private_key::<RANK_768, SECRET_KEY_SIZE_768, CPA_PKE_SECRET_KEY_SIZE_768, CPA_PKE_PUBLIC_KEY_SIZE_768, RANKED_BYTES_PER_RING_ELEMENT_768, T_AS_NTT_ENCODED_SIZE_768>(private_key, key_pair);
+                    p::unpacked::keypair_from_private_key::<RANK, SECRET_KEY_SIZE, CPA_PKE_SECRET_KEY_SIZE, CPA_PKE_PUBLIC_KEY_SIZE, T_AS_NTT_ENCODED_SIZE>(private_key, key_pair);
                 }
 
                 /// Get the unpacked public key.
@@ -303,10 +311,9 @@ macro_rules! instantiate {
                     unpacked_public_key: &mut MlKem768PublicKeyUnpacked
                 ) {
                     p::unpacked::unpack_public_key::<
-                        RANK_768,
-                        T_AS_NTT_ENCODED_SIZE_768,
-                        RANKED_BYTES_PER_RING_ELEMENT_768,
-                        CPA_PKE_PUBLIC_KEY_SIZE_768,
+                        RANK,
+                        T_AS_NTT_ENCODED_SIZE,
+                        CPA_PKE_PUBLIC_KEY_SIZE,
                     >(public_key, unpacked_public_key)
                 }
 
@@ -325,13 +332,13 @@ macro_rules! instantiate {
                     key_pair: &mut MlKem768KeyPairUnpacked,
                 ) {
                     p::unpacked::generate_keypair::<
-                        RANK_768,
-                        CPA_PKE_SECRET_KEY_SIZE_768,
-                        SECRET_KEY_SIZE_768,
-                        CPA_PKE_PUBLIC_KEY_SIZE_768,
-                        RANKED_BYTES_PER_RING_ELEMENT_768,
+                        RANK,
+                        CPA_PKE_SECRET_KEY_SIZE,
+                        SECRET_KEY_SIZE,
+                        CPA_PKE_PUBLIC_KEY_SIZE,
                         ETA1,
                         ETA1_RANDOMNESS_SIZE,
+                        PRF_OUTPUT_SIZE1,
                     >(randomness, key_pair);
                 }
 
@@ -358,19 +365,21 @@ macro_rules! instantiate {
                     randomness: [u8; SHARED_SECRET_SIZE],
                 ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
                     p::unpacked::encapsulate::<
-                        RANK_768,
-                        CPA_PKE_CIPHERTEXT_SIZE_768,
-                        CPA_PKE_PUBLIC_KEY_SIZE_768,
-                        T_AS_NTT_ENCODED_SIZE_768,
-                        C1_SIZE_768,
-                        C2_SIZE_768,
-                        VECTOR_U_COMPRESSION_FACTOR_768,
-                        VECTOR_V_COMPRESSION_FACTOR_768,
-                        C1_BLOCK_SIZE_768,
+                        RANK,
+                        CPA_PKE_CIPHERTEXT_SIZE,
+                        CPA_PKE_PUBLIC_KEY_SIZE,
+                        T_AS_NTT_ENCODED_SIZE,
+                        C1_SIZE,
+                        C2_SIZE,
+                        VECTOR_U_COMPRESSION_FACTOR,
+                        VECTOR_V_COMPRESSION_FACTOR,
+                        C1_BLOCK_SIZE,
                         ETA1,
                         ETA1_RANDOMNESS_SIZE,
                         ETA2,
                         ETA2_RANDOMNESS_SIZE,
+                        PRF_OUTPUT_SIZE1,
+                        PRF_OUTPUT_SIZE2,
                     >(public_key, randomness)
                 }
 
@@ -384,21 +393,23 @@ macro_rules! instantiate {
                     ciphertext: &MlKem768Ciphertext,
                 ) -> MlKemSharedSecret {
                     p::unpacked::decapsulate::<
-                        RANK_768,
-                        SECRET_KEY_SIZE_768,
-                        CPA_PKE_SECRET_KEY_SIZE_768,
-                        CPA_PKE_PUBLIC_KEY_SIZE_768,
-                        CPA_PKE_CIPHERTEXT_SIZE_768,
-                        T_AS_NTT_ENCODED_SIZE_768,
-                        C1_SIZE_768,
-                        C2_SIZE_768,
-                        VECTOR_U_COMPRESSION_FACTOR_768,
-                        VECTOR_V_COMPRESSION_FACTOR_768,
-                        C1_BLOCK_SIZE_768,
+                        RANK,
+                        SECRET_KEY_SIZE,
+                        CPA_PKE_SECRET_KEY_SIZE,
+                        CPA_PKE_PUBLIC_KEY_SIZE,
+                        CPA_PKE_CIPHERTEXT_SIZE,
+                        T_AS_NTT_ENCODED_SIZE,
+                        C1_SIZE,
+                        C2_SIZE,
+                        VECTOR_U_COMPRESSION_FACTOR,
+                        VECTOR_V_COMPRESSION_FACTOR,
+                        C1_BLOCK_SIZE,
                         ETA1,
                         ETA1_RANDOMNESS_SIZE,
                         ETA2,
                         ETA2_RANDOMNESS_SIZE,
+                        PRF_OUTPUT_SIZE1,
+                        PRF_OUTPUT_SIZE2,
                         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                     >(private_key, ciphertext)
                 }
@@ -420,11 +431,7 @@ instantiate! {neon, ind_cca::instantiations::neon, "Neon Optimised ML-KEM 768"}
 /// Returns `true` if valid, and `false` otherwise.
 #[cfg(not(eurydice))]
 pub fn validate_public_key(public_key: &MlKem768PublicKey) -> bool {
-    multiplexing::validate_public_key::<
-        RANK_768,
-        RANKED_BYTES_PER_RING_ELEMENT_768,
-        CPA_PKE_PUBLIC_KEY_SIZE_768,
-    >(&public_key.value)
+    multiplexing::validate_public_key::<RANK, CPA_PKE_PUBLIC_KEY_SIZE>(&public_key.value)
 }
 
 /// Validate a private key.
@@ -435,7 +442,7 @@ pub fn validate_private_key(
     private_key: &MlKem768PrivateKey,
     ciphertext: &MlKem768Ciphertext,
 ) -> bool {
-    multiplexing::validate_private_key::<RANK_768, SECRET_KEY_SIZE_768, CPA_PKE_CIPHERTEXT_SIZE_768>(
+    multiplexing::validate_private_key::<RANK, SECRET_KEY_SIZE, CPA_PKE_CIPHERTEXT_SIZE>(
         private_key,
         ciphertext,
     )
@@ -455,13 +462,13 @@ pub fn validate_private_key(
 )]
 pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> MlKem768KeyPair {
     multiplexing::generate_keypair::<
-        RANK_768,
-        CPA_PKE_SECRET_KEY_SIZE_768,
-        SECRET_KEY_SIZE_768,
-        CPA_PKE_PUBLIC_KEY_SIZE_768,
-        RANKED_BYTES_PER_RING_ELEMENT_768,
+        RANK,
+        CPA_PKE_SECRET_KEY_SIZE,
+        SECRET_KEY_SIZE,
+        CPA_PKE_PUBLIC_KEY_SIZE,
         ETA1,
         ETA1_RANDOMNESS_SIZE,
+        PRF_OUTPUT_SIZE1
     >(randomness)
 }
 
@@ -482,19 +489,21 @@ pub fn encapsulate(
     randomness: [u8; SHARED_SECRET_SIZE],
 ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
     multiplexing::encapsulate::<
-        RANK_768,
-        CPA_PKE_CIPHERTEXT_SIZE_768,
-        CPA_PKE_PUBLIC_KEY_SIZE_768,
-        T_AS_NTT_ENCODED_SIZE_768,
-        C1_SIZE_768,
-        C2_SIZE_768,
-        VECTOR_U_COMPRESSION_FACTOR_768,
-        VECTOR_V_COMPRESSION_FACTOR_768,
-        C1_BLOCK_SIZE_768,
+        RANK,
+        CPA_PKE_CIPHERTEXT_SIZE,
+        CPA_PKE_PUBLIC_KEY_SIZE,
+        T_AS_NTT_ENCODED_SIZE,
+        C1_SIZE,
+        C2_SIZE,
+        VECTOR_U_COMPRESSION_FACTOR,
+        VECTOR_V_COMPRESSION_FACTOR,
+        C1_BLOCK_SIZE,
         ETA1,
         ETA1_RANDOMNESS_SIZE,
         ETA2,
         ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
     >(public_key, randomness)
 }
 
@@ -513,21 +522,23 @@ pub fn decapsulate(
     ciphertext: &MlKem768Ciphertext,
 ) -> MlKemSharedSecret {
     multiplexing::decapsulate::<
-        RANK_768,
-        SECRET_KEY_SIZE_768,
-        CPA_PKE_SECRET_KEY_SIZE_768,
-        CPA_PKE_PUBLIC_KEY_SIZE_768,
-        CPA_PKE_CIPHERTEXT_SIZE_768,
-        T_AS_NTT_ENCODED_SIZE_768,
-        C1_SIZE_768,
-        C2_SIZE_768,
-        VECTOR_U_COMPRESSION_FACTOR_768,
-        VECTOR_V_COMPRESSION_FACTOR_768,
-        C1_BLOCK_SIZE_768,
+        RANK,
+        SECRET_KEY_SIZE,
+        CPA_PKE_SECRET_KEY_SIZE,
+        CPA_PKE_PUBLIC_KEY_SIZE,
+        CPA_PKE_CIPHERTEXT_SIZE,
+        T_AS_NTT_ENCODED_SIZE,
+        C1_SIZE,
+        C2_SIZE,
+        VECTOR_U_COMPRESSION_FACTOR,
+        VECTOR_V_COMPRESSION_FACTOR,
+        C1_BLOCK_SIZE,
         ETA1,
         ETA1_RANDOMNESS_SIZE,
         ETA2,
         ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
         IMPLICIT_REJECTION_HASH_INPUT_SIZE,
     >(private_key, ciphertext)
 }
@@ -536,7 +547,7 @@ pub fn decapsulate(
 ///
 /// The functions in this module are equivalent to the one in the main module,
 /// but sample their own randomness, provided a random number generator that
-/// implements `RngCore` and `CryptoRng`.
+/// implements `CryptoRng`.
 ///
 /// Decapsulation is not provided in this module as it does not require randomness.
 #[cfg(all(not(eurydice), feature = "rand"))]
@@ -545,15 +556,15 @@ pub mod rand {
         MlKem768Ciphertext, MlKem768KeyPair, MlKem768PublicKey, MlKemSharedSecret,
         KEY_GENERATION_SEED_SIZE, SHARED_SECRET_SIZE,
     };
-    use ::rand::{CryptoRng, RngCore};
+    use ::rand::CryptoRng;
 
     /// Generate ML-KEM 768 Key Pair
     ///
-    /// The random number generator `rng` needs to implement `RngCore` and
-    /// `CryptoRng` to sample the required randomness internally.
+    /// The random number generator `rng` needs to implement `CryptoRng`
+    /// to sample the required randomness internally.
     ///
     /// This function returns an [`MlKem768KeyPair`].
-    pub fn generate_key_pair(rng: &mut (impl RngCore + CryptoRng)) -> MlKem768KeyPair {
+    pub fn generate_key_pair(rng: &mut impl CryptoRng) -> MlKem768KeyPair {
         let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
         rng.fill_bytes(&mut randomness);
 
@@ -564,11 +575,11 @@ pub mod rand {
     ///
     /// Generates an ([`MlKem768Ciphertext`], [`MlKemSharedSecret`]) tuple.
     /// The input is a reference to an [`MlKem768PublicKey`].
-    /// The random number generator `rng` needs to implement `RngCore` and
-    /// `CryptoRng` to sample the required randomness internally.
+    /// The random number generator `rng` needs to implement `CryptoRng`
+    /// to sample the required randomness internally.
     pub fn encapsulate(
         public_key: &MlKem768PublicKey,
-        rng: &mut (impl RngCore + CryptoRng),
+        rng: &mut impl CryptoRng,
     ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
         let mut randomness = [0u8; SHARED_SECRET_SIZE];
         rng.fill_bytes(&mut randomness);
@@ -589,13 +600,13 @@ pub(crate) mod kyber {
     /// This function returns an [`MlKem768KeyPair`].
     pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> MlKem768KeyPair {
         multiplexing::kyber_generate_keypair::<
-            RANK_768,
-            CPA_PKE_SECRET_KEY_SIZE_768,
-            SECRET_KEY_SIZE_768,
-            CPA_PKE_PUBLIC_KEY_SIZE_768,
-            RANKED_BYTES_PER_RING_ELEMENT_768,
+            RANK,
+            CPA_PKE_SECRET_KEY_SIZE,
+            SECRET_KEY_SIZE,
+            CPA_PKE_PUBLIC_KEY_SIZE,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1
         >(randomness)
     }
 
@@ -609,19 +620,21 @@ pub(crate) mod kyber {
         randomness: [u8; SHARED_SECRET_SIZE],
     ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
         multiplexing::kyber_encapsulate::<
-            RANK_768,
-            CPA_PKE_CIPHERTEXT_SIZE_768,
-            CPA_PKE_PUBLIC_KEY_SIZE_768,
-            T_AS_NTT_ENCODED_SIZE_768,
-            C1_SIZE_768,
-            C2_SIZE_768,
-            VECTOR_U_COMPRESSION_FACTOR_768,
-            VECTOR_V_COMPRESSION_FACTOR_768,
-            C1_BLOCK_SIZE_768,
+            RANK,
+            CPA_PKE_CIPHERTEXT_SIZE,
+            CPA_PKE_PUBLIC_KEY_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            C1_BLOCK_SIZE,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
         >(public_key, randomness)
     }
 
@@ -634,28 +647,118 @@ pub(crate) mod kyber {
         ciphertext: &MlKem768Ciphertext,
     ) -> MlKemSharedSecret {
         multiplexing::kyber_decapsulate::<
-            RANK_768,
-            SECRET_KEY_SIZE_768,
-            CPA_PKE_SECRET_KEY_SIZE_768,
-            CPA_PKE_PUBLIC_KEY_SIZE_768,
-            CPA_PKE_CIPHERTEXT_SIZE_768,
-            T_AS_NTT_ENCODED_SIZE_768,
-            C1_SIZE_768,
-            C2_SIZE_768,
-            VECTOR_U_COMPRESSION_FACTOR_768,
-            VECTOR_V_COMPRESSION_FACTOR_768,
-            C1_BLOCK_SIZE_768,
+            RANK,
+            SECRET_KEY_SIZE,
+            CPA_PKE_SECRET_KEY_SIZE,
+            CPA_PKE_PUBLIC_KEY_SIZE,
+            CPA_PKE_CIPHERTEXT_SIZE,
+            T_AS_NTT_ENCODED_SIZE,
+            C1_SIZE,
+            C2_SIZE,
+            VECTOR_U_COMPRESSION_FACTOR,
+            VECTOR_V_COMPRESSION_FACTOR,
+            C1_BLOCK_SIZE,
             ETA1,
             ETA1_RANDOMNESS_SIZE,
             ETA2,
             ETA2_RANDOMNESS_SIZE,
+            PRF_OUTPUT_SIZE1,
+            PRF_OUTPUT_SIZE2,
             IMPLICIT_REJECTION_HASH_INPUT_SIZE,
         >(private_key, ciphertext)
     }
 }
+
+/// # Incremental API.
+///
+/// **NOTE:** This is a non-standard API. Use with caution!
+///
+/// ## Serialized keys
+/// ```
+/// #[cfg(feature = "rand")]
+/// {
+/// use libcrux_ml_kem::mlkem768::incremental::*;
+///
+/// // USE ONLY CRYPTOGRAPHICALLY SECURE RANDOMNESS OR `generate`
+/// let randomness = [0x13; 64];
+/// let key_pair = KeyPairBytes::from_seed(randomness);
+///
+/// // Get pk1 and pk2 to send to the other party.
+/// let pk1 = key_pair.pk1();
+/// let pk2 = key_pair.pk2();
+///
+/// // On the receiver, encapsulate to the public keys.
+/// // Check the public key for consistency.
+/// assert!(validate_pk_bytes(pk1, pk2).is_ok());
+///
+/// let mut encaps_state = [0u8; encaps_state_len()];
+/// let mut encaps_shared_secret = [0u8; shared_secret_size()];
+/// let randomness = [0xAF; 32];
+/// let ct1 = encapsulate1(
+///     pk1,
+///     randomness,
+///     &mut encaps_state,
+///     &mut encaps_shared_secret,
+/// )
+/// .unwrap();
+///
+/// let ct2 = encapsulate2(&encaps_state, &pk2);
+///
+/// // Decapsulate the shared secret after receiving ct1 and ct2.
+/// let shared_secret = decapsulate_incremental_key(key_pair.as_ref(), &ct1, &ct2).unwrap();
+///
+/// assert_eq!(shared_secret, encaps_shared_secret);
+/// }
+/// ```
+///
+/// ## Compressed keys and randomness
+/// ```
+/// #[cfg(feature = "rand")]
+/// {
+/// use libcrux_ml_kem::mlkem768::incremental::*;
+///
+/// // Use a n RNG that is safe to use for cryptography.
+/// // THIS ONE IS NOT!
+/// let mut rng = ::rand::rng();
+///
+/// let key_pair = KeyPairCompressedBytes::generate(&mut rng);
+///
+/// // Get pk1 and pk2 to send to the other party.
+/// let pk1 = key_pair.pk1();
+/// let pk2 = key_pair.pk2();
+///
+/// // On the receiver, encapsulate to the public keys.
+/// // Check the public key for consistency.
+/// assert!(validate_pk_bytes(pk1, pk2).is_ok());
+///
+/// let mut encaps_state = [0u8; encaps_state_len()];
+/// let mut encaps_shared_secret = [0u8; shared_secret_size()];
+/// let ct1 = rand::encapsulate1(
+///     pk1,
+///     &mut rng,
+///     &mut encaps_state,
+///     &mut encaps_shared_secret,
+/// )
+/// .unwrap();
+///
+/// let ct2 = encapsulate2(&encaps_state, pk2);
+///
+/// // Decapsulate the shared secret after receiving ct1 and ct2.
+/// let shared_secret = decapsulate_compressed_key(key_pair.sk(), &ct1, &ct2);
+///
+/// assert_eq!(shared_secret, encaps_shared_secret);
+/// }
+/// ```
+#[cfg(all(not(eurydice), feature = "incremental"))]
+pub mod incremental {
+    use crate::mlkem::impl_incr_key_size;
+
+    impl_incr_key_size!();
+}
+
 #[cfg(test)]
 mod tests {
-    use rand::{rngs::OsRng, RngCore};
+    use rand::{rngs::OsRng, TryRngCore};
 
     use super::{
         mlkem768::{generate_key_pair, validate_public_key},
@@ -665,7 +768,7 @@ mod tests {
     #[test]
     fn pk_validation() {
         let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
-        OsRng.fill_bytes(&mut randomness);
+        OsRng.try_fill_bytes(&mut randomness).unwrap();
 
         let key_pair = generate_key_pair(randomness);
         assert!(validate_public_key(&key_pair.pk));

--- a/libcrux/libcrux-ml-kem/src/ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/ntt.rs
@@ -53,8 +53,8 @@ pub(crate) fn ntt_at_layer_1<Vector: Operations>(
                         (Spec.Utils.is_i16b_array_opaque (11207+5*3328)
                         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"#
         );
-        re.coefficients[round] = Vector::ntt_layer_1_step(
-            re.coefficients[round],
+        Vector::ntt_layer_1_step(
+            &mut re.coefficients[round],
             zeta(*zeta_i),
             zeta(*zeta_i + 1),
             zeta(*zeta_i + 2),
@@ -113,8 +113,12 @@ pub(crate) fn ntt_at_layer_2<Vector: Operations>(
                         (Spec.Utils.is_i16b_array_opaque (11207+4*3328)
                         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"#
         );
-        re.coefficients[round] =
-            Vector::ntt_layer_2_step(re.coefficients[round], zeta(*zeta_i), zeta(*zeta_i + 1));
+
+        Vector::ntt_layer_2_step(
+            &mut re.coefficients[round],
+            zeta(*zeta_i),
+            zeta(*zeta_i + 1),
+        );
         *zeta_i += 1;
         hax_lib::fstar!(
             r#"reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
@@ -168,7 +172,7 @@ pub(crate) fn ntt_at_layer_3<Vector: Operations>(
                         (Spec.Utils.is_i16b_array_opaque (11207+3*3328)
                         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"#
         );
-        re.coefficients[round] = Vector::ntt_layer_3_step(re.coefficients[round], zeta(*zeta_i));
+        Vector::ntt_layer_3_step(&mut re.coefficients[round], zeta(*zeta_i));
         hax_lib::fstar!(
             "reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
             (Spec.Utils.is_i16b_array_opaque (11207+4*3328)
@@ -193,14 +197,16 @@ pub(crate) fn ntt_at_layer_3<Vector: Operations>(
         (v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array $a) i) +
         v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array t) i))))"#))]
 fn ntt_layer_int_vec_step<Vector: Operations>(
-    mut a: Vector,
-    mut b: Vector,
+    a: &mut Vector,
+    b: &mut Vector,
+    scratch: &mut Vector,
     zeta_r: i16,
-) -> (Vector, Vector) {
-    let t = montgomery_multiply_fe::<Vector>(b, zeta_r);
-    b = Vector::sub(a, &t);
-    a = Vector::add(a, &t);
-    (a, b)
+) {
+    *scratch = b.clone(); // XXX: Two copies here may not be necessary.
+    montgomery_multiply_fe::<Vector>(scratch, zeta_r);
+    *b = a.clone();
+    Vector::add(a, scratch);
+    Vector::sub(b, scratch);
 }
 
 #[inline(always)]
@@ -219,26 +225,23 @@ pub(crate) fn ntt_at_layer_4_plus<Vector: Operations>(
     zeta_i: &mut usize,
     re: &mut PolynomialRingElement<Vector>,
     layer: usize,
+    scratch: &mut Vector,
     _initial_coefficient_bound: usize, // This can be used for specifying the range of values allowed in re
 ) {
     let step = 1 << layer;
-
+    let step_vec = step / 16; //FIELD_ELEMENTS_IN_VECTOR;
     let _zeta_i_init = *zeta_i;
-    for round in 0..(128 >> layer) {
+
+    // For every round, split off two `step_vec` sized slices from the front.
+    let mut remaining_elements = &mut re.coefficients[..];
+    for _round in 0..(128 >> layer) {
         *zeta_i += 1;
 
-        let offset = round * step * 2;
-        let offset_vec = offset / 16; //FIELD_ELEMENTS_IN_VECTOR;
-        let step_vec = step / 16; //FIELD_ELEMENTS_IN_VECTOR;
-
-        for j in offset_vec..offset_vec + step_vec {
-            let (x, y) = ntt_layer_int_vec_step(
-                re.coefficients[j],
-                re.coefficients[j + step_vec],
-                zeta(*zeta_i),
-            );
-            re.coefficients[j] = x;
-            re.coefficients[j + step_vec] = y;
+        let (a, rest) = remaining_elements.split_at_mut(step_vec);
+        let (b, rest) = rest.split_at_mut(step_vec);
+        remaining_elements = rest;
+        for j in 0..step_vec {
+            ntt_layer_int_vec_step(&mut a[j], &mut b[j], scratch, zeta(*zeta_i));
         }
     }
 }
@@ -267,7 +270,10 @@ pub(crate) fn ntt_at_layer_4_plus<Vector: Operations>(
 )]
 #[hax_lib::requires(fstar!(r#"forall i. i < 8 ==> ntt_layer_7_pre (${re}.f_coefficients.[ sz i ])
     (${re}.f_coefficients.[ sz i +! sz 8 ])"#))]
-pub(crate) fn ntt_at_layer_7<Vector: Operations>(re: &mut PolynomialRingElement<Vector>) {
+pub(crate) fn ntt_at_layer_7<Vector: Operations>(
+    re: &mut PolynomialRingElement<Vector>,
+    scratch: &mut Vector,
+) {
     let step = VECTORS_IN_RING_ELEMENT / 2;
     hax_lib::fstar!(r#"assert (v $step == 8)"#);
     for j in 0..step {
@@ -279,9 +285,11 @@ pub(crate) fn ntt_at_layer_7<Vector: Operations>(re: &mut PolynomialRingElement<
             )
         });
         hax_lib::fstar!(r#"reveal_opaque (`%ntt_layer_7_pre) (ntt_layer_7_pre #$:Vector)"#);
-        let t = Vector::multiply_by_constant(re.coefficients[j + step], -1600);
-        re.coefficients[j + step] = Vector::sub(re.coefficients[j], &t);
-        re.coefficients[j] = Vector::add(re.coefficients[j], &t);
+        *scratch = re.coefficients[j + step].clone();
+        Vector::multiply_by_constant(scratch, -1600);
+        re.coefficients[j + step] = re.coefficients[j];
+        Vector::add(&mut re.coefficients[j], scratch);
+        Vector::sub(&mut re.coefficients[j + step], scratch);
     }
 }
 
@@ -295,15 +303,16 @@ pub(crate) fn ntt_at_layer_7<Vector: Operations>(re: &mut PolynomialRingElement<
     Libcrux_ml_kem.Serialize.coefficients_field_modulus_range #$:Vector ${re}_future"#))]
 pub(crate) fn ntt_binomially_sampled_ring_element<Vector: Operations>(
     re: &mut PolynomialRingElement<Vector>,
+    scratch: &mut Vector,
 ) {
     // Due to the small coefficient bound, we can skip the first round of
     // Montgomery reductions.
-    ntt_at_layer_7(re);
+    ntt_at_layer_7(re, scratch);
 
     let mut zeta_i = 1;
-    ntt_at_layer_4_plus(&mut zeta_i, re, 6, 11207);
-    ntt_at_layer_4_plus(&mut zeta_i, re, 5, 11207 + 3328);
-    ntt_at_layer_4_plus(&mut zeta_i, re, 4, 11207 + 2 * 3328);
+    ntt_at_layer_4_plus(&mut zeta_i, re, 6, scratch, 11207);
+    ntt_at_layer_4_plus(&mut zeta_i, re, 5, scratch, 11207 + 3328);
+    ntt_at_layer_4_plus(&mut zeta_i, re, 4, scratch, 11207 + 2 * 3328);
     ntt_at_layer_3(&mut zeta_i, re, 11207 + 3 * 3328);
     ntt_at_layer_2(&mut zeta_i, re, 11207 + 4 * 3328);
     ntt_at_layer_1(&mut zeta_i, re, 11207 + 5 * 3328);
@@ -318,6 +327,7 @@ pub(crate) fn ntt_binomially_sampled_ring_element<Vector: Operations>(
     Spec.MLKEM.poly_ntt (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)"#))]
 pub(crate) fn ntt_vector_u<const VECTOR_U_COMPRESSION_FACTOR: usize, Vector: Operations>(
     re: &mut PolynomialRingElement<Vector>,
+    scratch: &mut Vector,
 ) {
     hax_debug_assert!(to_i16_array(re)
         .into_iter()
@@ -325,10 +335,10 @@ pub(crate) fn ntt_vector_u<const VECTOR_U_COMPRESSION_FACTOR: usize, Vector: Ope
 
     let mut zeta_i = 0;
 
-    ntt_at_layer_4_plus(&mut zeta_i, re, 7, 3328);
-    ntt_at_layer_4_plus(&mut zeta_i, re, 6, 2 * 3328);
-    ntt_at_layer_4_plus(&mut zeta_i, re, 5, 3 * 3328);
-    ntt_at_layer_4_plus(&mut zeta_i, re, 4, 4 * 3328);
+    ntt_at_layer_4_plus(&mut zeta_i, re, 7, scratch, 3328);
+    ntt_at_layer_4_plus(&mut zeta_i, re, 6, scratch, 2 * 3328);
+    ntt_at_layer_4_plus(&mut zeta_i, re, 5, scratch, 3 * 3328);
+    ntt_at_layer_4_plus(&mut zeta_i, re, 4, scratch, 4 * 3328);
     ntt_at_layer_3(&mut zeta_i, re, 5 * 3328);
     ntt_at_layer_2(&mut zeta_i, re, 6 * 3328);
     ntt_at_layer_1(&mut zeta_i, re, 7 * 3328);

--- a/libcrux/libcrux-ml-kem/src/ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/ntt.rs
@@ -36,8 +36,6 @@ pub(crate) fn ntt_at_layer_1<Vector: Operations>(
     hax_lib::fstar!(r#"reveal_opaque (`%ntt_re_range_2) (ntt_re_range_2 #$:Vector)"#);
     hax_lib::fstar!(r#"reveal_opaque (`%ntt_re_range_1) (ntt_re_range_1 #$:Vector)"#);
     let _zeta_i_init = *zeta_i;
-    // The semicolon and parentheses at the end of loop are a workaround
-    // for the following bug https://github.com/hacspec/hax/issues/720
     for round in 0..16 {
         hax_lib::loop_invariant!(|round: usize| {
             fstar!(
@@ -73,7 +71,6 @@ pub(crate) fn ntt_at_layer_1<Vector: Operations>(
         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ $round ])))"
         );
     }
-    ()
 }
 
 #[inline(always)]
@@ -99,8 +96,6 @@ pub(crate) fn ntt_at_layer_2<Vector: Operations>(
     hax_lib::fstar!(r#"reveal_opaque (`%ntt_re_range_3) (ntt_re_range_3 #$:Vector)"#);
     hax_lib::fstar!(r#"reveal_opaque (`%ntt_re_range_2) (ntt_re_range_2 #$:Vector)"#);
     let _zeta_i_init = *zeta_i;
-    // The semicolon and parentheses at the end of loop are a workaround
-    // for the following bug https://github.com/hacspec/hax/issues/720
     for round in 0..16 {
         hax_lib::loop_invariant!(|round: usize| {
             fstar!(
@@ -131,7 +126,6 @@ pub(crate) fn ntt_at_layer_2<Vector: Operations>(
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ $round ])))"
         );
     }
-    ()
 }
 
 #[inline(always)]
@@ -157,8 +151,6 @@ pub(crate) fn ntt_at_layer_3<Vector: Operations>(
     hax_lib::fstar!(r#"reveal_opaque (`%ntt_re_range_4) (ntt_re_range_4 #$:Vector)"#);
     hax_lib::fstar!(r#"reveal_opaque (`%ntt_re_range_3) (ntt_re_range_3 #$:Vector)"#);
     let _zeta_i_init = *zeta_i;
-    // The semicolon and parentheses at the end of loop are a workaround
-    // for the following bug https://github.com/hacspec/hax/issues/720
     for round in 0..16 {
         hax_lib::loop_invariant!(|round: usize| {
             fstar!(
@@ -187,7 +179,6 @@ pub(crate) fn ntt_at_layer_3<Vector: Operations>(
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ $round ])))"
         );
     }
-    ()
 }
 
 #[inline(always)]
@@ -233,8 +224,6 @@ pub(crate) fn ntt_at_layer_4_plus<Vector: Operations>(
     let step = 1 << layer;
 
     let _zeta_i_init = *zeta_i;
-    // The semicolon and parentheses at the end of loop are a workaround
-    // for the following bug https://github.com/hacspec/hax/issues/720
     for round in 0..(128 >> layer) {
         *zeta_i += 1;
 
@@ -252,7 +241,6 @@ pub(crate) fn ntt_at_layer_4_plus<Vector: Operations>(
             re.coefficients[j + step_vec] = y;
         }
     }
-    ()
 }
 
 #[inline(always)]
@@ -266,8 +254,8 @@ pub(crate) fn ntt_at_layer_4_plus<Vector: Operations>(
         (re_0 re_1: v_Vector) =
     (forall i. i < 16 ==>
       Spec.Utils.is_intb (pow2 15 - 1)
-      (v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array re_1) i) * v (-1600s))) /\
-    (let t = Libcrux_ml_kem.Vector.Traits.f_multiply_by_constant re_1 (-1600s) in
+      (v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array re_1) i) * v ((mk_i16 (-1600))))) /\
+    (let t = Libcrux_ml_kem.Vector.Traits.f_multiply_by_constant re_1 ((mk_i16 (-1600))) in
     (forall i. i < 16 ==> 
       Spec.Utils.is_intb (pow2 15 - 1) 
         (v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array re_0) i) - 
@@ -282,8 +270,6 @@ pub(crate) fn ntt_at_layer_4_plus<Vector: Operations>(
 pub(crate) fn ntt_at_layer_7<Vector: Operations>(re: &mut PolynomialRingElement<Vector>) {
     let step = VECTORS_IN_RING_ELEMENT / 2;
     hax_lib::fstar!(r#"assert (v $step == 8)"#);
-    // The semicolon and parentheses at the end of loop are a workaround
-    // for the following bug https://github.com/hacspec/hax/issues/720
     for j in 0..step {
         hax_lib::loop_invariant!(|j: usize| {
             fstar!(
@@ -297,7 +283,6 @@ pub(crate) fn ntt_at_layer_7<Vector: Operations>(re: &mut PolynomialRingElement<
         re.coefficients[j + step] = Vector::sub(re.coefficients[j], &t);
         re.coefficients[j] = Vector::add(re.coefficients[j], &t);
     }
-    ()
 }
 
 #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/polynomial.rs
+++ b/libcrux/libcrux-ml-kem/src/polynomial.rs
@@ -185,7 +185,7 @@ fn add_message_error_reduce<Vector: Operations>(
     myself: &PolynomialRingElement<Vector>,
     message: &PolynomialRingElement<Vector>,
     result: &mut PolynomialRingElement<Vector>,
-    scratch: &mut Vector
+    scratch: &mut Vector,
 ) {
     // Using `hax_lib::fstar::verification_status(lax)` works but produces an error while extracting
     for i in 0..VECTORS_IN_RING_ELEMENT {
@@ -336,7 +336,7 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
     #[inline(always)]
     #[allow(dead_code)]
     #[requires(VECTORS_IN_RING_ELEMENT * 16 * 2 <= bytes.len())]
-    pub(crate) fn from_bytes(bytes: &[u8], out:& mut Self) {
+    pub(crate) fn from_bytes(bytes: &[u8], out: &mut Self) {
         from_bytes(bytes, out)
     }
 
@@ -365,7 +365,12 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
     }
 
     #[inline(always)]
-    pub(crate) fn add_message_error_reduce(&self, message: &Self, result: &mut Self, scratch: &mut Vector) {
+    pub(crate) fn add_message_error_reduce(
+        &self,
+        message: &Self,
+        result: &mut Self,
+        scratch: &mut Vector,
+    ) {
         add_message_error_reduce(self, message, result, scratch);
     }
 

--- a/libcrux/libcrux-ml-kem/src/polynomial.rs
+++ b/libcrux/libcrux-ml-kem/src/polynomial.rs
@@ -55,6 +55,7 @@ pub(crate) struct PolynomialRingElement<Vector: Operations> {
 }
 
 #[allow(non_snake_case)]
+#[inline(always)]
 fn ZERO<Vector: Operations>() -> PolynomialRingElement<Vector> {
     PolynomialRingElement {
         // https://github.com/hacspec/hax/issues/27

--- a/libcrux/libcrux-ml-kem/src/sampling.rs
+++ b/libcrux/libcrux-ml-kem/src/sampling.rs
@@ -1,6 +1,5 @@
 use crate::{
-    constants::COEFFICIENTS_IN_RING_ELEMENT, hash_functions::*, helper::cloop,
-    vector::Operations,
+    constants::COEFFICIENTS_IN_RING_ELEMENT, hash_functions::*, helper::cloop, vector::Operations,
 };
 
 /// If `bytes` contains a set of uniformly random bytes, this function
@@ -100,7 +99,7 @@ pub(super) fn sample_from_xof<const K: usize, Vector: Operations, Hasher: Hash>(
             sampled_coefficients,
             out,
         );
-    };
+    }
 }
 
 /// Given a series of uniformly random bytes in `randomness`, for some number `eta`,

--- a/libcrux/libcrux-ml-kem/src/serialize.rs
+++ b/libcrux/libcrux-ml-kem/src/serialize.rs
@@ -271,7 +271,7 @@ pub(super) fn compress_then_serialize_ring_element_u<
 fn compress_then_serialize_4<Vector: Operations>(
     re: PolynomialRingElement<Vector>,
     serialized: &mut [u8],
-    scratch: &mut Vector
+    scratch: &mut Vector,
 ) {
     hax_lib::fstar!(r#"assert_norm (pow2 4 == 16)"#);
     for i in 0..VECTORS_IN_RING_ELEMENT {
@@ -288,7 +288,7 @@ fn compress_then_serialize_4<Vector: Operations>(
             (coefficients_field_modulus_range #$:Vector)"
         );
         to_unsigned_field_modulus(&re.coefficients[i], scratch);
-         Vector::compress::<4>(scratch);
+        Vector::compress::<4>(scratch);
 
         Vector::serialize_4(*scratch, &mut serialized[8 * i..8 * i + 8]);
     }

--- a/libcrux/libcrux-ml-kem/src/types.rs
+++ b/libcrux/libcrux-ml-kem/src/types.rs
@@ -13,7 +13,7 @@ macro_rules! impl_generic_struct {
 
         #[hax_lib::attributes]
         impl<const SIZE: usize> AsRef<[u8]> for $name<SIZE> {
-            #[ensures(|result| fstar!(r#"$result = self___.f_value"#))]
+            #[ensures(|result| fstar!(r#"$result = ${self_}.f_value"#))]
             fn as_ref(&self) -> &[u8] {
                 &self.value
             }

--- a/libcrux/libcrux-ml-kem/src/utils.rs
+++ b/libcrux/libcrux-ml-kem/src/utils.rs
@@ -9,13 +9,13 @@
     slice.len() <= LEN
 ))]
 #[cfg_attr(hax, hax_lib::ensures(|result|
-    fstar!(r#"$result == Seq.append $slice (Seq.create (v $LEN - v (${slice.len()})) 0uy)"#)))]
+    fstar!(r#"$result == Seq.append $slice (Seq.create (v $LEN - v (${slice.len()})) (mk_u8 0))"#)))]
 pub(crate) fn into_padded_array<const LEN: usize>(slice: &[u8]) -> [u8; LEN] {
     let mut out = [0u8; LEN];
     out[0..slice.len()].copy_from_slice(slice);
     hax_lib::fstar!(r#"assert (Seq.slice out 0 (Seq.length slice) == slice)"#);
     hax_lib::fstar!(
-        r#"assert (Seq.slice out (Seq.length slice) (v v_LEN) == Seq.slice (Seq.create (v v_LEN) 0uy) (Seq.length slice) (v v_LEN))"#
+        r#"assert (Seq.slice out (Seq.length slice) (v v_LEN) == Seq.slice (Seq.create (v v_LEN) (mk_u8 0)) (Seq.length slice) (v v_LEN))"#
     );
     hax_lib::fstar!(
         "assert (forall i. i < Seq.length slice ==> Seq.index out i == Seq.index slice i)"
@@ -24,7 +24,7 @@ pub(crate) fn into_padded_array<const LEN: usize>(slice: &[u8]) -> [u8; LEN] {
         r#"assert (forall i. (i >= Seq.length slice && i < v v_LEN) ==> Seq.index out i == Seq.index (Seq.slice out (Seq.length slice) (v v_LEN)) (i - Seq.length slice))"#
     );
     hax_lib::fstar!(
-        "Seq.lemma_eq_intro out (Seq.append slice (Seq.create (v v_LEN - Seq.length slice) 0uy))"
+        "Seq.lemma_eq_intro out (Seq.append slice (Seq.create (v v_LEN - Seq.length slice) (mk_u8 0)))"
     );
     out
 }

--- a/libcrux/libcrux-ml-kem/src/utils.rs
+++ b/libcrux/libcrux-ml-kem/src/utils.rs
@@ -3,59 +3,6 @@
 // libcrux_core.{c,h}, so if you need something that has to be shared across multiple mlkem
 // instances / implementations, it can go in here.
 
-/// A utility to quickly get cycle counts during execution.
-///
-/// ⚠️ Note, that the hardware must be initialized before the counter
-/// can function.
-pub(crate) struct CycleCounter {
-    start: u32,
-}
-
-impl CycleCounter {
-    /// Use this to initialize the hardwar, if it hasn't been initialized elsewhere.
-    pub (crate) fn init() {
-        use cortex_m::peripheral::Peripherals;
-        let mut peripherals = Peripherals::take().unwrap();
-        peripherals.DCB.enable_trace();
-        peripherals.DWT.enable_cycle_counter();
-    }
-
-    /// Create a new CycleCounter.
-    pub (crate) fn new() -> Self {
-        Self {
-            start: 0
-        }
-    }
-
-    /// Signal the start of a measurement section.
-    pub (crate) fn start_section(msg: &str, file: &str, line: u32) {
-        let current = cortex_m::peripheral::DWT::cycle_count();
-        defmt::println!("[START_SECTION {=str}] ({=str}, {=u32}) : {=u32}", msg, file, line, current);
-    }
-
-    /// Signal the end of a measurement section.
-    pub (crate) fn end_section(msg: &str, file: &str, line: u32) {
-        let current = cortex_m::peripheral::DWT::cycle_count();
-        defmt::println!("[END_SECTION {=str}] ({=str}, {=u32}) : {=u32}", msg, file, line, current);
-    }
-
-    /// Start measuring cycles.
-    ///
-    /// ⚠️ Using this presupposes that the cycle counter has been initialized somewhere.
-    pub (crate) fn start_measurement(msg: &str, file: &str, line: u32) {
-        let current = cortex_m::peripheral::DWT::cycle_count();
-        defmt::println!("[START_MEASUREMENT {=str}] ({=str}, {=u32}) : {=u32}", msg, file, line, current);
-    }
-
-    /// Report cycles current cycles (Use this to mark the end of measurement).
-    ///
-    /// ⚠️ Using this presupposes that the cycle counter has been initialized somewhere.
-    pub (crate) fn end_measurement(msg: &str, file: &str, line: u32) {
-        let current = cortex_m::peripheral::DWT::cycle_count();
-        defmt::println!("[END_MEASUREMENT {=str}] ({=str}, {=u32}) : {=u32}", msg, file, line, current);
-    }
-}
-
 /// Pad the `slice` with `0`s at the end.
 #[inline(always)]
 #[cfg_attr(hax, hax_lib::requires(

--- a/libcrux/libcrux-ml-kem/src/utils.rs
+++ b/libcrux/libcrux-ml-kem/src/utils.rs
@@ -3,6 +3,59 @@
 // libcrux_core.{c,h}, so if you need something that has to be shared across multiple mlkem
 // instances / implementations, it can go in here.
 
+/// A utility to quickly get cycle counts during execution.
+///
+/// ⚠️ Note, that the hardware must be initialized before the counter
+/// can function.
+pub(crate) struct CycleCounter {
+    start: u32,
+}
+
+impl CycleCounter {
+    /// Use this to initialize the hardwar, if it hasn't been initialized elsewhere.
+    pub (crate) fn init() {
+        use cortex_m::peripheral::Peripherals;
+        let mut peripherals = Peripherals::take().unwrap();
+        peripherals.DCB.enable_trace();
+        peripherals.DWT.enable_cycle_counter();
+    }
+
+    /// Create a new CycleCounter.
+    pub (crate) fn new() -> Self {
+        Self {
+            start: 0
+        }
+    }
+
+    /// Signal the start of a measurement section.
+    pub (crate) fn start_section(msg: &str, file: &str, line: u32) {
+        let current = cortex_m::peripheral::DWT::cycle_count();
+        defmt::println!("[START_SECTION {=str}] ({=str}, {=u32}) : {=u32}", msg, file, line, current);
+    }
+
+    /// Signal the end of a measurement section.
+    pub (crate) fn end_section(msg: &str, file: &str, line: u32) {
+        let current = cortex_m::peripheral::DWT::cycle_count();
+        defmt::println!("[END_SECTION {=str}] ({=str}, {=u32}) : {=u32}", msg, file, line, current);
+    }
+
+    /// Start measuring cycles.
+    ///
+    /// ⚠️ Using this presupposes that the cycle counter has been initialized somewhere.
+    pub (crate) fn start_measurement(msg: &str, file: &str, line: u32) {
+        let current = cortex_m::peripheral::DWT::cycle_count();
+        defmt::println!("[START_MEASUREMENT {=str}] ({=str}, {=u32}) : {=u32}", msg, file, line, current);
+    }
+
+    /// Report cycles current cycles (Use this to mark the end of measurement).
+    ///
+    /// ⚠️ Using this presupposes that the cycle counter has been initialized somewhere.
+    pub (crate) fn end_measurement(msg: &str, file: &str, line: u32) {
+        let current = cortex_m::peripheral::DWT::cycle_count();
+        defmt::println!("[END_MEASUREMENT {=str}] ({=str}, {=u32}) : {=u32}", msg, file, line, current);
+    }
+}
+
 /// Pad the `slice` with `0`s at the end.
 #[inline(always)]
 #[cfg_attr(hax, hax_lib::requires(

--- a/libcrux/libcrux-ml-kem/src/variant.rs
+++ b/libcrux/libcrux-ml-kem/src/variant.rs
@@ -13,18 +13,19 @@ use crate::{constants::CPA_PKE_KEY_GENERATION_SEED_SIZE, hash_functions::Hash, M
 pub(crate) trait Variant {
     #[requires(shared_secret.len() == 32)]
     #[ensures(|res| fstar!(r#"$res == $shared_secret"#))] // We only have post-conditions for ML-KEM, not Kyber
-    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash<K>>(
+    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash>(
         shared_secret: &[u8],
         ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
-    ) -> [u8; 32];
+        out: &mut [u8],
+    );
     #[requires(randomness.len() == 32)]
     #[ensures(|res| fstar!(r#"$res == $randomness"#))] // We only have post-conditions for ML-KEM, not Kyber
-    fn entropy_preprocess<const K: usize, Hasher: Hash<K>>(randomness: &[u8]) -> [u8; 32];
+    fn entropy_preprocess<const K: usize, Hasher: Hash>(randomness: &[u8], out: &mut [u8]);
     #[requires(seed.len() == 32)]
     #[ensures(|res| fstar!(r#"Seq.length $seed == 32 ==> $res == Spec.Utils.v_G
         (Seq.append $seed (Seq.create 1 (cast $K <: u8)))"#)
     )]
-    fn cpa_keygen_seed<const K: usize, Hasher: Hash<K>>(seed: &[u8]) -> [u8; 64];
+    fn cpa_keygen_seed<const K: usize, Hasher: Hash>(seed: &[u8], out: &mut [u8]);
 }
 
 /// Implements [`Variant`], to perform the Kyber-specific actions
@@ -39,25 +40,29 @@ pub(crate) struct Kyber {}
 #[cfg(feature = "kyber")]
 impl Variant for Kyber {
     #[inline(always)]
-    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash<K>>(
+    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash>(
         shared_secret: &[u8],
         ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
-    ) -> [u8; 32] {
+        out: &mut [u8],
+    ) {
         use crate::{constants::H_DIGEST_SIZE, utils::into_padded_array};
 
         let mut kdf_input: [u8; 2 * H_DIGEST_SIZE] = into_padded_array(&shared_secret);
-        kdf_input[H_DIGEST_SIZE..].copy_from_slice(&Hasher::H(ciphertext.as_slice()));
-        Hasher::PRF::<32>(&kdf_input)
+        Hasher::H(ciphertext.as_slice(), &mut kdf_input[H_DIGEST_SIZE..]);
+        Hasher::PRF::<32>(&kdf_input, out)
     }
 
     #[inline(always)]
-    fn entropy_preprocess<const K: usize, Hasher: Hash<K>>(randomness: &[u8]) -> [u8; 32] {
-        Hasher::H(&randomness)
+    fn entropy_preprocess<const K: usize, Hasher: Hash>(randomness: &mut [u8], out: &mut [u8]) {
+        Hasher::H(&randomness, out)
     }
 
     #[inline(always)]
-    fn cpa_keygen_seed<const K: usize, Hasher: Hash<K>>(key_generation_seed: &[u8]) -> [u8; 64] {
-        Hasher::G(key_generation_seed)
+    fn cpa_keygen_seed<const K: usize, Hasher: Hash>(
+        key_generation_seed: &[u8],
+        out: &mut [u8],
+    ) -> [u8; 64] {
+        Hasher::G(key_generation_seed, out)
     }
 }
 
@@ -74,22 +79,19 @@ impl Variant for MlKem {
     #[inline(always)]
     #[requires(shared_secret.len() == 32)]
     #[ensures(|res| fstar!(r#"$res == $shared_secret"#))]
-    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash<K>>(
+    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash>(
         shared_secret: &[u8],
         _: &MlKemCiphertext<CIPHERTEXT_SIZE>,
-    ) -> [u8; 32] {
-        let mut out = [0u8; 32];
+        out: &mut [u8],
+    ) {
         out.copy_from_slice(shared_secret);
-        out
     }
 
     #[inline(always)]
     #[requires(randomness.len() == 32)]
     #[ensures(|res| fstar!(r#"$res == $randomness"#))]
-    fn entropy_preprocess<const K: usize, Hasher: Hash<K>>(randomness: &[u8]) -> [u8; 32] {
-        let mut out = [0u8; 32];
+    fn entropy_preprocess<const K: usize, Hasher: Hash>(randomness: &[u8], out: &mut [u8]) {
         out.copy_from_slice(randomness);
-        out
     }
 
     #[inline(always)]
@@ -97,7 +99,7 @@ impl Variant for MlKem {
     #[ensures(|res| fstar!(r#"Seq.length $key_generation_seed == 32 ==> $res == Spec.Utils.v_G
         (Seq.append $key_generation_seed (Seq.create 1 (cast $K <: u8)))"#)
     )]
-    fn cpa_keygen_seed<const K: usize, Hasher: Hash<K>>(key_generation_seed: &[u8]) -> [u8; 64] {
+    fn cpa_keygen_seed<const K: usize, Hasher: Hash>(key_generation_seed: &[u8], out: &mut [u8]) {
         let mut seed = [0u8; CPA_PKE_KEY_GENERATION_SEED_SIZE + 1];
         seed[0..CPA_PKE_KEY_GENERATION_SEED_SIZE].copy_from_slice(key_generation_seed);
         seed[CPA_PKE_KEY_GENERATION_SEED_SIZE] = K as u8;
@@ -105,6 +107,6 @@ impl Variant for MlKem {
             "Lib.Sequence.eq_intro #u8 #33 $seed
             (Seq.append $key_generation_seed (Seq.create 1 (cast $K <: u8)))"
         );
-        Hasher::G(&seed)
+        Hasher::G(&seed, out);
     }
 }

--- a/libcrux/libcrux-ml-kem/src/vector.rs
+++ b/libcrux/libcrux-ml-kem/src/vector.rs
@@ -28,9 +28,9 @@ pub(crate) mod rej_sample_table;
 mod neon;
 #[cfg(feature = "simd128")]
 pub(crate) use neon::SIMD128Vector;
-#[cfg(feature = "simd256")]
-mod avx2;
-#[cfg(feature = "simd256")]
-pub(crate) use avx2::SIMD256Vector;
+// #[cfg(feature = "simd256")]
+// mod avx2;
+// #[cfg(feature = "simd256")]
+// pub(crate) use avx2::SIMD256Vector;
 
 pub mod portable;

--- a/libcrux/libcrux-ml-kem/src/vector/avx2.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/avx2.rs
@@ -36,10 +36,8 @@ fn vec_to_i16_array(v: SIMD256Vector) -> [i16; 16] {
 #[inline(always)]
 #[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::ensures(|result| fstar!(r#"repr ${result} == ${array}"#))]
-fn vec_from_i16_array(array: &[i16]) -> SIMD256Vector {
-    SIMD256Vector {
-        elements: mm256_loadu_si256_i16(array),
-    }
+fn vec_from_i16_array(array: &[i16], out: &mut SIMD256Vector) {
+    out.elements = mm256_loadu_si256_i16(array);
 }
 
 #[inline(always)]
@@ -271,8 +269,8 @@ impl Operations for SIMD256Vector {
     #[requires(array.len() == 16)]
     #[ensures(|out| fstar!(r#"impl.f_repr out == $array"#))]
     #[inline(always)]
-    fn from_i16_array(array: &[i16]) -> Self {
-        vec_from_i16_array(array)
+    fn from_i16_array(array: &[i16], out: &mut Self) {
+        vec_from_i16_array(array, out)
     }
 
     #[ensures(|out| fstar!(r#"out == impl.f_repr $x"#))]

--- a/libcrux/libcrux-ml-kem/src/vector/avx2.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/avx2.rs
@@ -16,7 +16,7 @@ pub struct SIMD256Vector {
 
 #[inline(always)]
 #[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::ensures(|result| fstar!(r#"repr ${result} == Seq.create 16 0s"#))]
+#[hax_lib::ensures(|result| fstar!(r#"repr ${result} == Seq.create 16 (mk_i16 0)"#))]
 fn vec_zero() -> SIMD256Vector {
     SIMD256Vector {
         elements: mm256_setzero_si256(),
@@ -45,7 +45,7 @@ fn vec_from_i16_array(array: &[i16]) -> SIMD256Vector {
 #[inline(always)]
 #[hax_lib::fstar::verification_status(lax)]
 #[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (repr $vector)"#))]
-#[hax_lib::ensures(|out| fstar!(r#"repr out == Spec.Utils.map_array (fun x -> if x >=. 3329s then x -! 3329s else x) (repr $vector)"#))]
+#[hax_lib::ensures(|out| fstar!(r#"repr out == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (repr $vector)"#))]
 fn cond_subtract_3329(vector: SIMD256Vector) -> SIMD256Vector {
     SIMD256Vector {
         elements: arithmetic::cond_subtract_3329(vector.elements),
@@ -263,7 +263,7 @@ impl crate::vector::traits::Repr for SIMD256Vector {
 #[hax_lib::attributes]
 impl Operations for SIMD256Vector {
     #[inline(always)]
-    #[ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 0s"#))]
+    #[ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 (mk_i16 0)"#))]
     fn ZERO() -> Self {
         vec_zero()
     }
@@ -279,6 +279,18 @@ impl Operations for SIMD256Vector {
     #[inline(always)]
     fn to_i16_array(x: Self) -> [i16; 16] {
         vec_to_i16_array(x)
+    }
+
+    #[requires(array.len() >= 32)]
+    #[inline(always)]
+    fn from_bytes(array: &[u8]) -> Self {
+        from_bytes(array)
+    }
+
+    #[requires(bytes.len() >= 32)]
+    #[inline(always)]
+    fn to_bytes(x: Self, bytes: &mut [u8]) {
+        to_bytes(x, bytes)
     }
 
     #[requires(fstar!(r#"forall i. i < 16 ==> 
@@ -326,7 +338,7 @@ impl Operations for SIMD256Vector {
     }
 
     #[requires(SHIFT_BY >= 0 && SHIFT_BY < 16)]
-    #[ensures(|out| fstar!(r#"(v_SHIFT_BY >=. 0l /\ v_SHIFT_BY <. 16l) ==> impl.f_repr out == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (impl.f_repr $vector)"#))]
+    #[ensures(|out| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> impl.f_repr out == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (impl.f_repr $vector)"#))]
     #[inline(always)]
     fn shift_right<const SHIFT_BY: i32>(vector: Self) -> Self {
         Self {
@@ -335,7 +347,7 @@ impl Operations for SIMD256Vector {
     }
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (impl.f_repr $vector)"#))]
-    #[ensures(|out| fstar!(r#"impl.f_repr out == Spec.Utils.map_array (fun x -> if x >=. 3329s then x -! 3329s else x) (impl.f_repr $vector)"#))]
+    #[ensures(|out| fstar!(r#"impl.f_repr out == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (impl.f_repr $vector)"#))]
     #[inline(always)]
     fn cond_subtract_3329(vector: Self) -> Self {
         cond_subtract_3329(vector)
@@ -554,4 +566,19 @@ impl Operations for SIMD256Vector {
     fn rej_sample(input: &[u8], output: &mut [i16]) -> usize {
         sampling::rejection_sample(input, output)
     }
+}
+
+#[inline(always)]
+#[hax_lib::requires(array.len() >= 32)]
+pub(super) fn from_bytes(array: &[u8]) -> SIMD256Vector {
+    SIMD256Vector {
+        elements: mm256_loadu_si256_u8(&array[0..32]),
+    }
+}
+
+#[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
+#[hax_lib::requires(bytes.len() >= 32)]
+pub(super) fn to_bytes(x: SIMD256Vector, bytes: &mut [u8]) {
+    mm256_storeu_si256_u8(&mut bytes[0..32], x.elements)
 }

--- a/libcrux/libcrux-ml-kem/src/vector/avx2/arithmetic.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/avx2/arithmetic.rs
@@ -91,7 +91,7 @@ pub(crate) fn bitwise_and_with_constant(vector: Vec256, constant: i16) -> Vec256
 
 #[inline(always)]
 #[hax_lib::requires(SHIFT_BY >= 0 && SHIFT_BY < 16)]
-#[hax_lib::ensures(|result| fstar!(r#"(v_SHIFT_BY >=. 0l /\ v_SHIFT_BY <. 16l) ==> 
+#[hax_lib::ensures(|result| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> 
                             Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $result == 
                             Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $vector)"#))]
 pub(crate) fn shift_right<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
@@ -109,33 +109,33 @@ pub(crate) fn shift_right<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 #[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $vector)"#))]
 #[hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
                 get_lane $result i == 
-                (if (get_lane $vector i) >=. 3329s then get_lane $vector i -! 3329s else get_lane $vector i)"#))]
+                (if (get_lane $vector i) >=. (mk_i16 3329) then get_lane $vector i -! (mk_i16 3329) else get_lane $vector i)"#))]
 pub(crate) fn cond_subtract_3329(vector: Vec256) -> Vec256 {
     let field_modulus = mm256_set1_epi16(FIELD_MODULUS);
-    hax_lib::fstar!(r#"assert (forall i. get_lane $field_modulus i == 3329s)"#);
+    hax_lib::fstar!(r#"assert (forall i. get_lane $field_modulus i == (mk_i16 3329))"#);
     // Compute v_i - Q and crate a mask from the sign bit of each of these
     // quantities.
     let v_minus_field_modulus = mm256_sub_epi16(vector, field_modulus);
     hax_lib::fstar!(
-        "assert (forall i. get_lane $v_minus_field_modulus i == get_lane $vector i -. 3329s)"
+        "assert (forall i. get_lane $v_minus_field_modulus i == get_lane $vector i -. (mk_i16 3329))"
     );
 
     let sign_mask = mm256_srai_epi16::<15>(v_minus_field_modulus);
     hax_lib::fstar!(
-        "assert (forall i. get_lane $sign_mask i == (get_lane $v_minus_field_modulus i >>! 15l))"
+        "assert (forall i. get_lane $sign_mask i == (get_lane $v_minus_field_modulus i >>! (mk_i32 15)))"
     );
 
     // If v_i - Q < 0 then add back Q to (v_i - Q).
     let conditional_add_field_modulus = mm256_and_si256(sign_mask, field_modulus);
     hax_lib::fstar!(
-        r#"assert (forall i. get_lane $conditional_add_field_modulus i == (get_lane $sign_mask i &. 3329s))"#
+        r#"assert (forall i. get_lane $conditional_add_field_modulus i == (get_lane $sign_mask i &. (mk_i16 3329)))"#
     );
 
     let result = mm256_add_epi16(v_minus_field_modulus, conditional_add_field_modulus);
     hax_lib::fstar!(
         r#"assert (forall i. get_lane $result i == (get_lane $v_minus_field_modulus i +. get_lane $conditional_add_field_modulus i));
                      assert (forall i. get_lane $result i == Spec.Utils.cond_sub (get_lane $vector i));
-                     assert (forall i. get_lane $result i == (if (get_lane $vector i) >=. 3329s then get_lane $vector i -! 3329s else get_lane $vector i))"#
+                     assert (forall i. get_lane $result i == (if (get_lane $vector i) >=. (mk_i16 3329) then get_lane $vector i -! (mk_i16 3329) else get_lane $vector i))"#
     );
 
     result
@@ -154,15 +154,15 @@ const BARRETT_MULTIPLIER: i16 = 20159;
 pub(crate) fn barrett_reduce(vector: Vec256) -> Vec256 {
     let t0 = mm256_mulhi_epi16(vector, mm256_set1_epi16(BARRETT_MULTIPLIER));
     hax_lib::fstar!(
-        r#"assert (forall i. get_lane $t0 i == (cast (((cast (get_lane $vector i) <: i32) *. (cast v_BARRETT_MULTIPLIER <: i32)) >>! 16l) <: i16))"#
+        r#"assert (forall i. get_lane $t0 i == (cast (((cast (get_lane $vector i) <: i32) *. (cast v_BARRETT_MULTIPLIER <: i32)) >>! (mk_i32 16)) <: i16))"#
     );
     let t512 = mm256_set1_epi16(512);
-    hax_lib::fstar!(r#"assert (forall i. get_lane $t512 i == 512s)"#);
+    hax_lib::fstar!(r#"assert (forall i. get_lane $t512 i == (mk_i16 512))"#);
     let t1 = mm256_add_epi16(t0, t512);
-    hax_lib::fstar!(r#"assert (forall i. get_lane $t1 i == get_lane $t0 i +. 512s)"#);
+    hax_lib::fstar!(r#"assert (forall i. get_lane $t1 i == get_lane $t0 i +. (mk_i16 512))"#);
     let quotient = mm256_srai_epi16::<10>(t1);
     hax_lib::fstar!(
-        "assert (forall i. get_lane $quotient i == (((get_lane $t1 i) <: i16) >>! (10l <: i32)))"
+        "assert (forall i. get_lane $quotient i == (((get_lane $t1 i) <: i16) >>! ((mk_i32 10) <: i32)))"
     );
     let quotient_times_field_modulus = mm256_mullo_epi16(quotient, mm256_set1_epi16(FIELD_MODULUS));
     hax_lib::fstar!(
@@ -199,31 +199,33 @@ pub(crate) fn montgomery_multiply_by_constant(vector: Vec256, constant: i16) -> 
         value_low,
         mm256_set1_epi16(INVERSE_OF_MODULUS_MOD_MONTGOMERY_R as i16),
     );
-    hax_lib::fstar!(r#"assert (forall i. get_lane $k i == get_lane $value_low i *. (neg 3327s))"#);
+    hax_lib::fstar!(
+        r#"assert (forall i. get_lane $k i == get_lane $value_low i *. (neg (mk_i16 3327)))"#
+    );
     let modulus = mm256_set1_epi16(FIELD_MODULUS);
-    hax_lib::fstar!(r#"assert (forall i. get_lane $modulus i == 3329s)"#);
+    hax_lib::fstar!(r#"assert (forall i. get_lane $modulus i == (mk_i16 3329))"#);
     let k_times_modulus = mm256_mulhi_epi16(k, modulus);
     hax_lib::fstar!(
         r#"assert (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $k_times_modulus == 
-                        Spec.Utils.map2 (fun x y -> cast (((cast x <: i32) *. (cast y <: i32)) >>! 16l) <: i16)
+                        Spec.Utils.map2 (fun x y -> cast (((cast x <: i32) *. (cast y <: i32)) >>! (mk_i32 16)) <: i16)
                                 (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $k)
                                 (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $modulus));
                      assert (forall i. get_lane $k_times_modulus i == 
-                        (cast (((cast (get_lane $k i) <: i32) *. (cast (get_lane $modulus i) <: i32)) >>! 16l) <: i16))"#
+                        (cast (((cast (get_lane $k i) <: i32) *. (cast (get_lane $modulus i) <: i32)) >>! (mk_i32 16)) <: i16))"#
     );
 
     let value_high = mm256_mulhi_epi16(vector, vec_constant);
     hax_lib::fstar!(
         r#"assert (forall i. get_lane $value_high i == 
-        (cast (((cast (get_lane $vector i) <: i32) *. (cast (get_lane $vec_constant i) <: i32)) >>! 16l) <: i16))"#
+        (cast (((cast (get_lane $vector i) <: i32) *. (cast (get_lane $vec_constant i) <: i32)) >>! (mk_i32 16)) <: i16))"#
     );
 
     let result = mm256_sub_epi16(value_high, k_times_modulus);
     hax_lib::fstar!(
         r#"Spec.Utils.lemma_range_at_percent 3329 (pow2 32);
-                    assert (v (cast 3329s <: i32) == (3329 @% pow2 32));
-                    assert (v (cast 3329s <: i32) == 3329);
-                    assert ((cast 3329s <: i32) == 3329l);
+                    assert (v (cast (mk_i16 3329) <: i32) == (3329 @% pow2 32));
+                    assert (v (cast (mk_i16 3329) <: i32) == 3329);
+                    assert ((cast (mk_i16 3329) <: i32) == (mk_i32 3329));
                     assert (forall i. get_lane $result i == (get_lane $value_high i) -. (get_lane $k_times_modulus i));
                     assert (forall i. get_lane $result i == Spec.Utils.mont_mul_red_i16 (get_lane $vector i) $constant);
                     assert (forall i. Spec.Utils.is_i16b 3328 (get_lane $result i));
@@ -250,33 +252,35 @@ pub(crate) fn montgomery_multiply_by_constants(vec: Vec256, constants: Vec256) -
         value_low,
         mm256_set1_epi16(INVERSE_OF_MODULUS_MOD_MONTGOMERY_R as i16),
     );
-    hax_lib::fstar!(r#"assert (forall i. get_lane $k i == get_lane $value_low i *. (neg 3327s))"#);
+    hax_lib::fstar!(
+        r#"assert (forall i. get_lane $k i == get_lane $value_low i *. (neg (mk_i16 3327)))"#
+    );
 
     let modulus = mm256_set1_epi16(FIELD_MODULUS);
-    hax_lib::fstar!(r#"assert (forall i. get_lane $modulus i == 3329s)"#);
+    hax_lib::fstar!(r#"assert (forall i. get_lane $modulus i == (mk_i16 3329))"#);
 
     let k_times_modulus = mm256_mulhi_epi16(k, modulus);
     hax_lib::fstar!(
         r#"assert (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $k_times_modulus == 
-                        Spec.Utils.map2 (fun x y -> cast (((cast x <: i32) *. (cast y <: i32)) >>! 16l) <: i16)
+                        Spec.Utils.map2 (fun x y -> cast (((cast x <: i32) *. (cast y <: i32)) >>! (mk_i32 16)) <: i16)
                                 (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $k)
                                 (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $modulus));
                     assert (forall i. get_lane $k_times_modulus i == 
-                        (cast (((cast (get_lane $k i) <: i32) *. (cast (get_lane $modulus i) <: i32)) >>! 16l) <: i16))"#
+                        (cast (((cast (get_lane $k i) <: i32) *. (cast (get_lane $modulus i) <: i32)) >>! (mk_i32 16)) <: i16))"#
     );
 
     let value_high = mm256_mulhi_epi16(vec, constants);
     hax_lib::fstar!(
         r#"assert (forall i. get_lane $value_high i == 
-            (cast (((cast (get_lane $vec i) <: i32) *. (cast (get_lane $constants i) <: i32)) >>! 16l) <: i16))"#
+            (cast (((cast (get_lane $vec i) <: i32) *. (cast (get_lane $constants i) <: i32)) >>! (mk_i32 16)) <: i16))"#
     );
 
     let result = mm256_sub_epi16(value_high, k_times_modulus);
     hax_lib::fstar!(
         r#"Spec.Utils.lemma_range_at_percent 3329 (pow2 32);
-                    assert (v (cast 3329s <: i32) == (3329 @% pow2 32));
-                    assert (v (cast 3329s <: i32) == 3329);
-                    assert ((cast 3329s <: i32) == 3329l);
+                    assert (v (cast (mk_i16 3329) <: i32) == (3329 @% pow2 32));
+                    assert (v (cast (mk_i16 3329) <: i32) == 3329);
+                    assert ((cast (mk_i16 3329) <: i32) == (mk_i32 3329));
                     assert (forall i. get_lane $result i == (get_lane $value_high i) -. (get_lane $k_times_modulus i));
                     assert (forall i. get_lane $result i == Spec.Utils.mont_mul_red_i16 (get_lane $vec i) (get_lane $constants i));
                     assert (forall i. Spec.Utils.is_i16b 3328 (get_lane $result i));
@@ -328,34 +332,34 @@ pub(crate) fn montgomery_multiply_m128i_by_constants(vec: Vec128, constants: Vec
         mm_set1_epi16(INVERSE_OF_MODULUS_MOD_MONTGOMERY_R as i16),
     );
     hax_lib::fstar!(
-        "assert (forall i. get_lane128 $k i == get_lane128 $value_low i *. (neg 3327s))"
+        "assert (forall i. get_lane128 $k i == get_lane128 $value_low i *. (neg (mk_i16 3327)))"
     );
 
     let modulus = mm_set1_epi16(FIELD_MODULUS);
-    hax_lib::fstar!(r#"assert (forall i. get_lane128 $modulus i == 3329s)"#);
+    hax_lib::fstar!(r#"assert (forall i. get_lane128 $modulus i == (mk_i16 3329))"#);
 
     let k_times_modulus = mm_mulhi_epi16(k, modulus);
     hax_lib::fstar!(
         r#"assert (Libcrux_intrinsics.Avx2_extract.vec128_as_i16x8 $k_times_modulus == 
-                        Spec.Utils.map2 (fun x y -> cast (((cast x <: i32) *. (cast y <: i32)) >>! 16l) <: i16)
+                        Spec.Utils.map2 (fun x y -> cast (((cast x <: i32) *. (cast y <: i32)) >>! (mk_i32 16)) <: i16)
                                 (Libcrux_intrinsics.Avx2_extract.vec128_as_i16x8 $k)
                                 (Libcrux_intrinsics.Avx2_extract.vec128_as_i16x8 $modulus));
                     assert (forall i. get_lane128 $k_times_modulus i == 
-                        (cast (((cast (get_lane128 $k i) <: i32) *. (cast (get_lane128 $modulus i) <: i32)) >>! 16l) <: i16))"#
+                        (cast (((cast (get_lane128 $k i) <: i32) *. (cast (get_lane128 $modulus i) <: i32)) >>! (mk_i32 16)) <: i16))"#
     );
 
     let value_high = mm_mulhi_epi16(vec, constants);
     hax_lib::fstar!(
         r#"assert (forall i. get_lane128 $value_high i == 
-                        (cast (((cast (get_lane128 $vec i) <: i32) *. (cast (get_lane128 $constants i) <: i32)) >>! 16l) <: i16))"#
+                        (cast (((cast (get_lane128 $vec i) <: i32) *. (cast (get_lane128 $constants i) <: i32)) >>! (mk_i32 16)) <: i16))"#
     );
 
     let result = mm_sub_epi16(value_high, k_times_modulus);
     hax_lib::fstar!(
         r#"Spec.Utils.lemma_range_at_percent 3329 (pow2 32);
-                    assert (v (cast 3329s <: i32) == (3329 @% pow2 32));
-                    assert (v (cast 3329s <: i32) == 3329);
-                    assert ((cast 3329s <: i32) == 3329l);
+                    assert (v (cast (mk_i16 3329) <: i32) == (3329 @% pow2 32));
+                    assert (v (cast (mk_i16 3329) <: i32) == 3329);
+                    assert ((cast (mk_i16 3329) <: i32) == (mk_i32 3329));
                     assert (forall i. get_lane128 $result i == (get_lane128 $value_high i) -. (get_lane128 $k_times_modulus i));
                     assert (forall i. get_lane128 $result i == Spec.Utils.mont_mul_red_i16 (get_lane128 $vec i) (get_lane128 $constants i));
                     assert (forall i. Spec.Utils.is_i16b 3328 (get_lane128 $result i));

--- a/libcrux/libcrux-ml-kem/src/vector/avx2/compress.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/avx2/compress.rs
@@ -39,7 +39,7 @@ pub(crate) fn compress_message_coefficient(vector: Vec256) -> Vec256 {
 
 #[inline(always)]
 #[hax_lib::requires(fstar!(r#"v $COEFFICIENT_BITS >= 0 /\ v $COEFFICIENT_BITS < bits i32_inttype /\
-    range (v (1l <<! $COEFFICIENT_BITS) - 1) i32_inttype"#))]
+    range (v ((mk_i32 1) <<! $COEFFICIENT_BITS) - 1) i32_inttype"#))]
 pub(crate) fn compress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(
     vector: Vec256,
 ) -> Vec256 {

--- a/libcrux/libcrux-ml-kem/src/vector/avx2/sampling.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/avx2/sampling.rs
@@ -34,12 +34,12 @@ pub(crate) fn rejection_sample(input: &[u8], output: &mut [i16]) -> usize {
     hax_lib::fstar!(
         r#"assert (v (cast (${good}.[ sz 0 ] <: u8) <: usize) < 256);
         assert (v (cast (${good}.[ sz 1 ] <: u8) <: usize) < 256);
-        // We need to provide a definition or post-condition for Core.Num.impl__u8__count_ones
-        assume (v (cast (Core.Num.impl__u8__count_ones ${good}.[ sz 0 ]) <: usize) <= 8);
-        assume (v (cast (Core.Num.impl__u8__count_ones ${good}.[ sz 1 ]) <: usize) <= 8);
+        // We need to provide a definition or post-condition for ${u8::count_ones}
+        assume (v (cast (${u8::count_ones} ${good}.[ sz 0 ]) <: usize) <= 8);
+        assume (v (cast (${u8::count_ones} ${good}.[ sz 1 ]) <: usize) <= 8);
         assume (Core.Ops.Index.f_index_pre output ({
-                    Core.Ops.Range.f_start = cast (Core.Num.impl__u8__count_ones ${good}.[ sz 0 ]) <: usize;
-                    Core.Ops.Range.f_end = (cast (Core.Num.impl__u8__count_ones ${good}.[ sz 0 ]) <: usize) +! sz 8 }))"#
+                    Core.Ops.Range.f_start = cast (${u8::count_ones} ${good}.[ sz 0 ]) <: usize;
+                    Core.Ops.Range.f_end = (cast (${u8::count_ones} ${good}.[ sz 0 ]) <: usize) +! sz 8 }))"#
     );
 
     // Each bit (and its corresponding position) represents an element we

--- a/libcrux/libcrux-ml-kem/src/vector/avx2/serialize.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/avx2/serialize.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::vector::portable::PortableVector;
 
 #[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
 #[hax_lib::fstar::options("--ext context_pruning --compat_pre_core 0")]
 #[hax_lib::requires(fstar!(r#"forall i. i % 16 >= 1 ==> vector i == 0"#))]
 #[hax_lib::ensures(|result| fstar!(r#"forall i. bit_vec_of_int_t_array $result 8 i == $vector (i * 16)"#))]
@@ -67,7 +68,7 @@ let bits_packed' = BitVec.Intrinsics.mm_movemask_epi8_bv msbs in
 
     hax_lib::fstar!(
         r#"
-assert (forall (i: nat {i < 8}). get_bit ($bits_packed >>! 8l <: i32) (sz i) == get_bit $bits_packed (sz (i + 8)))
+assert (forall (i: nat {i < 8}). get_bit ($bits_packed >>! (mk_i32 8) <: i32) (sz i) == get_bit $bits_packed (sz (i + 8)))
 "#
     );
 

--- a/libcrux/libcrux-ml-kem/src/vector/neon.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/neon.rs
@@ -32,8 +32,8 @@ impl Operations for SIMD128Vector {
 
     #[requires(array.len() == 16)]
     #[ensures(|out| fstar!(r#"impl.f_repr out == $array"#))]
-    fn from_i16_array(array: &[i16]) -> Self {
-        from_i16_array(array)
+    fn from_i16_array(array: &[i16], out: &mut Self) {
+        from_i16_array(array, out)
     }
 
     #[ensures(|out| fstar!(r#"out == impl.f_repr $x"#))]

--- a/libcrux/libcrux-ml-kem/src/vector/neon.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/neon.rs
@@ -25,7 +25,7 @@ impl crate::vector::traits::Repr for SIMD128Vector {
 #[hax_lib::attributes]
 impl Operations for SIMD128Vector {
     #[inline(always)]
-    #[ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 0s"#))]
+    #[ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 (mk_i16 0)"#))]
     fn ZERO() -> Self {
         ZERO()
     }
@@ -39,6 +39,16 @@ impl Operations for SIMD128Vector {
     #[ensures(|out| fstar!(r#"out == impl.f_repr $x"#))]
     fn to_i16_array(x: Self) -> [i16; 16] {
         to_i16_array(x)
+    }
+
+    #[requires(array.len() >= 32)]
+    fn from_bytes(array: &[u8]) -> Self {
+        from_bytes(array)
+    }
+
+    #[requires(bytes.len() >= 32)]
+    fn to_bytes(x: Self, bytes: &mut [u8]) {
+        to_bytes(x, bytes)
     }
 
     fn add(lhs: Self, rhs: &Self) -> Self {

--- a/libcrux/libcrux-ml-kem/src/vector/neon/vector_type.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/neon/vector_type.rs
@@ -20,11 +20,9 @@ pub(crate) fn to_i16_array(v: SIMD128Vector) -> [i16; 16] {
 #[inline(always)]
 #[hax_lib::fstar::verification_status(panic_free)]
 #[hax_lib::ensures(|result| fstar!("repr ${result} == $array"))]
-pub(crate) fn from_i16_array(array: &[i16]) -> SIMD128Vector {
-    SIMD128Vector {
-        low: _vld1q_s16(&array[0..8]),
-        high: _vld1q_s16(&array[8..16]),
-    }
+pub(crate) fn from_i16_array(array: &[i16], out: &mut SIMD128Vector) {
+    out.low = _vld1q_s16(&array[0..8]);
+    out.high = _vld1q_s16(&array[8..16]);
 }
 
 #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/vector/neon/vector_type.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/neon/vector_type.rs
@@ -27,10 +27,26 @@ pub(crate) fn from_i16_array(array: &[i16]) -> SIMD128Vector {
     }
 }
 
+#[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
+pub(crate) fn to_bytes(v: SIMD128Vector, bytes: &mut [u8]) {
+    _vst1q_bytes(&mut bytes[0..16], v.low);
+    _vst1q_bytes(&mut bytes[16..32], v.high);
+}
+
+#[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
+pub(crate) fn from_bytes(array: &[u8]) -> SIMD128Vector {
+    SIMD128Vector {
+        low: _vld1q_bytes(&array[0..16]),
+        high: _vld1q_bytes(&array[16..32]),
+    }
+}
+
 #[allow(non_snake_case)]
 #[inline(always)]
 #[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::ensures(|result| fstar!("repr result == Seq.create 16 0s"))]
+#[hax_lib::ensures(|result| fstar!("repr result == Seq.create 16 (mk_i16 0)"))]
 pub(crate) fn ZERO() -> SIMD128Vector {
     SIMD128Vector {
         low: _vdupq_n_s16(0),

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -158,7 +158,7 @@ impl Operations for PortableVector {
     fn negate(vec: &mut Self) {
         negate(vec)
     }
-    
+
     #[requires(fstar!(r#"forall i. i < 16 ==> 
         Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${vec}.f_elements i) * v c)"#))]
     #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -16,93 +16,95 @@ pub(crate) use vector_type::PortableVector;
 
 impl crate::vector::traits::Repr for PortableVector {
     fn repr(x: Self) -> [i16; 16] {
-        to_i16_array(x)
+        let mut out = [0i16; 16];
+        to_i16_array(x, &mut out);
+        out
     }
 }
 
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a)"#))]
 #[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a) ==> 
                                  Spec.MLKEM.serialize_post 1 (impl.f_repr $a) $out"#))]
-fn serialize_1(a: PortableVector) -> [u8; 2] {
+fn serialize_1(a: PortableVector, out: &mut [u8]) {
     hax_lib::fstar!(
         r#"assert (forall i. Rust_primitives.bounded (Seq.index ${a}.f_elements i) 1)"#
     );
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.serialize_1_lemma $a"#);
-    serialize::serialize_1(a)
+    serialize::serialize_1(a, out)
 }
 
 #[hax_lib::requires(a.len() == 2)]
 #[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $a (impl.f_repr $out)"#))]
-fn deserialize_1(a: &[u8]) -> PortableVector {
+fn deserialize_1(a: &[u8], out: &mut PortableVector) {
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.deserialize_1_lemma $a"#);
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.deserialize_1_bounded_lemma $a"#);
-    serialize::deserialize_1(a)
+    serialize::deserialize_1(a, out)
 }
 
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a)"#))]
 #[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 4 (impl.f_repr $a) $out"#))]
-fn serialize_4(a: PortableVector) -> [u8; 8] {
+fn serialize_4(a: PortableVector, out: &mut [u8]) {
     hax_lib::fstar!(
         r#"assert (forall i. Rust_primitives.bounded (Seq.index ${a}.f_elements i) 4)"#
     );
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.serialize_4_lemma $a"#);
-    serialize::serialize_4(a)
+    serialize::serialize_4(a, out)
 }
 
 #[hax_lib::requires(a.len() == 8)]
 #[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $a (impl.f_repr $out)"#))]
-fn deserialize_4(a: &[u8]) -> PortableVector {
+fn deserialize_4(a: &[u8], out: &mut PortableVector) {
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.deserialize_4_lemma $a"#);
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.deserialize_4_bounded_lemma $a"#);
-    serialize::deserialize_4(a)
+    serialize::deserialize_4(a, out)
 }
 
-fn serialize_5(a: PortableVector) -> [u8; 10] {
-    serialize::serialize_5(a)
+fn serialize_5(a: PortableVector, out: &mut [u8]) {
+    serialize::serialize_5(a, out)
 }
 
 #[hax_lib::requires(a.len() == 10)]
-fn deserialize_5(a: &[u8]) -> PortableVector {
-    serialize::deserialize_5(a)
+fn deserialize_5(a: &[u8], out: &mut PortableVector) {
+    serialize::deserialize_5(a, out)
 }
 
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a)"#))]
 #[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 10 (impl.f_repr $a) $out"#))]
-fn serialize_10(a: PortableVector) -> [u8; 20] {
+fn serialize_10(a: PortableVector, out: &mut [u8]) {
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.serialize_10_lemma $a"#);
-    serialize::serialize_10(a)
+    serialize::serialize_10(a, out)
 }
 
 #[hax_lib::requires(a.len() == 20)]
 #[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $a (impl.f_repr $out)"#))]
-fn deserialize_10(a: &[u8]) -> PortableVector {
+fn deserialize_10(a: &[u8], out: &mut PortableVector) {
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.deserialize_10_lemma $a"#);
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.deserialize_10_bounded_lemma $a"#);
-    serialize::deserialize_10(a)
+    serialize::deserialize_10(a, out)
 }
 
-fn serialize_11(a: PortableVector) -> [u8; 22] {
-    serialize::serialize_11(a)
+fn serialize_11(a: PortableVector, out: &mut [u8]) {
+    serialize::serialize_11(a, out)
 }
 
 #[hax_lib::requires(a.len() == 22)]
-fn deserialize_11(a: &[u8]) -> PortableVector {
-    serialize::deserialize_11(a)
+fn deserialize_11(a: &[u8], out: &mut PortableVector) {
+    serialize::deserialize_11(a, out)
 }
 
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a)"#))]
 #[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 12 (impl.f_repr $a) $out"#))]
-fn serialize_12(a: PortableVector) -> [u8; 24] {
+fn serialize_12(a: PortableVector, out: &mut [u8]) {
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.serialize_12_lemma $a"#);
-    serialize::serialize_12(a)
+    serialize::serialize_12(a, out)
 }
 
 #[hax_lib::requires(a.len() == 24)]
 #[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $a (impl.f_repr $out)"#))]
-fn deserialize_12(a: &[u8]) -> PortableVector {
+fn deserialize_12(a: &[u8], out: &mut PortableVector) {
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.deserialize_12_lemma $a"#);
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.deserialize_12_bounded_lemma $a"#);
-    serialize::deserialize_12(a)
+    serialize::deserialize_12(a, out)
 }
 
 #[hax_lib::fstar::before(r#"#push-options "--z3rlimit 400 --split_queries always""#)]
@@ -116,18 +118,18 @@ impl Operations for PortableVector {
 
     #[requires(array.len() == 16)]
     #[ensures(|out| fstar!(r#"impl.f_repr out == $array"#))]
-    fn from_i16_array(array: &[i16]) -> Self {
-        from_i16_array(array)
+    fn from_i16_array(array: &[i16], out: &mut Self) {
+        from_i16_array(array, out)
     }
 
     #[ensures(|out| fstar!(r#"out == impl.f_repr $x"#))]
-    fn to_i16_array(x: Self) -> [i16; 16] {
-        to_i16_array(x)
+    fn to_i16_array(x: Self, out: &mut [i16; 16]) {
+        to_i16_array(x, out)
     }
 
     #[requires(array.len() >= 32)]
-    fn from_bytes(array: &[u8]) -> Self {
-        from_bytes(array)
+    fn from_bytes(array: &[u8], out: &mut Self) {
+        from_bytes(array, out)
     }
 
     #[requires(bytes.len() >= 32)]
@@ -140,7 +142,7 @@ impl Operations for PortableVector {
     #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index ${result}.f_elements i) == 
          v (Seq.index ${lhs}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"#))]
-    fn add(lhs: Self, rhs: &Self) -> Self {
+    fn add(lhs: &mut Self, rhs: &Self) {
         add(lhs, rhs)
     }
 
@@ -149,50 +151,54 @@ impl Operations for PortableVector {
     #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index ${result}.f_elements i) == 
          v (Seq.index ${lhs}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"#))]
-    fn sub(lhs: Self, rhs: &Self) -> Self {
+    fn sub(lhs: &mut Self, rhs: &Self) {
         sub(lhs, rhs)
     }
 
+    fn negate(vec: &mut Self) {
+        negate(vec)
+    }
+    
     #[requires(fstar!(r#"forall i. i < 16 ==> 
         Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${vec}.f_elements i) * v c)"#))]
     #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index ${result}.f_elements i) == 
         v (Seq.index ${vec}.f_elements i) * v c)"#))]
-    fn multiply_by_constant(vec: Self, c: i16) -> Self {
+    fn multiply_by_constant(vec: &mut Self, c: i16) {
         multiply_by_constant(vec, c)
     }
 
     #[ensures(|out| fstar!(r#"impl.f_repr out == Spec.Utils.map_array (fun x -> x &. c) (impl.f_repr $v)"#))]
-    fn bitwise_and_with_constant(v: Self, c: i16) -> Self {
+    fn bitwise_and_with_constant(v: &mut Self, c: i16) {
         bitwise_and_with_constant(v, c)
     }
 
     #[requires(SHIFT_BY >= 0 && SHIFT_BY < 16)]
     #[ensures(|out| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> impl.f_repr out == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (impl.f_repr $v)"#))]
-    fn shift_right<const SHIFT_BY: i32>(v: Self) -> Self {
+    fn shift_right<const SHIFT_BY: i32>(v: &mut Self) {
         shift_right::<{ SHIFT_BY }>(v)
     }
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (impl.f_repr $v)"#))]
     #[ensures(|out| fstar!(r#"impl.f_repr out == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (impl.f_repr $v)"#))]
-    fn cond_subtract_3329(v: Self) -> Self {
+    fn cond_subtract_3329(v: &mut Self) {
         cond_subtract_3329(v)
     }
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b_array 28296 (impl.f_repr ${v})"#))]
-    fn barrett_reduce(v: Self) -> Self {
+    fn barrett_reduce(v: &mut Self) {
         barrett_reduce(v)
     }
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 $r"#))]
-    fn montgomery_multiply_by_constant(v: Self, r: i16) -> Self {
+    fn montgomery_multiply_by_constant(v: &mut Self, r: i16) {
         montgomery_multiply_by_constant(v, r)
     }
 
     #[requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (impl.f_repr $a) i) >= 0 /\
         v (Seq.index (impl.f_repr $a) i) < 3329"#))]
     #[ensures(|out| fstar!(r#"forall (i:nat). i < 16 ==> bounded (Seq.index (impl.f_repr $out) i) 1"#))]
-    fn compress_1(a: Self) -> Self {
+    fn compress_1(a: &mut Self) {
         compress_1(a)
     }
 
@@ -207,7 +213,7 @@ impl Operations for PortableVector {
             v $COEFFICIENT_BITS == 10 \/
             v $COEFFICIENT_BITS == 11) ==>
                 (forall (i:nat). i < 16 ==> bounded (Seq.index (impl.f_repr $out) i) (v $COEFFICIENT_BITS))"#))]
-    fn compress<const COEFFICIENT_BITS: i32>(a: Self) -> Self {
+    fn compress<const COEFFICIENT_BITS: i32>(a: &mut Self) {
         compress::<COEFFICIENT_BITS>(a)
     }
 
@@ -217,7 +223,7 @@ impl Operations for PortableVector {
         v $COEFFICIENT_BITS == 11) /\
     (forall (i:nat). i < 16 ==> v (Seq.index (impl.f_repr $a) i) >= 0 /\
         v (Seq.index (impl.f_repr $a) i) < pow2 (v $COEFFICIENT_BITS))"#))]
-    fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(a: Self) -> Self {
+    fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(a: &mut Self) {
         decompress_ciphertext_coefficient::<COEFFICIENT_BITS>(a)
     }
 
@@ -225,21 +231,21 @@ impl Operations for PortableVector {
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3  /\
                        Spec.Utils.is_i16b_array (11207+5*3328) (impl.f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) (impl.f_repr $out)"#))]
-    fn ntt_layer_1_step(a: Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) -> Self {
+    fn ntt_layer_1_step(a: &mut Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) {
         ntt_layer_1_step(a, zeta0, zeta1, zeta2, zeta3)
     }
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                        Spec.Utils.is_i16b_array (11207+4*3328) (impl.f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) (impl.f_repr $out)"#))]
-    fn ntt_layer_2_step(a: Self, zeta0: i16, zeta1: i16) -> Self {
+    fn ntt_layer_2_step(a: &mut Self, zeta0: i16, zeta1: i16) {
         ntt_layer_2_step(a, zeta0, zeta1)
     }
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
                        Spec.Utils.is_i16b_array (11207+3*3328) (impl.f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) (impl.f_repr $out)"#))]
-    fn ntt_layer_3_step(a: Self, zeta: i16) -> Self {
+    fn ntt_layer_3_step(a: &mut Self, zeta: i16) {
         ntt_layer_3_step(a, zeta)
     }
 
@@ -247,21 +253,21 @@ impl Operations for PortableVector {
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
                        Spec.Utils.is_i16b_array (4*3328) (impl.f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
-    fn inv_ntt_layer_1_step(a: Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) -> Self {
+    fn inv_ntt_layer_1_step(a: &mut Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) {
         inv_ntt_layer_1_step(a, zeta0, zeta1, zeta2, zeta3)
     }
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                        Spec.Utils.is_i16b_array 3328 (impl.f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
-    fn inv_ntt_layer_2_step(a: Self, zeta0: i16, zeta1: i16) -> Self {
+    fn inv_ntt_layer_2_step(a: &mut Self, zeta0: i16, zeta1: i16) {
         inv_ntt_layer_2_step(a, zeta0, zeta1)
     }
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
                        Spec.Utils.is_i16b_array 3328 (impl.f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
-    fn inv_ntt_layer_3_step(a: Self, zeta: i16) -> Self {
+    fn inv_ntt_layer_3_step(a: &mut Self, zeta: i16) {
         inv_ntt_layer_3_step(a, zeta)
     }
 
@@ -273,78 +279,79 @@ impl Operations for PortableVector {
     fn ntt_multiply(
         lhs: &Self,
         rhs: &Self,
+        out: &mut Self,
         zeta0: i16,
         zeta1: i16,
         zeta2: i16,
         zeta3: i16,
-    ) -> Self {
-        ntt_multiply(lhs, rhs, zeta0, zeta1, zeta2, zeta3)
+    ) {
+        ntt_multiply(lhs, rhs, out, zeta0, zeta1, zeta2, zeta3)
     }
 
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a)"#))]
     #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 1 (impl.f_repr $a) $out"#))]
-    fn serialize_1(a: Self) -> [u8; 2] {
-        serialize_1(a)
+    fn serialize_1(a: Self, out: &mut [u8]) {
+        serialize_1(a, out)
     }
 
     #[requires(a.len() == 2)]
     #[ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $a (impl.f_repr $out)"#))]
-    fn deserialize_1(a: &[u8]) -> Self {
-        deserialize_1(a)
+    fn deserialize_1(a: &[u8], out: &mut Self) {
+        deserialize_1(a, out)
     }
 
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a)"#))]
     #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 4 (impl.f_repr $a) $out"#))]
-    fn serialize_4(a: Self) -> [u8; 8] {
-        serialize_4(a)
+    fn serialize_4(a: Self, out: &mut [u8]) {
+        serialize_4(a, out)
     }
 
     #[requires(a.len() == 8)]
     #[ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $a (impl.f_repr $out)"#))]
-    fn deserialize_4(a: &[u8]) -> Self {
-        deserialize_4(a)
+    fn deserialize_4(a: &[u8], out: &mut Self) {
+        deserialize_4(a, out)
     }
 
-    fn serialize_5(a: Self) -> [u8; 10] {
-        serialize_5(a)
+    fn serialize_5(a: Self, out: &mut [u8]) {
+        serialize_5(a, out)
     }
 
     #[requires(a.len() == 10)]
-    fn deserialize_5(a: &[u8]) -> Self {
-        deserialize_5(a)
+    fn deserialize_5(a: &[u8], out: &mut Self) {
+        deserialize_5(a, out)
     }
 
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a)"#))]
     #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 10 (impl.f_repr $a) $out"#))]
-    fn serialize_10(a: Self) -> [u8; 20] {
-        serialize_10(a)
+    fn serialize_10(a: Self, out: &mut [u8]) {
+        serialize_10(a, out)
     }
 
     #[requires(a.len() == 20)]
     #[ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $a (impl.f_repr $out)"#))]
-    fn deserialize_10(a: &[u8]) -> Self {
-        deserialize_10(a)
+    fn deserialize_10(a: &[u8], out: &mut Self) {
+        deserialize_10(a, out)
     }
 
-    fn serialize_11(a: Self) -> [u8; 22] {
-        serialize_11(a)
+    fn serialize_11(a: Self, out: &mut [u8]) {
+        serialize_11(a, out)
     }
 
     #[requires(a.len() == 22)]
-    fn deserialize_11(a: &[u8]) -> Self {
-        deserialize_11(a)
+    fn deserialize_11(a: &[u8], out: &mut Self) {
+        deserialize_11(a, out)
     }
 
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a)"#))]
     #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 12 (impl.f_repr $a) $out"#))]
-    fn serialize_12(a: Self) -> [u8; 24] {
-        serialize_12(a)
+    fn serialize_12(a: Self, out: &mut [u8]) {
+        serialize_12(a, out)
     }
 
     #[requires(a.len() == 24)]
     #[ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $a (impl.f_repr $out)"#))]
-    fn deserialize_12(a: &[u8]) -> Self {
-        deserialize_12(a)
+    fn deserialize_12(a: &[u8], out: &mut Self) {
+        deserialize_12(a, out)
     }
 
     #[requires(a.len() == 24 && out.len() == 16)]

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -109,7 +109,7 @@ fn deserialize_12(a: &[u8]) -> PortableVector {
 #[hax_lib::fstar::after(r#"#pop-options"#)]
 #[hax_lib::attributes]
 impl Operations for PortableVector {
-    #[ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 0s"#))]
+    #[ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 (mk_i16 0)"#))]
     fn ZERO() -> Self {
         zero()
     }
@@ -123,6 +123,16 @@ impl Operations for PortableVector {
     #[ensures(|out| fstar!(r#"out == impl.f_repr $x"#))]
     fn to_i16_array(x: Self) -> [i16; 16] {
         to_i16_array(x)
+    }
+
+    #[requires(array.len() >= 32)]
+    fn from_bytes(array: &[u8]) -> Self {
+        from_bytes(array)
+    }
+
+    #[requires(bytes.len() >= 32)]
+    fn to_bytes(x: Self, bytes: &mut [u8]) {
+        to_bytes(x, bytes)
     }
 
     #[requires(fstar!(r#"forall i. i < 16 ==> 
@@ -158,13 +168,13 @@ impl Operations for PortableVector {
     }
 
     #[requires(SHIFT_BY >= 0 && SHIFT_BY < 16)]
-    #[ensures(|out| fstar!(r#"(v_SHIFT_BY >=. 0l /\ v_SHIFT_BY <. 16l) ==> impl.f_repr out == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (impl.f_repr $v)"#))]
+    #[ensures(|out| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> impl.f_repr out == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (impl.f_repr $v)"#))]
     fn shift_right<const SHIFT_BY: i32>(v: Self) -> Self {
         shift_right::<{ SHIFT_BY }>(v)
     }
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (impl.f_repr $v)"#))]
-    #[ensures(|out| fstar!(r#"impl.f_repr out == Spec.Utils.map_array (fun x -> if x >=. 3329s then x -! 3329s else x) (impl.f_repr $v)"#))]
+    #[ensures(|out| fstar!(r#"impl.f_repr out == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (impl.f_repr $v)"#))]
     fn cond_subtract_3329(v: Self) -> Self {
         cond_subtract_3329(v)
     }

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -22,6 +22,7 @@ impl crate::vector::traits::Repr for PortableVector {
     }
 }
 
+#[inline(always)]
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a)"#))]
 #[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a) ==> 
                                  Spec.MLKEM.serialize_post 1 (impl.f_repr $a) $out"#))]
@@ -33,6 +34,7 @@ fn serialize_1(a: PortableVector, out: &mut [u8]) {
     serialize::serialize_1(a, out)
 }
 
+#[inline(always)]
 #[hax_lib::requires(a.len() == 2)]
 #[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $a (impl.f_repr $out)"#))]
 fn deserialize_1(a: &[u8], out: &mut PortableVector) {
@@ -41,6 +43,7 @@ fn deserialize_1(a: &[u8], out: &mut PortableVector) {
     serialize::deserialize_1(a, out)
 }
 
+#[inline(always)]
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a)"#))]
 #[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 4 (impl.f_repr $a) $out"#))]
 fn serialize_4(a: PortableVector, out: &mut [u8]) {
@@ -51,6 +54,7 @@ fn serialize_4(a: PortableVector, out: &mut [u8]) {
     serialize::serialize_4(a, out)
 }
 
+#[inline(always)]
 #[hax_lib::requires(a.len() == 8)]
 #[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $a (impl.f_repr $out)"#))]
 fn deserialize_4(a: &[u8], out: &mut PortableVector) {
@@ -59,15 +63,18 @@ fn deserialize_4(a: &[u8], out: &mut PortableVector) {
     serialize::deserialize_4(a, out)
 }
 
+#[inline(always)]
 fn serialize_5(a: PortableVector, out: &mut [u8]) {
     serialize::serialize_5(a, out)
 }
 
+#[inline(always)]
 #[hax_lib::requires(a.len() == 10)]
 fn deserialize_5(a: &[u8], out: &mut PortableVector) {
     serialize::deserialize_5(a, out)
 }
 
+#[inline(always)]
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a)"#))]
 #[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 10 (impl.f_repr $a) $out"#))]
 fn serialize_10(a: PortableVector, out: &mut [u8]) {
@@ -75,6 +82,7 @@ fn serialize_10(a: PortableVector, out: &mut [u8]) {
     serialize::serialize_10(a, out)
 }
 
+#[inline(always)]
 #[hax_lib::requires(a.len() == 20)]
 #[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $a (impl.f_repr $out)"#))]
 fn deserialize_10(a: &[u8], out: &mut PortableVector) {
@@ -83,15 +91,18 @@ fn deserialize_10(a: &[u8], out: &mut PortableVector) {
     serialize::deserialize_10(a, out)
 }
 
+#[inline(always)]
 fn serialize_11(a: PortableVector, out: &mut [u8]) {
     serialize::serialize_11(a, out)
 }
 
+#[inline(always)]
 #[hax_lib::requires(a.len() == 22)]
 fn deserialize_11(a: &[u8], out: &mut PortableVector) {
     serialize::deserialize_11(a, out)
 }
 
+#[inline(always)]
 #[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a)"#))]
 #[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 12 (impl.f_repr $a) $out"#))]
 fn serialize_12(a: PortableVector, out: &mut [u8]) {
@@ -99,6 +110,7 @@ fn serialize_12(a: PortableVector, out: &mut [u8]) {
     serialize::serialize_12(a, out)
 }
 
+#[inline(always)]
 #[hax_lib::requires(a.len() == 24)]
 #[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $a (impl.f_repr $out)"#))]
 fn deserialize_12(a: &[u8], out: &mut PortableVector) {
@@ -111,32 +123,38 @@ fn deserialize_12(a: &[u8], out: &mut PortableVector) {
 #[hax_lib::fstar::after(r#"#pop-options"#)]
 #[hax_lib::attributes]
 impl Operations for PortableVector {
+    #[inline(always)]
     #[ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 (mk_i16 0)"#))]
     fn ZERO() -> Self {
         zero()
     }
 
+    #[inline(always)]
     #[requires(array.len() == 16)]
     #[ensures(|out| fstar!(r#"impl.f_repr out == $array"#))]
     fn from_i16_array(array: &[i16], out: &mut Self) {
         from_i16_array(array, out)
     }
 
+    #[inline(always)]
     #[ensures(|out| fstar!(r#"out == impl.f_repr $x"#))]
     fn to_i16_array(x: Self, out: &mut [i16; 16]) {
         to_i16_array(x, out)
     }
 
+    #[inline(always)]
     #[requires(array.len() >= 32)]
     fn from_bytes(array: &[u8], out: &mut Self) {
         from_bytes(array, out)
     }
 
+    #[inline(always)]
     #[requires(bytes.len() >= 32)]
     fn to_bytes(x: Self, bytes: &mut [u8]) {
         to_bytes(x, bytes)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"forall i. i < 16 ==> 
         Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${lhs}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"#))]
     #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
@@ -146,6 +164,7 @@ impl Operations for PortableVector {
         add(lhs, rhs)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"forall i. i < 16 ==> 
         Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${lhs}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"#))]
     #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
@@ -154,11 +173,13 @@ impl Operations for PortableVector {
     fn sub(lhs: &mut Self, rhs: &Self) {
         sub(lhs, rhs)
     }
-
+    
+    #[inline(always)]
     fn negate(vec: &mut Self) {
         negate(vec)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"forall i. i < 16 ==> 
         Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${vec}.f_elements i) * v c)"#))]
     #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
@@ -168,33 +189,39 @@ impl Operations for PortableVector {
         multiply_by_constant(vec, c)
     }
 
+    #[inline(always)]
     #[ensures(|out| fstar!(r#"impl.f_repr out == Spec.Utils.map_array (fun x -> x &. c) (impl.f_repr $v)"#))]
     fn bitwise_and_with_constant(v: &mut Self, c: i16) {
         bitwise_and_with_constant(v, c)
     }
 
+    #[inline(always)]
     #[requires(SHIFT_BY >= 0 && SHIFT_BY < 16)]
     #[ensures(|out| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> impl.f_repr out == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (impl.f_repr $v)"#))]
     fn shift_right<const SHIFT_BY: i32>(v: &mut Self) {
         shift_right::<{ SHIFT_BY }>(v)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (impl.f_repr $v)"#))]
     #[ensures(|out| fstar!(r#"impl.f_repr out == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (impl.f_repr $v)"#))]
     fn cond_subtract_3329(v: &mut Self) {
         cond_subtract_3329(v)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.Utils.is_i16b_array 28296 (impl.f_repr ${v})"#))]
     fn barrett_reduce(v: &mut Self) {
         barrett_reduce(v)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 $r"#))]
     fn montgomery_multiply_by_constant(v: &mut Self, r: i16) {
         montgomery_multiply_by_constant(v, r)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (impl.f_repr $a) i) >= 0 /\
         v (Seq.index (impl.f_repr $a) i) < 3329"#))]
     #[ensures(|out| fstar!(r#"forall (i:nat). i < 16 ==> bounded (Seq.index (impl.f_repr $out) i) 1"#))]
@@ -202,6 +229,7 @@ impl Operations for PortableVector {
         compress_1(a)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
             v $COEFFICIENT_BITS == 5 \/
             v $COEFFICIENT_BITS == 10 \/
@@ -217,6 +245,7 @@ impl Operations for PortableVector {
         compress::<COEFFICIENT_BITS>(a)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
         v $COEFFICIENT_BITS == 5 \/
         v $COEFFICIENT_BITS == 10 \/
@@ -227,6 +256,7 @@ impl Operations for PortableVector {
         decompress_ciphertext_coefficient::<COEFFICIENT_BITS>(a)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3  /\
                        Spec.Utils.is_i16b_array (11207+5*3328) (impl.f_repr ${a})"#))]
@@ -235,6 +265,7 @@ impl Operations for PortableVector {
         ntt_layer_1_step(a, zeta0, zeta1, zeta2, zeta3)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                        Spec.Utils.is_i16b_array (11207+4*3328) (impl.f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) (impl.f_repr $out)"#))]
@@ -242,6 +273,7 @@ impl Operations for PortableVector {
         ntt_layer_2_step(a, zeta0, zeta1)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
                        Spec.Utils.is_i16b_array (11207+3*3328) (impl.f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) (impl.f_repr $out)"#))]
@@ -249,6 +281,7 @@ impl Operations for PortableVector {
         ntt_layer_3_step(a, zeta)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
                        Spec.Utils.is_i16b_array (4*3328) (impl.f_repr ${a})"#))]
@@ -257,6 +290,7 @@ impl Operations for PortableVector {
         inv_ntt_layer_1_step(a, zeta0, zeta1, zeta2, zeta3)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                        Spec.Utils.is_i16b_array 3328 (impl.f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
@@ -264,6 +298,7 @@ impl Operations for PortableVector {
         inv_ntt_layer_2_step(a, zeta0, zeta1)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
                        Spec.Utils.is_i16b_array 3328 (impl.f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
@@ -271,6 +306,7 @@ impl Operations for PortableVector {
         inv_ntt_layer_3_step(a, zeta)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
                        Spec.Utils.is_i16b_array 3328 (impl.f_repr ${lhs}) /\
@@ -288,72 +324,85 @@ impl Operations for PortableVector {
         ntt_multiply(lhs, rhs, out, zeta0, zeta1, zeta2, zeta3)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a)"#))]
     #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 1 (impl.f_repr $a) $out"#))]
     fn serialize_1(a: Self, out: &mut [u8]) {
         serialize_1(a, out)
     }
 
+    #[inline(always)]
     #[requires(a.len() == 2)]
     #[ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $a (impl.f_repr $out)"#))]
     fn deserialize_1(a: &[u8], out: &mut Self) {
         deserialize_1(a, out)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a)"#))]
     #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 4 (impl.f_repr $a) $out"#))]
     fn serialize_4(a: Self, out: &mut [u8]) {
         serialize_4(a, out)
     }
 
+    #[inline(always)]
     #[requires(a.len() == 8)]
     #[ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $a (impl.f_repr $out)"#))]
     fn deserialize_4(a: &[u8], out: &mut Self) {
         deserialize_4(a, out)
     }
 
+    #[inline(always)]
     fn serialize_5(a: Self, out: &mut [u8]) {
         serialize_5(a, out)
     }
 
+    #[inline(always)]
     #[requires(a.len() == 10)]
     fn deserialize_5(a: &[u8], out: &mut Self) {
         deserialize_5(a, out)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a)"#))]
     #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 10 (impl.f_repr $a) $out"#))]
     fn serialize_10(a: Self, out: &mut [u8]) {
         serialize_10(a, out)
     }
 
+    #[inline(always)]
     #[requires(a.len() == 20)]
     #[ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $a (impl.f_repr $out)"#))]
     fn deserialize_10(a: &[u8], out: &mut Self) {
         deserialize_10(a, out)
     }
 
+    #[inline(always)]
     fn serialize_11(a: Self, out: &mut [u8]) {
         serialize_11(a, out)
     }
-
+    
+    #[inline(always)]
     #[requires(a.len() == 22)]
     fn deserialize_11(a: &[u8], out: &mut Self) {
         deserialize_11(a, out)
     }
 
+    #[inline(always)]
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a)"#))]
     #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 12 (impl.f_repr $a) $out"#))]
     fn serialize_12(a: Self, out: &mut [u8]) {
         serialize_12(a, out)
     }
 
+    #[inline(always)]
     #[requires(a.len() == 24)]
     #[ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $a (impl.f_repr $out)"#))]
     fn deserialize_12(a: &[u8], out: &mut Self) {
         deserialize_12(a, out)
     }
 
+    #[inline(always)]
     #[requires(a.len() == 24 && out.len() == 16)]
     #[ensures(|result|
         fstar!(r#"Seq.length $out_future == Seq.length $out /\ v $result <= 16"#)

--- a/libcrux/libcrux-ml-kem/src/vector/portable/arithmetic.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/arithmetic.rs
@@ -98,7 +98,7 @@ pub fn sub(lhs: &mut PortableVector, rhs: &PortableVector) {
 }
 
 pub fn negate(vec: &mut PortableVector) {
-       for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+    for i in 0..FIELD_ELEMENTS_IN_VECTOR {
         vec.elements[i] = -vec.elements[i];
     }
 }

--- a/libcrux/libcrux-ml-kem/src/vector/portable/arithmetic.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/arithmetic.rs
@@ -30,8 +30,8 @@ pub(crate) fn get_n_least_significant_bits(n: u8, value: u32) -> u32 {
         "calc (==) {
     v res;
     (==) { }
-    v (logand value ((1ul <<! n) -! 1ul));
-    (==) {mk_int_equiv_lemma #u32_inttype 1} 
+    v (logand value (((mk_u32 1) <<! n) -! (mk_u32 1)));
+    (==) {} 
     v (logand value (((mk_int 1) <<! n) -! (mk_int 1)));
     (==) { }
     v (logand value (mk_int ((1 * pow2 (v n)) % pow2 32) -! (mk_int 1)));
@@ -146,7 +146,7 @@ pub fn bitwise_and_with_constant(mut vec: PortableVector, c: i16) -> PortableVec
 
 #[inline(always)]
 #[hax_lib::requires(SHIFT_BY >= 0 && SHIFT_BY < 16)]
-#[hax_lib::ensures(|result| fstar!(r#"(v_SHIFT_BY >=. 0l /\ v_SHIFT_BY <. 16l) ==> 
+#[hax_lib::ensures(|result| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> 
         ${result}.f_elements == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (${vec}.f_elements)"#))]
 pub fn shift_right<const SHIFT_BY: i32>(mut vec: PortableVector) -> PortableVector {
     let _vec0 = vec;
@@ -173,7 +173,7 @@ pub fn shift_right<const SHIFT_BY: i32>(mut vec: PortableVector) -> PortableVect
 #[hax_lib::fstar::options("--z3rlimit 300")]
 #[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) ${vec}.f_elements"#))]
 #[hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == Spec.Utils.map_array 
-                (fun x -> if x >=. 3329s then x -! 3329s else x) (${vec}.f_elements)"#))]
+                (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (${vec}.f_elements)"#))]
 pub fn cond_subtract_3329(mut vec: PortableVector) -> PortableVector {
     let _vec0 = vec;
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
@@ -182,7 +182,7 @@ pub fn cond_subtract_3329(mut vec: PortableVector) -> PortableVector {
                 r#"
               (forall j. j < v i ==> Seq.index ${vec}.f_elements j == 
                                      (let x = Seq.index ${_vec0}.f_elements j in
-                                      if x >=. 3329s then x -! 3329s else x)) /\
+                                      if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x)) /\
               (forall j. j >= v i ==> Seq.index ${vec}.f_elements j == Seq.index ${_vec0}.f_elements j)"#
             )
         });
@@ -192,7 +192,7 @@ pub fn cond_subtract_3329(mut vec: PortableVector) -> PortableVector {
     }
     hax_lib::fstar!(
         r#"Seq.lemma_eq_intro ${vec}.f_elements (Spec.Utils.map_array 
-                            (fun x -> if x >=. 3329s then x -! 3329s else x) ${_vec0}.f_elements)"#
+                            (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) ${_vec0}.f_elements)"#
     );
     vec
 }

--- a/libcrux/libcrux-ml-kem/src/vector/portable/arithmetic.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/arithmetic.rs
@@ -51,8 +51,9 @@ pub(crate) fn get_n_least_significant_bits(n: u8, value: u32) -> u32 {
 #[hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
     (v (Seq.index ${result}.f_elements i) == 
      v (Seq.index ${lhs}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"#))]
-pub fn add(mut lhs: PortableVector, rhs: &PortableVector) -> PortableVector {
-    let _lhs0 = lhs;
+pub fn add(lhs: &mut PortableVector, rhs: &PortableVector) {
+    #[cfg(hax)]
+    let _lhs0 = (*lhs).clone();
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
@@ -68,7 +69,6 @@ pub fn add(mut lhs: PortableVector, rhs: &PortableVector) -> PortableVector {
         "assert (forall i. v (Seq.index ${lhs}.f_elements i) ==
     			          v (Seq.index ${_lhs0}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"
     );
-    lhs
 }
 
 #[inline(always)]
@@ -77,8 +77,9 @@ pub fn add(mut lhs: PortableVector, rhs: &PortableVector) -> PortableVector {
 #[hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
     (v (Seq.index ${result}.f_elements i) == 
      v (Seq.index ${lhs}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"#))]
-pub fn sub(mut lhs: PortableVector, rhs: &PortableVector) -> PortableVector {
-    let _lhs0 = lhs;
+pub fn sub(lhs: &mut PortableVector, rhs: &PortableVector) {
+    #[cfg(hax)]
+    let _lhs0 = (*lhs).clone();
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
@@ -94,7 +95,12 @@ pub fn sub(mut lhs: PortableVector, rhs: &PortableVector) -> PortableVector {
         "assert (forall i. v (Seq.index ${lhs}.f_elements i) ==
     			          v (Seq.index ${_lhs0}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"
     );
-    lhs
+}
+
+pub fn negate(vec: &mut PortableVector) {
+       for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        vec.elements[i] = -vec.elements[i];
+    }
 }
 
 #[inline(always)]
@@ -103,8 +109,9 @@ pub fn sub(mut lhs: PortableVector, rhs: &PortableVector) -> PortableVector {
 #[hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
     (v (Seq.index ${result}.f_elements i) == 
      v (Seq.index ${vec}.f_elements i) * v c)"#))]
-pub fn multiply_by_constant(mut vec: PortableVector, c: i16) -> PortableVector {
-    let _vec0 = vec;
+pub fn multiply_by_constant(vec: &mut PortableVector, c: i16) {
+    #[cfg(hax)]
+    let _vec0 = (*vec).clone();
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
@@ -120,13 +127,13 @@ pub fn multiply_by_constant(mut vec: PortableVector, c: i16) -> PortableVector {
         "assert (forall i. v (Seq.index ${vec}.f_elements i) ==
     			          v (Seq.index ${_vec0}.f_elements i) * v c)"
     );
-    vec
 }
 
 #[inline(always)]
 #[hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == Spec.Utils.map_array (fun x -> x &. c) (${vec}.f_elements)"#))]
-pub fn bitwise_and_with_constant(mut vec: PortableVector, c: i16) -> PortableVector {
-    let _vec0 = vec;
+pub fn bitwise_and_with_constant(vec: &mut PortableVector, c: i16) {
+    #[cfg(hax)]
+    let _vec0 = (*vec).clone();
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
@@ -141,15 +148,15 @@ pub fn bitwise_and_with_constant(mut vec: PortableVector, c: i16) -> PortableVec
     hax_lib::fstar!(
         r#"Seq.lemma_eq_intro ${vec}.f_elements (Spec.Utils.map_array (fun x -> x &. c) ${_vec0}.f_elements)"#
     );
-    vec
 }
 
 #[inline(always)]
 #[hax_lib::requires(SHIFT_BY >= 0 && SHIFT_BY < 16)]
 #[hax_lib::ensures(|result| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> 
         ${result}.f_elements == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (${vec}.f_elements)"#))]
-pub fn shift_right<const SHIFT_BY: i32>(mut vec: PortableVector) -> PortableVector {
-    let _vec0 = vec;
+pub fn shift_right<const SHIFT_BY: i32>(vec: &mut PortableVector) {
+    #[cfg(hax)]
+    let _vec0 = (*vec).clone();
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
@@ -164,7 +171,6 @@ pub fn shift_right<const SHIFT_BY: i32>(mut vec: PortableVector) -> PortableVect
     hax_lib::fstar!(
         r#"Seq.lemma_eq_intro ${vec}.f_elements (Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) ${_vec0}.f_elements)"#
     );
-    vec
 }
 
 /// Note: This function is not secret independent
@@ -174,8 +180,9 @@ pub fn shift_right<const SHIFT_BY: i32>(mut vec: PortableVector) -> PortableVect
 #[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) ${vec}.f_elements"#))]
 #[hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == Spec.Utils.map_array 
                 (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (${vec}.f_elements)"#))]
-pub fn cond_subtract_3329(mut vec: PortableVector) -> PortableVector {
-    let _vec0 = vec;
+pub fn cond_subtract_3329(vec: &mut PortableVector) {
+    #[cfg(hax)]
+    let _vec0 = *(vec).clone();
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
@@ -194,7 +201,6 @@ pub fn cond_subtract_3329(mut vec: PortableVector) -> PortableVector {
         r#"Seq.lemma_eq_intro ${vec}.f_elements (Spec.Utils.map_array 
                             (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) ${_vec0}.f_elements)"#
     );
-    vec
 }
 
 /// Signed Barrett Reduction
@@ -247,8 +253,9 @@ pub(crate) fn barrett_reduce_element(value: FieldElement) -> FieldElement {
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 ${result}.f_elements /\
                 (forall i. (v (Seq.index ${result}.f_elements i) % 3329) == 
                            (v (Seq.index ${vec}.f_elements i) % 3329))"#)))]
-pub(crate) fn barrett_reduce(mut vec: PortableVector) -> PortableVector {
-    let _vec0 = vec;
+pub(crate) fn barrett_reduce(vec: &mut PortableVector) {
+    #[cfg(hax)]
+    let _vec0 = (*vec).clone();
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
@@ -269,7 +276,6 @@ pub(crate) fn barrett_reduce(mut vec: PortableVector) -> PortableVector {
                          assert (forall j. j < v i + 1 ==> Spec.Utils.is_i16b 3328 (Seq.index vec.f_elements j))"#
         );
     }
-    vec
 }
 
 /// Signed Montgomery Reduction
@@ -404,8 +410,9 @@ Spec.Utils.is_i16b_array 3328 ${result}.f_elements /\
 (forall i. i < 16 ==> 
     (v (Seq.index ${result}.f_elements i) % 3329 == 
        (v (Seq.index ${vec}.f_elements i) * v c * 169) %3329))"#)))]
-pub(crate) fn montgomery_multiply_by_constant(mut vec: PortableVector, c: i16) -> PortableVector {
-    let _vec0 = vec;
+pub(crate) fn montgomery_multiply_by_constant(vec: &mut PortableVector, c: i16) {
+    #[cfg(hax)]
+    let _vec0 = (*vec).clone();
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
@@ -419,5 +426,4 @@ pub(crate) fn montgomery_multiply_by_constant(mut vec: PortableVector, c: i16) -
         });
         vec.elements[i] = montgomery_multiply_fe_by_fer(vec.elements[i], c)
     }
-    vec
 }

--- a/libcrux/libcrux-ml-kem/src/vector/portable/arithmetic.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/arithmetic.rs
@@ -219,6 +219,7 @@ pub fn cond_subtract_3329(vec: &mut PortableVector) {
 #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 28296 value"#)))]
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b 3328 result /\
                 v result % 3329 == v value % 3329"#)))]
+#[inline(always)]
 pub(crate) fn barrett_reduce_element(value: FieldElement) -> FieldElement {
     let t = (i32::from(value) * BARRETT_MULTIPLIER) + (BARRETT_R >> 1);
     hax_lib::fstar!(
@@ -291,6 +292,7 @@ pub(crate) fn barrett_reduce(vec: &mut PortableVector) {
 /// In particular, if `|value| ≤ FIELD_MODULUS-1 * FIELD_MODULUS-1`, then `|o| <= FIELD_MODULUS-1`.
 /// And, if `|value| ≤ pow2 16 * FIELD_MODULUS-1`, then `|o| <= FIELD_MODULUS + 1664
 ///
+#[inline(always)]
 #[hax_lib::fstar::options("--z3rlimit 500 --split_queries always")]
 #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b (3328 * pow2 16) value "#)))]
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b (3328 + 1665) result /\

--- a/libcrux/libcrux-ml-kem/src/vector/portable/compress.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/compress.rs
@@ -135,7 +135,7 @@ let compress_message_coefficient_range_helper (fe: u16) : Lemma
     v (Seq.index ${a}.f_elements i) < 3329"#))]
 #[hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> v (${result}.f_elements.[ sz i ] <: i16) >= 0 /\
     v (${result}.f_elements.[ sz i ] <: i16) < 2"#))]
-pub(crate) fn compress_1(mut a: PortableVector) -> PortableVector {
+pub(crate) fn compress_1(a: &mut PortableVector) {
     hax_lib::fstar!(
         "assert (forall (i:nat). i < 16 ==> (cast (${a}.f_elements.[ sz i ]) <: u16) <.
         (cast ($FIELD_MODULUS) <: u16))"
@@ -163,7 +163,6 @@ pub(crate) fn compress_1(mut a: PortableVector) -> PortableVector {
         r#"assert (forall (i:nat). i < 16 ==> v (${a}.f_elements.[ sz i ] <: i16) >= 0 /\
         v (${a}.f_elements.[ sz i ] <: i16) < 2)"#
     );
-    a
 }
 
 #[inline(always)]
@@ -176,7 +175,7 @@ pub(crate) fn compress_1(mut a: PortableVector) -> PortableVector {
         v (Seq.index ${a}.f_elements i) < 3329)"#))]
 #[hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> v (${result}.f_elements.[ sz i ] <: i16) >= 0 /\
     v (${result}.f_elements.[ sz i ] <: i16) < pow2 (v $COEFFICIENT_BITS))"#))]
-pub(crate) fn compress<const COEFFICIENT_BITS: i32>(mut a: PortableVector) -> PortableVector {
+pub(crate) fn compress<const COEFFICIENT_BITS: i32>(a: &mut PortableVector) {
     hax_lib::fstar!(
         "assert (v (cast ($COEFFICIENT_BITS) <: u8) == v $COEFFICIENT_BITS);
         assert (v (cast ($COEFFICIENT_BITS) <: u32) == v $COEFFICIENT_BITS);
@@ -206,7 +205,6 @@ pub(crate) fn compress<const COEFFICIENT_BITS: i32>(mut a: PortableVector) -> Po
         r#"assert (forall (i:nat). i < 16 ==> v (${a}.f_elements.[ sz i ] <: i16) >= 0 /\
         v (${a}.f_elements.[ sz i ] <: i16) < pow2 (v $COEFFICIENT_BITS))"#
     );
-    a
 }
 
 #[inline(always)]
@@ -219,8 +217,8 @@ pub(crate) fn compress<const COEFFICIENT_BITS: i32>(mut a: PortableVector) -> Po
         v (Seq.index ${a}.f_elements i) < pow2 (v $COEFFICIENT_BITS))"#))]
 #[hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index ${result}.f_elements i) < v $FIELD_MODULUS"#))]
 pub(crate) fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(
-    mut a: PortableVector,
-) -> PortableVector {
+    a: &mut PortableVector,
+) {
     hax_lib::fstar!(
         "assert_norm (pow2 1 == 2);
         assert_norm (pow2 4 == 16);
@@ -269,6 +267,4 @@ pub(crate) fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(
         );
         a.elements[i] = decompressed as i16;
     }
-
-    a
 }

--- a/libcrux/libcrux-ml-kem/src/vector/portable/compress.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/compress.rs
@@ -25,10 +25,8 @@ use crate::vector::FIELD_MODULUS;
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
 #[cfg_attr(hax, hax_lib::requires(fe < (FIELD_MODULUS as u16)))]
-#[cfg_attr(hax, hax_lib::ensures(|result|
-        hax_lib::implies(833 <= fe && fe <= 2496, || result == 1) &&
-        hax_lib::implies(!(833 <= fe && fe <= 2496), || result == 0)
-))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"((833 <= v fe && v fe <= 2496) ==> v result == 1) /\
+						    (~(833 <=  v fe && v fe <= 2496) ==> v result == 0)"#)))]
 pub(crate) fn compress_message_coefficient(fe: u16) -> u8 {
     // The approach used here is inspired by:
     // https://github.com/cloudflare/circl/blob/main/pke/kyber/internal/common/poly.go#L150

--- a/libcrux/libcrux-ml-kem/src/vector/portable/compress.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/compress.rs
@@ -23,6 +23,7 @@ use crate::vector::FIELD_MODULUS;
 ///
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
+#[inline(always)]
 #[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
 #[cfg_attr(hax, hax_lib::requires(fe < (FIELD_MODULUS as u16)))]
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"((833 <= v fe && v fe <= 2496) ==> v result == 1) /\
@@ -85,6 +86,7 @@ pub(crate) fn compress_message_coefficient(fe: u16) -> u8 {
     res
 }
 
+#[inline(always)]
 #[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
 #[cfg_attr(hax,
     hax_lib::requires(

--- a/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
@@ -406,20 +406,20 @@ pub(crate) fn ntt_multiply(
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta0, 0,  out);
+    ntt_multiply_binomials(lhs, rhs, zeta0, 0, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta0, 1,  out);
+    ntt_multiply_binomials(lhs, rhs, nzeta0, 1, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta1, 2,  out);
+    ntt_multiply_binomials(lhs, rhs, zeta1, 2, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta1, 3,  out);
+    ntt_multiply_binomials(lhs, rhs, nzeta1, 3, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta2, 4,  out);
+    ntt_multiply_binomials(lhs, rhs, zeta2, 4, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta2, 5,  out);
+    ntt_multiply_binomials(lhs, rhs, nzeta2, 5, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta3, 6,  out);
+    ntt_multiply_binomials(lhs, rhs, zeta3, 6, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta3, 7,  out);
+    ntt_multiply_binomials(lhs, rhs, nzeta3, 7, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
 }

--- a/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
@@ -65,21 +65,20 @@ pub(crate) fn ntt_step(vec: &mut PortableVector, zeta: i16, i: usize, j: usize) 
                             Spec.Utils.is_i16b_array (11207+5*3328) ${vec}.f_elements"#))]
 #[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) ${result}.f_elements"#))]
 pub(crate) fn ntt_layer_1_step(
-    mut vec: PortableVector,
+    vec: &mut PortableVector,
     zeta0: i16,
     zeta1: i16,
     zeta2: i16,
     zeta3: i16,
-) -> PortableVector {
-    ntt_step(&mut vec, zeta0, 0, 2);
-    ntt_step(&mut vec, zeta0, 1, 3);
-    ntt_step(&mut vec, zeta1, 4, 6);
-    ntt_step(&mut vec, zeta1, 5, 7);
-    ntt_step(&mut vec, zeta2, 8, 10);
-    ntt_step(&mut vec, zeta2, 9, 11);
-    ntt_step(&mut vec, zeta3, 12, 14);
-    ntt_step(&mut vec, zeta3, 13, 15);
-    vec
+) {
+    ntt_step(vec, zeta0, 0, 2);
+    ntt_step(vec, zeta0, 1, 3);
+    ntt_step(vec, zeta1, 4, 6);
+    ntt_step(vec, zeta1, 5, 7);
+    ntt_step(vec, zeta2, 8, 10);
+    ntt_step(vec, zeta2, 9, 11);
+    ntt_step(vec, zeta3, 12, 14);
+    ntt_step(vec, zeta3, 13, 15);
 }
 
 #[inline(always)]
@@ -87,16 +86,15 @@ pub(crate) fn ntt_layer_1_step(
 #[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                             Spec.Utils.is_i16b_array (11207+4*3328) ${vec}.f_elements"#))]
 #[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) ${result}.f_elements"#))]
-pub(crate) fn ntt_layer_2_step(mut vec: PortableVector, zeta0: i16, zeta1: i16) -> PortableVector {
-    ntt_step(&mut vec, zeta0, 0, 4);
-    ntt_step(&mut vec, zeta0, 1, 5);
-    ntt_step(&mut vec, zeta0, 2, 6);
-    ntt_step(&mut vec, zeta0, 3, 7);
-    ntt_step(&mut vec, zeta1, 8, 12);
-    ntt_step(&mut vec, zeta1, 9, 13);
-    ntt_step(&mut vec, zeta1, 10, 14);
-    ntt_step(&mut vec, zeta1, 11, 15);
-    vec
+pub(crate) fn ntt_layer_2_step(vec: &mut PortableVector, zeta0: i16, zeta1: i16) {
+    ntt_step(vec, zeta0, 0, 4);
+    ntt_step(vec, zeta0, 1, 5);
+    ntt_step(vec, zeta0, 2, 6);
+    ntt_step(vec, zeta0, 3, 7);
+    ntt_step(vec, zeta1, 8, 12);
+    ntt_step(vec, zeta1, 9, 13);
+    ntt_step(vec, zeta1, 10, 14);
+    ntt_step(vec, zeta1, 11, 15);
 }
 
 #[inline(always)]
@@ -104,16 +102,15 @@ pub(crate) fn ntt_layer_2_step(mut vec: PortableVector, zeta0: i16, zeta1: i16) 
 #[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
                             Spec.Utils.is_i16b_array (11207+3*3328) ${vec}.f_elements"#))]
 #[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) ${result}.f_elements"#))]
-pub(crate) fn ntt_layer_3_step(mut vec: PortableVector, zeta: i16) -> PortableVector {
-    ntt_step(&mut vec, zeta, 0, 8);
-    ntt_step(&mut vec, zeta, 1, 9);
-    ntt_step(&mut vec, zeta, 2, 10);
-    ntt_step(&mut vec, zeta, 3, 11);
-    ntt_step(&mut vec, zeta, 4, 12);
-    ntt_step(&mut vec, zeta, 5, 13);
-    ntt_step(&mut vec, zeta, 6, 14);
-    ntt_step(&mut vec, zeta, 7, 15);
-    vec
+pub(crate) fn ntt_layer_3_step(vec: &mut PortableVector, zeta: i16) {
+    ntt_step(vec, zeta, 0, 8);
+    ntt_step(vec, zeta, 1, 9);
+    ntt_step(vec, zeta, 2, 10);
+    ntt_step(vec, zeta, 3, 11);
+    ntt_step(vec, zeta, 4, 12);
+    ntt_step(vec, zeta, 5, 13);
+    ntt_step(vec, zeta, 6, 14);
+    ntt_step(vec, zeta, 7, 15);
 }
 
 #[inline(always)]
@@ -168,20 +165,20 @@ pub(crate) fn inv_ntt_step(vec: &mut PortableVector, zeta: i16, i: usize, j: usi
                             Spec.Utils.is_i16b_array (4*3328) ${vec}.f_elements"#))]
 #[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 ${result}.f_elements"#))]
 pub(crate) fn inv_ntt_layer_1_step(
-    mut vec: PortableVector,
+    vec: &mut PortableVector,
     zeta0: i16,
     zeta1: i16,
     zeta2: i16,
     zeta3: i16,
-) -> PortableVector {
-    inv_ntt_step(&mut vec, zeta0, 0, 2);
-    inv_ntt_step(&mut vec, zeta0, 1, 3);
-    inv_ntt_step(&mut vec, zeta1, 4, 6);
-    inv_ntt_step(&mut vec, zeta1, 5, 7);
-    inv_ntt_step(&mut vec, zeta2, 8, 10);
-    inv_ntt_step(&mut vec, zeta2, 9, 11);
-    inv_ntt_step(&mut vec, zeta3, 12, 14);
-    inv_ntt_step(&mut vec, zeta3, 13, 15);
+) {
+    inv_ntt_step(vec, zeta0, 0, 2);
+    inv_ntt_step(vec, zeta0, 1, 3);
+    inv_ntt_step(vec, zeta1, 4, 6);
+    inv_ntt_step(vec, zeta1, 5, 7);
+    inv_ntt_step(vec, zeta2, 8, 10);
+    inv_ntt_step(vec, zeta2, 9, 11);
+    inv_ntt_step(vec, zeta3, 12, 14);
+    inv_ntt_step(vec, zeta3, 13, 15);
     hax_lib::fstar!(
         r#"assert (Spec.Utils.is_i16b 3328 (Seq.index ${vec}.f_elements 13));
         assert (Spec.Utils.is_i16b 3328 (Seq.index ${vec}.f_elements 15));
@@ -201,7 +198,6 @@ pub(crate) fn inv_ntt_layer_1_step(
         assert (Spec.Utils.is_i16b 3328 (Seq.index ${vec}.f_elements 2));
         assert (forall (i:nat). i < 16 ==> Spec.Utils.is_i16b 3328 (Seq.index ${vec}.f_elements i))"#
     );
-    vec
 }
 
 #[inline(always)]
@@ -209,20 +205,15 @@ pub(crate) fn inv_ntt_layer_1_step(
 #[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                             Spec.Utils.is_i16b_array 3328 ${vec}.f_elements"#))]
 #[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 ${result}.f_elements"#))]
-pub(crate) fn inv_ntt_layer_2_step(
-    mut vec: PortableVector,
-    zeta0: i16,
-    zeta1: i16,
-) -> PortableVector {
-    inv_ntt_step(&mut vec, zeta0, 0, 4);
-    inv_ntt_step(&mut vec, zeta0, 1, 5);
-    inv_ntt_step(&mut vec, zeta0, 2, 6);
-    inv_ntt_step(&mut vec, zeta0, 3, 7);
-    inv_ntt_step(&mut vec, zeta1, 8, 12);
-    inv_ntt_step(&mut vec, zeta1, 9, 13);
-    inv_ntt_step(&mut vec, zeta1, 10, 14);
-    inv_ntt_step(&mut vec, zeta1, 11, 15);
-    vec
+pub(crate) fn inv_ntt_layer_2_step(vec: &mut PortableVector, zeta0: i16, zeta1: i16) {
+    inv_ntt_step(vec, zeta0, 0, 4);
+    inv_ntt_step(vec, zeta0, 1, 5);
+    inv_ntt_step(vec, zeta0, 2, 6);
+    inv_ntt_step(vec, zeta0, 3, 7);
+    inv_ntt_step(vec, zeta1, 8, 12);
+    inv_ntt_step(vec, zeta1, 9, 13);
+    inv_ntt_step(vec, zeta1, 10, 14);
+    inv_ntt_step(vec, zeta1, 11, 15);
 }
 
 #[inline(always)]
@@ -230,16 +221,15 @@ pub(crate) fn inv_ntt_layer_2_step(
 #[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
                             Spec.Utils.is_i16b_array 3328 ${vec}.f_elements"#))]
 #[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 ${result}.f_elements"#))]
-pub(crate) fn inv_ntt_layer_3_step(mut vec: PortableVector, zeta: i16) -> PortableVector {
-    inv_ntt_step(&mut vec, zeta, 0, 8);
-    inv_ntt_step(&mut vec, zeta, 1, 9);
-    inv_ntt_step(&mut vec, zeta, 2, 10);
-    inv_ntt_step(&mut vec, zeta, 3, 11);
-    inv_ntt_step(&mut vec, zeta, 4, 12);
-    inv_ntt_step(&mut vec, zeta, 5, 13);
-    inv_ntt_step(&mut vec, zeta, 6, 14);
-    inv_ntt_step(&mut vec, zeta, 7, 15);
-    vec
+pub(crate) fn inv_ntt_layer_3_step(vec: &mut PortableVector, zeta: i16) {
+    inv_ntt_step(vec, zeta, 0, 8);
+    inv_ntt_step(vec, zeta, 1, 9);
+    inv_ntt_step(vec, zeta, 2, 10);
+    inv_ntt_step(vec, zeta, 3, 11);
+    inv_ntt_step(vec, zeta, 4, 12);
+    inv_ntt_step(vec, zeta, 5, 13);
+    inv_ntt_step(vec, zeta, 6, 14);
+    inv_ntt_step(vec, zeta, 7, 15);
 }
 
 /// Compute the product of two Kyber binomials with respect to the
@@ -401,11 +391,12 @@ pub(crate) fn ntt_multiply_binomials(
 pub(crate) fn ntt_multiply(
     lhs: &PortableVector,
     rhs: &PortableVector,
+    out: &mut PortableVector,
     zeta0: i16,
     zeta1: i16,
     zeta2: i16,
     zeta3: i16,
-) -> PortableVector {
+) {
     let nzeta0 = -zeta0;
     let nzeta1 = -zeta1;
     let nzeta2 = -zeta2;
@@ -414,23 +405,21 @@ pub(crate) fn ntt_multiply(
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta1)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
-    let mut out = zero();
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta0, 0, &mut out);
+    ntt_multiply_binomials(lhs, rhs, zeta0, 0,  out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta0, 1, &mut out);
+    ntt_multiply_binomials(lhs, rhs, nzeta0, 1,  out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta1, 2, &mut out);
+    ntt_multiply_binomials(lhs, rhs, zeta1, 2,  out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta1, 3, &mut out);
+    ntt_multiply_binomials(lhs, rhs, nzeta1, 3,  out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta2, 4, &mut out);
+    ntt_multiply_binomials(lhs, rhs, zeta2, 4,  out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta2, 5, &mut out);
+    ntt_multiply_binomials(lhs, rhs, nzeta2, 5,  out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta3, 6, &mut out);
+    ntt_multiply_binomials(lhs, rhs, zeta3, 6,  out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta3, 7, &mut out);
+    ntt_multiply_binomials(lhs, rhs, nzeta3, 7,  out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    out
 }

--- a/libcrux/libcrux-ml-kem/src/vector/portable/serialize.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/serialize.rs
@@ -56,7 +56,7 @@ val serialize_1_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_Port
 #[inline(always)]
 pub(crate) fn serialize_1(v: PortableVector, out: &mut [u8]) {
     debug_assert!(out.len() == 2);
-    
+
     out[0] = (v.elements[0] as u8)
         | ((v.elements[1] as u8) << 1)
         | ((v.elements[2] as u8) << 2)

--- a/libcrux/libcrux-ml-kem/src/vector/portable/serialize.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/serialize.rs
@@ -54,8 +54,10 @@ val serialize_1_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_Port
   (ensures bit_vec_of_int_t_array (${serialize_1} inputs) 8 == bit_vec_of_int_t_array inputs.f_elements 1)
 "))]
 #[inline(always)]
-pub(crate) fn serialize_1(v: PortableVector) -> [u8; 2] {
-    let result0 = (v.elements[0] as u8)
+pub(crate) fn serialize_1(v: PortableVector, out: &mut [u8]) {
+    debug_assert!(out.len() == 2);
+    
+    out[0] = (v.elements[0] as u8)
         | ((v.elements[1] as u8) << 1)
         | ((v.elements[2] as u8) << 2)
         | ((v.elements[3] as u8) << 3)
@@ -63,7 +65,7 @@ pub(crate) fn serialize_1(v: PortableVector) -> [u8; 2] {
         | ((v.elements[5] as u8) << 5)
         | ((v.elements[6] as u8) << 6)
         | ((v.elements[7] as u8) << 7);
-    let result1 = (v.elements[8] as u8)
+    out[1] = (v.elements[8] as u8)
         | ((v.elements[9] as u8) << 1)
         | ((v.elements[10] as u8) << 2)
         | ((v.elements[11] as u8) << 3)
@@ -71,7 +73,6 @@ pub(crate) fn serialize_1(v: PortableVector) -> [u8; 2] {
         | ((v.elements[13] as u8) << 5)
         | ((v.elements[14] as u8) << 6)
         | ((v.elements[15] as u8) << 7);
-    [result0, result1]
 }
 
 //deserialize_1_bit_vec_lemma
@@ -137,29 +138,23 @@ val deserialize_1_bounded_lemma (inputs: t_Array u8 (sz 2)) : Lemma
      ${v.len() == 2}
 "#))]
 #[inline(always)]
-pub(crate) fn deserialize_1(v: &[u8]) -> PortableVector {
-    let result0 = (v[0] & 0x1) as i16;
-    let result1 = ((v[0] >> 1) & 0x1) as i16;
-    let result2 = ((v[0] >> 2) & 0x1) as i16;
-    let result3 = ((v[0] >> 3) & 0x1) as i16;
-    let result4 = ((v[0] >> 4) & 0x1) as i16;
-    let result5 = ((v[0] >> 5) & 0x1) as i16;
-    let result6 = ((v[0] >> 6) & 0x1) as i16;
-    let result7 = ((v[0] >> 7) & 0x1) as i16;
-    let result8 = (v[1] & 0x1) as i16;
-    let result9 = ((v[1] >> 1) & 0x1) as i16;
-    let result10 = ((v[1] >> 2) & 0x1) as i16;
-    let result11 = ((v[1] >> 3) & 0x1) as i16;
-    let result12 = ((v[1] >> 4) & 0x1) as i16;
-    let result13 = ((v[1] >> 5) & 0x1) as i16;
-    let result14 = ((v[1] >> 6) & 0x1) as i16;
-    let result15 = ((v[1] >> 7) & 0x1) as i16;
-    PortableVector {
-        elements: [
-            result0, result1, result2, result3, result4, result5, result6, result7, result8,
-            result9, result10, result11, result12, result13, result14, result15,
-        ],
-    }
+pub(crate) fn deserialize_1(v: &[u8], out: &mut PortableVector) {
+    out.elements[0] = (v[0] & 0x1) as i16;
+    out.elements[1] = ((v[0] >> 1) & 0x1) as i16;
+    out.elements[2] = ((v[0] >> 2) & 0x1) as i16;
+    out.elements[3] = ((v[0] >> 3) & 0x1) as i16;
+    out.elements[4] = ((v[0] >> 4) & 0x1) as i16;
+    out.elements[5] = ((v[0] >> 5) & 0x1) as i16;
+    out.elements[6] = ((v[0] >> 6) & 0x1) as i16;
+    out.elements[7] = ((v[0] >> 7) & 0x1) as i16;
+    out.elements[8] = (v[1] & 0x1) as i16;
+    out.elements[9] = ((v[1] >> 1) & 0x1) as i16;
+    out.elements[10] = ((v[1] >> 2) & 0x1) as i16;
+    out.elements[11] = ((v[1] >> 3) & 0x1) as i16;
+    out.elements[12] = ((v[1] >> 4) & 0x1) as i16;
+    out.elements[13] = ((v[1] >> 5) & 0x1) as i16;
+    out.elements[14] = ((v[1] >> 6) & 0x1) as i16;
+    out.elements[15] = ((v[1] >> 7) & 0x1) as i16;
 }
 
 #[inline(always)]
@@ -214,19 +209,10 @@ val serialize_4_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_Port
   (ensures bit_vec_of_int_t_array (${serialize_4} inputs) 8 == bit_vec_of_int_t_array inputs.f_elements 4)
 "))]
 #[inline(always)]
-pub(crate) fn serialize_4(v: PortableVector) -> [u8; 8] {
-    let result0_3 = serialize_4_int(&v.elements[0..8]);
-    let result4_7 = serialize_4_int(&v.elements[8..16]);
-    [
-        result0_3.0,
-        result0_3.1,
-        result0_3.2,
-        result0_3.3,
-        result4_7.0,
-        result4_7.1,
-        result4_7.2,
-        result4_7.3,
-    ]
+pub(crate) fn serialize_4(v: PortableVector, out: &mut [u8]) {
+    debug_assert!(out.len() == 8);
+    (out[0], out[1], out[2], out[3]) = serialize_4_int(&v.elements[0..8]);
+    (out[4], out[5], out[6], out[7]) = serialize_4_int(&v.elements[8..16]);
 }
 
 #[inline(always)]
@@ -308,15 +294,27 @@ let deserialize_4_lemma inputs =
      ${bytes.len() == 8}
 "#))]
 #[inline(always)]
-pub(crate) fn deserialize_4(bytes: &[u8]) -> PortableVector {
-    let v0_7 = deserialize_4_int(&bytes[0..4]);
-    let v8_15 = deserialize_4_int(&bytes[4..8]);
-    PortableVector {
-        elements: [
-            v0_7.0, v0_7.1, v0_7.2, v0_7.3, v0_7.4, v0_7.5, v0_7.6, v0_7.7, v8_15.0, v8_15.1,
-            v8_15.2, v8_15.3, v8_15.4, v8_15.5, v8_15.6, v8_15.7,
-        ],
-    }
+pub(crate) fn deserialize_4(bytes: &[u8], out: &mut PortableVector) {
+    (
+        out.elements[0],
+        out.elements[1],
+        out.elements[2],
+        out.elements[3],
+        out.elements[4],
+        out.elements[5],
+        out.elements[6],
+        out.elements[7],
+    ) = deserialize_4_int(&bytes[0..4]);
+    (
+        out.elements[8],
+        out.elements[9],
+        out.elements[10],
+        out.elements[11],
+        out.elements[12],
+        out.elements[13],
+        out.elements[14],
+        out.elements[15],
+    ) = deserialize_4_int(&bytes[4..8]);
 }
 
 #[inline(always)]
@@ -333,12 +331,10 @@ pub(crate) fn serialize_5_int(v: &[i16]) -> (u8, u8, u8, u8, u8) {
 }
 
 #[inline(always)]
-pub(crate) fn serialize_5(v: PortableVector) -> [u8; 10] {
-    let r0_4 = serialize_5_int(&v.elements[0..8]);
-    let r5_9 = serialize_5_int(&v.elements[8..16]);
-    [
-        r0_4.0, r0_4.1, r0_4.2, r0_4.3, r0_4.4, r5_9.0, r5_9.1, r5_9.2, r5_9.3, r5_9.4,
-    ]
+pub(crate) fn serialize_5(v: PortableVector, out: &mut [u8]) {
+    debug_assert!(out.len() == 10);
+    (out[0], out[1], out[2], out[3], out[4]) = serialize_5_int(&v.elements[0..8]);
+    (out[5], out[6], out[7], out[8], out[9]) = serialize_5_int(&v.elements[8..16]);
 }
 
 #[inline(always)]
@@ -361,15 +357,27 @@ pub(crate) fn deserialize_5_int(bytes: &[u8]) -> (i16, i16, i16, i16, i16, i16, 
      ${bytes.len() == 10}
 "#))]
 #[inline(always)]
-pub(crate) fn deserialize_5(bytes: &[u8]) -> PortableVector {
-    let v0_7 = deserialize_5_int(&bytes[0..5]);
-    let v8_15 = deserialize_5_int(&bytes[5..10]);
-    PortableVector {
-        elements: [
-            v0_7.0, v0_7.1, v0_7.2, v0_7.3, v0_7.4, v0_7.5, v0_7.6, v0_7.7, v8_15.0, v8_15.1,
-            v8_15.2, v8_15.3, v8_15.4, v8_15.5, v8_15.6, v8_15.7,
-        ],
-    }
+pub(crate) fn deserialize_5(bytes: &[u8], out: &mut PortableVector) {
+    (
+        out.elements[0],
+        out.elements[1],
+        out.elements[2],
+        out.elements[3],
+        out.elements[4],
+        out.elements[5],
+        out.elements[6],
+        out.elements[7],
+    ) = deserialize_5_int(&bytes[0..5]);
+    (
+        out.elements[8],
+        out.elements[9],
+        out.elements[10],
+        out.elements[11],
+        out.elements[12],
+        out.elements[13],
+        out.elements[14],
+        out.elements[15],
+    ) = deserialize_5_int(&bytes[5..10]);
 }
 
 #[inline(always)]
@@ -425,15 +433,12 @@ let serialize_10_lemma inputs =
     )
 )]
 #[inline(always)]
-pub(crate) fn serialize_10(v: PortableVector) -> [u8; 20] {
-    let r0_4 = serialize_10_int(&v.elements[0..4]);
-    let r5_9 = serialize_10_int(&v.elements[4..8]);
-    let r10_14 = serialize_10_int(&v.elements[8..12]);
-    let r15_19 = serialize_10_int(&v.elements[12..16]);
-    [
-        r0_4.0, r0_4.1, r0_4.2, r0_4.3, r0_4.4, r5_9.0, r5_9.1, r5_9.2, r5_9.3, r5_9.4, r10_14.0,
-        r10_14.1, r10_14.2, r10_14.3, r10_14.4, r15_19.0, r15_19.1, r15_19.2, r15_19.3, r15_19.4,
-    ]
+pub(crate) fn serialize_10(v: PortableVector, out: &mut [u8]) {
+    debug_assert!(out.len() == 20);
+    (out[0], out[1], out[2], out[3], out[4]) = serialize_10_int(&v.elements[0..4]);
+    (out[5], out[6], out[7], out[8], out[9]) = serialize_10_int(&v.elements[4..8]);
+    (out[10], out[11], out[12], out[13], out[14]) = serialize_10_int(&v.elements[8..12]);
+    (out[15], out[16], out[17], out[18], out[19]) = serialize_10_int(&v.elements[12..16]);
 }
 
 #[inline(always)]
@@ -515,15 +520,27 @@ val deserialize_10_bounded_lemma (inputs: t_Array u8 (sz 20)) : Lemma
      ${bytes.len() == 20}
 "#))]
 #[inline(always)]
-pub(crate) fn deserialize_10(bytes: &[u8]) -> PortableVector {
-    let v0_7 = deserialize_10_int(&bytes[0..10]);
-    let v8_15 = deserialize_10_int(&bytes[10..20]);
-    PortableVector {
-        elements: [
-            v0_7.0, v0_7.1, v0_7.2, v0_7.3, v0_7.4, v0_7.5, v0_7.6, v0_7.7, v8_15.0, v8_15.1,
-            v8_15.2, v8_15.3, v8_15.4, v8_15.5, v8_15.6, v8_15.7,
-        ],
-    }
+pub(crate) fn deserialize_10(bytes: &[u8], out: &mut PortableVector) {
+    (
+        out.elements[0],
+        out.elements[1],
+        out.elements[2],
+        out.elements[3],
+        out.elements[4],
+        out.elements[5],
+        out.elements[6],
+        out.elements[7],
+    ) = deserialize_10_int(&bytes[0..10]);
+    (
+        out.elements[8],
+        out.elements[9],
+        out.elements[10],
+        out.elements[11],
+        out.elements[12],
+        out.elements[13],
+        out.elements[14],
+        out.elements[15],
+    ) = deserialize_10_int(&bytes[10..20]);
 }
 
 #[inline(always)]
@@ -546,14 +563,15 @@ pub(crate) fn serialize_11_int(v: &[i16]) -> (u8, u8, u8, u8, u8, u8, u8, u8, u8
 }
 
 #[inline(always)]
-pub(crate) fn serialize_11(v: PortableVector) -> [u8; 22] {
-    let r0_10 = serialize_11_int(&v.elements[0..8]);
-    let r11_21 = serialize_11_int(&v.elements[8..16]);
-    [
-        r0_10.0, r0_10.1, r0_10.2, r0_10.3, r0_10.4, r0_10.5, r0_10.6, r0_10.7, r0_10.8, r0_10.9,
-        r0_10.10, r11_21.0, r11_21.1, r11_21.2, r11_21.3, r11_21.4, r11_21.5, r11_21.6, r11_21.7,
-        r11_21.8, r11_21.9, r11_21.10,
-    ]
+pub(crate) fn serialize_11(v: PortableVector, out: &mut [u8]) {
+    debug_assert!(out.len() == 22);
+    (
+        out[0], out[1], out[2], out[3], out[4], out[5], out[6], out[7], out[8], out[9], out[10],
+    ) = serialize_11_int(&v.elements[0..8]);
+    (
+        out[11], out[12], out[13], out[14], out[15], out[16], out[17], out[18], out[19], out[20],
+        out[21],
+    ) = serialize_11_int(&v.elements[8..16]);
 }
 
 #[inline(always)]
@@ -576,15 +594,27 @@ pub(crate) fn deserialize_11_int(bytes: &[u8]) -> (i16, i16, i16, i16, i16, i16,
      ${bytes.len() == 22}
 "#))]
 #[inline(always)]
-pub(crate) fn deserialize_11(bytes: &[u8]) -> PortableVector {
-    let v0_7 = deserialize_11_int(&bytes[0..11]);
-    let v8_15 = deserialize_11_int(&bytes[11..22]);
-    PortableVector {
-        elements: [
-            v0_7.0, v0_7.1, v0_7.2, v0_7.3, v0_7.4, v0_7.5, v0_7.6, v0_7.7, v8_15.0, v8_15.1,
-            v8_15.2, v8_15.3, v8_15.4, v8_15.5, v8_15.6, v8_15.7,
-        ],
-    }
+pub(crate) fn deserialize_11(bytes: &[u8], out: &mut PortableVector) {
+    (
+        out.elements[0],
+        out.elements[1],
+        out.elements[2],
+        out.elements[3],
+        out.elements[4],
+        out.elements[5],
+        out.elements[6],
+        out.elements[7],
+    ) = deserialize_11_int(&bytes[0..11]);
+    (
+        out.elements[8],
+        out.elements[9],
+        out.elements[10],
+        out.elements[11],
+        out.elements[12],
+        out.elements[13],
+        out.elements[14],
+        out.elements[15],
+    ) = deserialize_11_int(&bytes[11..22]);
 }
 
 #[inline(always)]
@@ -638,20 +668,16 @@ let serialize_12_lemma inputs =
     )
 )]
 #[inline(always)]
-pub(crate) fn serialize_12(v: PortableVector) -> [u8; 24] {
-    let r0_2 = serialize_12_int(&v.elements[0..2]);
-    let r3_5 = serialize_12_int(&v.elements[2..4]);
-    let r6_8 = serialize_12_int(&v.elements[4..6]);
-    let r9_11 = serialize_12_int(&v.elements[6..8]);
-    let r12_14 = serialize_12_int(&v.elements[8..10]);
-    let r15_17 = serialize_12_int(&v.elements[10..12]);
-    let r18_20 = serialize_12_int(&v.elements[12..14]);
-    let r21_23 = serialize_12_int(&v.elements[14..16]);
-    [
-        r0_2.0, r0_2.1, r0_2.2, r3_5.0, r3_5.1, r3_5.2, r6_8.0, r6_8.1, r6_8.2, r9_11.0, r9_11.1,
-        r9_11.2, r12_14.0, r12_14.1, r12_14.2, r15_17.0, r15_17.1, r15_17.2, r18_20.0, r18_20.1,
-        r18_20.2, r21_23.0, r21_23.1, r21_23.2,
-    ]
+pub(crate) fn serialize_12(v: PortableVector, out: &mut [u8]) {
+    debug_assert!(out.len() == 24);
+    (out[0], out[1], out[2]) = serialize_12_int(&v.elements[0..2]);
+    (out[3], out[4], out[5]) = serialize_12_int(&v.elements[2..4]);
+    (out[6], out[7], out[8]) = serialize_12_int(&v.elements[4..6]);
+    (out[9], out[10], out[11]) = serialize_12_int(&v.elements[6..8]);
+    (out[12], out[13], out[14]) = serialize_12_int(&v.elements[8..10]);
+    (out[15], out[16], out[17]) = serialize_12_int(&v.elements[10..12]);
+    (out[18], out[19], out[20]) = serialize_12_int(&v.elements[12..14]);
+    (out[21], out[22], out[23]) = serialize_12_int(&v.elements[14..16]);
 }
 
 #[inline(always)]
@@ -730,19 +756,13 @@ let deserialize_12_lemma inputs =
      ${bytes.len() == 24}
 "#))]
 #[inline(always)]
-pub(crate) fn deserialize_12(bytes: &[u8]) -> PortableVector {
-    let v0_1 = deserialize_12_int(&bytes[0..3]);
-    let v2_3 = deserialize_12_int(&bytes[3..6]);
-    let v4_5 = deserialize_12_int(&bytes[6..9]);
-    let v6_7 = deserialize_12_int(&bytes[9..12]);
-    let v8_9 = deserialize_12_int(&bytes[12..15]);
-    let v10_11 = deserialize_12_int(&bytes[15..18]);
-    let v12_13 = deserialize_12_int(&bytes[18..21]);
-    let v14_15 = deserialize_12_int(&bytes[21..24]);
-    PortableVector {
-        elements: [
-            v0_1.0, v0_1.1, v2_3.0, v2_3.1, v4_5.0, v4_5.1, v6_7.0, v6_7.1, v8_9.0, v8_9.1,
-            v10_11.0, v10_11.1, v12_13.0, v12_13.1, v14_15.0, v14_15.1,
-        ],
-    }
+pub(crate) fn deserialize_12(bytes: &[u8], out: &mut PortableVector) {
+    (out.elements[0], out.elements[1]) = deserialize_12_int(&bytes[0..3]);
+    (out.elements[2], out.elements[3]) = deserialize_12_int(&bytes[3..6]);
+    (out.elements[4], out.elements[5]) = deserialize_12_int(&bytes[6..9]);
+    (out.elements[6], out.elements[7]) = deserialize_12_int(&bytes[9..12]);
+    (out.elements[8], out.elements[9]) = deserialize_12_int(&bytes[12..15]);
+    (out.elements[10], out.elements[11]) = deserialize_12_int(&bytes[15..18]);
+    (out.elements[12], out.elements[13]) = deserialize_12_int(&bytes[18..21]);
+    (out.elements[14], out.elements[15]) = deserialize_12_int(&bytes[21..24]);
 }

--- a/libcrux/libcrux-ml-kem/src/vector/portable/serialize.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/serialize.rs
@@ -14,26 +14,6 @@
 
 use super::vector_type::*;
 
-#[cfg_attr(hax, hax_lib::fstar::after(interface, "
-val serialize_1_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) : Lemma
-  (requires (forall i. Rust_primitives.bounded (Seq.index inputs.f_elements i) 1)) 
-  (ensures bit_vec_of_int_t_array (${serialize_1} inputs) 8 == bit_vec_of_int_t_array inputs.f_elements 1)
-"))]
-#[cfg_attr(
-    hax,
-    hax_lib::fstar::after(
-        "
-#push-options \"--z3rlimit 300\"
-
-let serialize_1_lemma inputs =
-  serialize_1_bit_vec_lemma inputs.f_elements ();
-  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (${serialize_1} inputs) 8) 
-    (BitVecEq.retype (bit_vec_of_int_t_array inputs.f_elements 1))
-
-#pop-options
-"
-    )
-)]
 #[cfg_attr(
     hax,
     hax_lib::fstar::after(
@@ -53,6 +33,26 @@ let serialize_1_bit_vec_lemma (v: t_Array i16 (sz 16))
 "
     )
 )]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::after(
+        "
+#push-options \"--z3rlimit 300\"
+
+let serialize_1_lemma inputs =
+  serialize_1_bit_vec_lemma inputs.f_elements ();
+  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (${serialize_1} inputs) 8) 
+    (BitVecEq.retype (bit_vec_of_int_t_array inputs.f_elements 1))
+
+#pop-options
+"
+    )
+)]
+#[cfg_attr(hax, hax_lib::fstar::after(interface, "
+val serialize_1_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) : Lemma
+  (requires (forall i. Rust_primitives.bounded (Seq.index inputs.f_elements i) 1)) 
+  (ensures bit_vec_of_int_t_array (${serialize_1} inputs) 8 == bit_vec_of_int_t_array inputs.f_elements 1)
+"))]
 #[inline(always)]
 pub(crate) fn serialize_1(v: PortableVector) -> [u8; 2] {
     let result0 = (v.elements[0] as u8)
@@ -74,23 +74,22 @@ pub(crate) fn serialize_1(v: PortableVector) -> [u8; 2] {
     [result0, result1]
 }
 
-//deserialize_1_bounded_lemma
-#[cfg_attr(
-    hax,
-    hax_lib::fstar::after(
-        interface,
-        "
-val deserialize_1_bounded_lemma (inputs: t_Array u8 (sz 2)) : Lemma
-  (ensures forall i. i < 16 ==> bounded (Seq.index (${deserialize_1} inputs).f_elements i) 1)
-"
-    )
-)]
+//deserialize_1_bit_vec_lemma
 #[cfg_attr(
     hax,
     hax_lib::fstar::after(
         "
-let deserialize_1_bounded_lemma inputs =
-  admit()
+#push-options \"--compat_pre_core 2 --z3rlimit 300 --z3refresh\"
+
+let deserialize_1_bit_vec_lemma (v: t_Array u8 (sz 2))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v 8 in
+     let outputs = bit_vec_of_int_t_array (${deserialize_1} v).f_elements 1 in
+     (forall (i: nat {i < 16}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
 "
     )
 )]
@@ -114,22 +113,23 @@ let deserialize_1_lemma inputs =
 "
     )
 )]
-//deserialize_1_bit_vec_lemma
 #[cfg_attr(
     hax,
     hax_lib::fstar::after(
         "
-#push-options \"--compat_pre_core 2 --z3rlimit 300 --z3refresh\"
-
-let deserialize_1_bit_vec_lemma (v: t_Array u8 (sz 2))
-   : squash (
-     let inputs = bit_vec_of_int_t_array v 8 in
-     let outputs = bit_vec_of_int_t_array (${deserialize_1} v).f_elements 1 in
-     (forall (i: nat {i < 16}). inputs i == outputs i)
-   ) =
-  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
-
-#pop-options
+let deserialize_1_bounded_lemma inputs =
+  admit()
+"
+    )
+)]
+//deserialize_1_bounded_lemma
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::after(
+        interface,
+        "
+val deserialize_1_bounded_lemma (inputs: t_Array u8 (sz 2)) : Lemma
+  (ensures forall i. i < 16 ==> bounded (Seq.index (${deserialize_1} inputs).f_elements i) 1)
 "
     )
 )]
@@ -174,26 +174,6 @@ pub(crate) fn serialize_4_int(v: &[i16]) -> (u8, u8, u8, u8) {
     (result0, result1, result2, result3)
 }
 
-#[cfg_attr(hax, hax_lib::fstar::after(interface, "
-val serialize_4_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) : Lemma
-  (requires (forall i. Rust_primitives.bounded (Seq.index inputs.f_elements i) 4)) 
-  (ensures bit_vec_of_int_t_array (${serialize_4} inputs) 8 == bit_vec_of_int_t_array inputs.f_elements 4)
-"))]
-#[cfg_attr(
-    hax,
-    hax_lib::fstar::after(
-        "
-#push-options \"--z3rlimit 300\"
-
-let serialize_4_lemma inputs =
-  serialize_4_bit_vec_lemma inputs.f_elements ();
-  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (${serialize_4} inputs) 8) 
-    (BitVecEq.retype (bit_vec_of_int_t_array inputs.f_elements 4))
-
-#pop-options
-"
-    )
-)]
 #[cfg_attr(
     hax,
     hax_lib::fstar::after(
@@ -213,6 +193,26 @@ let serialize_4_bit_vec_lemma (v: t_Array i16 (sz 16))
 "
     )
 )]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::after(
+        "
+#push-options \"--z3rlimit 300\"
+
+let serialize_4_lemma inputs =
+  serialize_4_bit_vec_lemma inputs.f_elements ();
+  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (${serialize_4} inputs) 8) 
+    (BitVecEq.retype (bit_vec_of_int_t_array inputs.f_elements 4))
+
+#pop-options
+"
+    )
+)]
+#[cfg_attr(hax, hax_lib::fstar::after(interface, "
+val serialize_4_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) : Lemma
+  (requires (forall i. Rust_primitives.bounded (Seq.index inputs.f_elements i) 4)) 
+  (ensures bit_vec_of_int_t_array (${serialize_4} inputs) 8 == bit_vec_of_int_t_array inputs.f_elements 4)
+"))]
 #[inline(always)]
 pub(crate) fn serialize_4(v: PortableVector) -> [u8; 8] {
     let result0_3 = serialize_4_int(&v.elements[0..8]);
@@ -265,6 +265,25 @@ let deserialize_4_bounded_lemma inputs =
 "
     )
 )]
+//deserialize_4_bit_vec_lemma
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::after(
+        "
+#push-options \"--compat_pre_core 2 --z3rlimit 300 --z3refresh\"
+
+let deserialize_4_bit_vec_lemma (v: t_Array u8 (sz 8))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v 8 in
+     let outputs = bit_vec_of_int_t_array (${deserialize_4} v).f_elements 4 in
+     (forall (i: nat {i < 64}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
+"
+    )
+)]
 //deserialize_4_lemma
 #[cfg_attr(hax, hax_lib::fstar::after(interface, "
 val deserialize_4_lemma (inputs: t_Array u8 (sz 8)) : Lemma
@@ -280,25 +299,6 @@ let deserialize_4_lemma inputs =
   deserialize_4_bit_vec_lemma inputs;
   BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (${deserialize_4} inputs).f_elements 4) 
     (BitVecEq.retype (bit_vec_of_int_t_array inputs 8))
-
-#pop-options
-"
-    )
-)]
-//deserialize_4_bit_vec_lemma
-#[cfg_attr(
-    hax,
-    hax_lib::fstar::after(
-        "
-#push-options \"--compat_pre_core 2 --z3rlimit 300 --z3refresh\"
-
-let deserialize_4_bit_vec_lemma (v: t_Array u8 (sz 8))
-   : squash (
-     let inputs = bit_vec_of_int_t_array v 8 in
-     let outputs = bit_vec_of_int_t_array (${deserialize_4} v).f_elements 4 in
-     (forall (i: nat {i < 64}). inputs i == outputs i)
-   ) =
-  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
 
 #pop-options
 "
@@ -385,6 +385,25 @@ pub(crate) fn serialize_10_int(v: &[i16]) -> (u8, u8, u8, u8, u8) {
     (r0, r1, r2, r3, r4)
 }
 
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::after(
+        "
+#push-options \"--compat_pre_core 2 --z3rlimit 300 --z3refresh\"
+
+let serialize_10_bit_vec_lemma (v: t_Array i16 (sz 16))
+  (_: squash (forall i. Rust_primitives.bounded (Seq.index v i) 10))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v 10 in
+     let outputs = bit_vec_of_int_t_array (${serialize_10} ({ f_elements = v })) 8 in
+     (forall (i: nat {i < 160}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
+"
+    )
+)]
 #[cfg_attr(hax, hax_lib::fstar::after(interface, "
 val serialize_10_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) : Lemma
   (requires (forall i. Rust_primitives.bounded (Seq.index inputs.f_elements i) 10)) 
@@ -400,25 +419,6 @@ let serialize_10_lemma inputs =
   serialize_10_bit_vec_lemma inputs.f_elements ();
   BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (${serialize_10} inputs) 8) 
     (BitVecEq.retype (bit_vec_of_int_t_array inputs.f_elements 10))
-
-#pop-options
-"
-    )
-)]
-#[cfg_attr(
-    hax,
-    hax_lib::fstar::after(
-        "
-#push-options \"--compat_pre_core 2 --z3rlimit 300 --z3refresh\"
-
-let serialize_10_bit_vec_lemma (v: t_Array i16 (sz 16))
-  (_: squash (forall i. Rust_primitives.bounded (Seq.index v i) 10))
-   : squash (
-     let inputs = bit_vec_of_int_t_array v 10 in
-     let outputs = bit_vec_of_int_t_array (${serialize_10} ({ f_elements = v })) 8 in
-     (forall (i: nat {i < 160}). inputs i == outputs i)
-   ) =
-  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
 
 #pop-options
 "
@@ -452,46 +452,6 @@ pub(crate) fn deserialize_10_int(bytes: &[u8]) -> (i16, i16, i16, i16, i16, i16,
     (r0, r1, r2, r3, r4, r5, r6, r7)
 }
 
-//deserialize_10_bounded_lemma
-#[cfg_attr(
-    hax,
-    hax_lib::fstar::after(
-        interface,
-        "
-val deserialize_10_bounded_lemma (inputs: t_Array u8 (sz 20)) : Lemma
-  (ensures forall i. i < 16 ==> bounded (Seq.index (${deserialize_10} inputs).f_elements i) 10)
-"
-    )
-)]
-#[cfg_attr(
-    hax,
-    hax_lib::fstar::after(
-        "
-let deserialize_10_bounded_lemma inputs =
-  admit()
-"
-    )
-)]
-//deserialize_10_lemma
-#[cfg_attr(hax, hax_lib::fstar::after(interface, "
-val deserialize_10_lemma (inputs: t_Array u8 (sz 20)) : Lemma
-  (ensures bit_vec_of_int_t_array (${deserialize_10} inputs).f_elements 10 == bit_vec_of_int_t_array inputs 8)
-"))]
-#[cfg_attr(
-    hax,
-    hax_lib::fstar::after(
-        "
-#push-options \"--z3rlimit 300\"
-
-let deserialize_10_lemma inputs =
-  deserialize_10_bit_vec_lemma inputs;
-  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (${deserialize_10} inputs).f_elements 10) 
-    (BitVecEq.retype (bit_vec_of_int_t_array inputs 8))
-
-#pop-options
-"
-    )
-)]
 //deserialize_10_bit_vec_lemma
 #[cfg_attr(
     hax,
@@ -508,6 +468,46 @@ let deserialize_10_bit_vec_lemma (v: t_Array u8 (sz 20))
   _ by (Tactics.GetBit.prove_bit_vector_equality' ())
 
 #pop-options
+"
+    )
+)]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::after(
+        "
+#push-options \"--z3rlimit 300\"
+
+let deserialize_10_lemma inputs =
+  deserialize_10_bit_vec_lemma inputs;
+  BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (${deserialize_10} inputs).f_elements 10) 
+    (BitVecEq.retype (bit_vec_of_int_t_array inputs 8))
+
+#pop-options
+"
+    )
+)]
+//deserialize_10_lemma
+#[cfg_attr(hax, hax_lib::fstar::after(interface, "
+val deserialize_10_lemma (inputs: t_Array u8 (sz 20)) : Lemma
+  (ensures bit_vec_of_int_t_array (${deserialize_10} inputs).f_elements 10 == bit_vec_of_int_t_array inputs 8)
+"))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::after(
+        "
+let deserialize_10_bounded_lemma inputs =
+  admit()
+"
+    )
+)]
+//deserialize_10_bounded_lemma
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::after(
+        interface,
+        "
+val deserialize_10_bounded_lemma (inputs: t_Array u8 (sz 20)) : Lemma
+  (ensures forall i. i < 16 ==> bounded (Seq.index (${deserialize_10} inputs).f_elements i) 10)
 "
     )
 )]
@@ -598,6 +598,25 @@ pub(crate) fn serialize_12_int(v: &[i16]) -> (u8, u8, u8) {
     (r0, r1, r2)
 }
 
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::after(
+        "
+#push-options \"--compat_pre_core 2 --z3rlimit 300 --z3refresh\"
+
+let serialize_12_bit_vec_lemma (v: t_Array i16 (sz 16))
+  (_: squash (forall i. Rust_primitives.bounded (Seq.index v i) 12))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v 12 in
+     let outputs = bit_vec_of_int_t_array (${serialize_12} ({ f_elements = v })) 8 in
+     (forall (i: nat {i < 192}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
+"
+    )
+)]
 #[cfg_attr(hax, hax_lib::fstar::after(interface, "
 val serialize_12_lemma (inputs: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector) : Lemma
   (requires (forall i. Rust_primitives.bounded (Seq.index inputs.f_elements i) 12)) 
@@ -613,25 +632,6 @@ let serialize_12_lemma inputs =
   serialize_12_bit_vec_lemma inputs.f_elements ();
   BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (${serialize_12} inputs) 8) 
     (BitVecEq.retype (bit_vec_of_int_t_array inputs.f_elements 12))
-
-#pop-options
-"
-    )
-)]
-#[cfg_attr(
-    hax,
-    hax_lib::fstar::after(
-        "
-#push-options \"--compat_pre_core 2 --z3rlimit 300 --z3refresh\"
-
-let serialize_12_bit_vec_lemma (v: t_Array i16 (sz 16))
-  (_: squash (forall i. Rust_primitives.bounded (Seq.index v i) 12))
-   : squash (
-     let inputs = bit_vec_of_int_t_array v 12 in
-     let outputs = bit_vec_of_int_t_array (${serialize_12} ({ f_elements = v })) 8 in
-     (forall (i: nat {i < 192}). inputs i == outputs i)
-   ) =
-  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
 
 #pop-options
 "
@@ -687,6 +687,25 @@ let deserialize_12_bounded_lemma inputs =
 "
     )
 )]
+//deserialize_12_bit_vec_lemma
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::after(
+        "
+#push-options \"--compat_pre_core 2 --z3rlimit 300 --z3refresh\"
+
+let deserialize_12_bit_vec_lemma (v: t_Array u8 (sz 24))
+   : squash (
+     let inputs = bit_vec_of_int_t_array v 8 in
+     let outputs = bit_vec_of_int_t_array (${deserialize_12} v).f_elements 12 in
+     (forall (i: nat {i < 192}). inputs i == outputs i)
+   ) =
+  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
+
+#pop-options
+"
+    )
+)]
 //deserialize_12_lemma
 #[cfg_attr(hax, hax_lib::fstar::after(interface, "
 val deserialize_12_lemma (inputs: t_Array u8 (sz 24)) : Lemma
@@ -702,25 +721,6 @@ let deserialize_12_lemma inputs =
   deserialize_12_bit_vec_lemma inputs;
   BitVecEq.bit_vec_equal_intro (bit_vec_of_int_t_array (${deserialize_12} inputs).f_elements 12) 
     (BitVecEq.retype (bit_vec_of_int_t_array inputs 8))
-
-#pop-options
-"
-    )
-)]
-//deserialize_12_bit_vec_lemma
-#[cfg_attr(
-    hax,
-    hax_lib::fstar::after(
-        "
-#push-options \"--compat_pre_core 2 --z3rlimit 300 --z3refresh\"
-
-let deserialize_12_bit_vec_lemma (v: t_Array u8 (sz 24))
-   : squash (
-     let inputs = bit_vec_of_int_t_array v 8 in
-     let outputs = bit_vec_of_int_t_array (${deserialize_12} v).f_elements 12 in
-     (forall (i: nat {i < 192}). inputs i == outputs i)
-   ) =
-  _ by (Tactics.GetBit.prove_bit_vector_equality' ())
 
 #pop-options
 "

--- a/libcrux/libcrux-ml-kem/src/vector/portable/vector_type.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/vector_type.rs
@@ -19,27 +19,23 @@ pub fn zero() -> PortableVector {
 
 #[inline(always)]
 #[hax_lib::ensures(|result| fstar!(r#"${result} == ${x}.f_elements"#))]
-pub fn to_i16_array(x: PortableVector) -> [i16; 16] {
-    x.elements
+pub fn to_i16_array(x: PortableVector, out: &mut [i16; 16]) {
+    *out = x.elements;
 }
 
 #[inline(always)]
 #[hax_lib::requires(array.len() == 16)]
 #[hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == $array"#))]
-pub fn from_i16_array(array: &[i16]) -> PortableVector {
-    PortableVector {
-        elements: array[0..16].try_into().unwrap(),
-    }
+pub fn from_i16_array(array: &[i16], out: &mut PortableVector) {
+    out.elements = array[0..16].try_into().unwrap();
 }
 
 #[inline(always)]
 #[hax_lib::requires(array.len() >= 32)]
-pub(super) fn from_bytes(array: &[u8]) -> PortableVector {
-    let mut elements = [0; FIELD_ELEMENTS_IN_VECTOR];
+pub(super) fn from_bytes(array: &[u8], out: &mut PortableVector) {
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
-        elements[i] = (array[2 * i] as i16) << 8 | array[2 * i + 1] as i16;
+        out.elements[i] = (array[2 * i] as i16) << 8 | array[2 * i + 1] as i16;
     }
-    PortableVector { elements }
 }
 
 #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/traits.rs
@@ -258,8 +258,8 @@ pub fn to_standard_domain<T: Operations>(v: &mut T) {
 #[inline(always)]
 pub fn to_unsigned_representative<T: Operations>(a: &T, out: &mut T) {
     *out = a.clone(); // XXX: We need a copy of `a` here. At least
-                       // the allocation becomes apparent on the
-                       // outside.
+                      // the allocation becomes apparent on the
+                      // outside.
     T::shift_right::<15>(out);
     T::bitwise_and_with_constant(out, FIELD_MODULUS);
     T::add(out, a)

--- a/libcrux/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/traits.rs
@@ -23,14 +23,14 @@ pub trait Operations: Copy + Clone + Repr {
 
     #[requires(array.len() == 16)]
     #[ensures(|result| fstar!(r#"f_repr $result == $array"#))]
-    fn from_i16_array(array: &[i16]) -> Self;
+    fn from_i16_array(array: &[i16], out: &mut Self);
 
     #[requires(true)]
     #[ensures(|result| fstar!(r#"f_repr $x == $result"#))]
-    fn to_i16_array(x: Self) -> [i16; 16];
+    fn to_i16_array(x: Self, out: &mut [i16; 16]);
 
     #[requires(array.len() >= 32)]
-    fn from_bytes(array: &[u8]) -> Self;
+    fn from_bytes(array: &[u8], out: &mut Self);
 
     #[requires(bytes.len() >= 32)]
     fn to_bytes(x: Self, bytes: &mut [u8]);
@@ -41,48 +41,50 @@ pub trait Operations: Copy + Clone + Repr {
     #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index (f_repr ${result}) i) == 
          v (Seq.index (f_repr ${lhs}) i) + v (Seq.index (f_repr ${rhs}) i))"#))]
-    fn add(lhs: Self, rhs: &Self) -> Self;
+    fn add(lhs: &mut Self, rhs: &Self);
 
     #[requires(fstar!(r#"forall i. i < 16 ==> 
         Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index (f_repr ${lhs}) i) - v (Seq.index (f_repr ${rhs}) i))"#))]
     #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index (f_repr ${result}) i) == 
          v (Seq.index (f_repr ${lhs}) i) - v (Seq.index (f_repr ${rhs}) i))"#))]
-    fn sub(lhs: Self, rhs: &Self) -> Self;
+    fn sub(lhs: &mut Self, rhs: &Self);
+
+    fn negate(vec: &mut Self);
 
     #[requires(fstar!(r#"forall i. i < 16 ==> 
         Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index (f_repr ${vec}) i) * v c)"#))]
     #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index (f_repr ${result}) i) == 
          v (Seq.index (f_repr ${vec}) i) * v c)"#))]
-    fn multiply_by_constant(vec: Self, c: i16) -> Self;
+    fn multiply_by_constant(vec: &mut Self, c: i16);
 
     // Bitwise operations
     #[requires(true)]
     #[ensures(|result| fstar!(r#"f_repr $result == Spec.Utils.map_array (fun x -> x &. c) (f_repr $v)"#))]
-    fn bitwise_and_with_constant(v: Self, c: i16) -> Self;
+    fn bitwise_and_with_constant(v: &mut Self, c: i16);
 
     #[requires(SHIFT_BY >= 0 && SHIFT_BY < 16)]
     #[ensures(|result| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> f_repr $result == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (f_repr $v)"#))]
-    fn shift_right<const SHIFT_BY: i32>(v: Self) -> Self;
+    fn shift_right<const SHIFT_BY: i32>(v: &mut Self);
     // fn shift_left<const SHIFT_BY: i32>(v: Self) -> Self;
 
     // Modular operations
     #[requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (f_repr $v)"#))]
     #[ensures(|result| fstar!(r#"f_repr $result == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (f_repr $v)"#))]
-    fn cond_subtract_3329(v: Self) -> Self;
+    fn cond_subtract_3329(v: &mut Self);
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b_array 28296 (f_repr $vector)"#))]
-    fn barrett_reduce(vector: Self) -> Self;
+    fn barrett_reduce(vector: &mut Self);
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 c"#))]
-    fn montgomery_multiply_by_constant(v: Self, c: i16) -> Self;
+    fn montgomery_multiply_by_constant(v: &mut Self, c: i16);
 
     // Compression
     #[requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (f_repr $a) i) >= 0 /\
         v (Seq.index (f_repr $a) i) < 3329"#))]
     #[ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> bounded (Seq.index (f_repr $result) i) 1"#))]
-    fn compress_1(a: Self) -> Self;
+    fn compress_1(a: &mut Self);
     #[requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
             v $COEFFICIENT_BITS == 5 \/
             v $COEFFICIENT_BITS == 10 \/
@@ -94,88 +96,95 @@ pub trait Operations: Copy + Clone + Repr {
             v $COEFFICIENT_BITS == 10 \/
             v $COEFFICIENT_BITS == 11) ==>
                 (forall (i:nat). i < 16 ==> bounded (Seq.index (f_repr $result) i) (v $COEFFICIENT_BITS))"#))]
-    fn compress<const COEFFICIENT_BITS: i32>(a: Self) -> Self;
+    fn compress<const COEFFICIENT_BITS: i32>(a: &mut Self);
     #[requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
         v $COEFFICIENT_BITS == 5 \/
         v $COEFFICIENT_BITS == 10 \/
         v $COEFFICIENT_BITS == 11) /\
     (forall (i:nat). i < 16 ==> v (Seq.index (f_repr $a) i) >= 0 /\
         v (Seq.index (f_repr $a) i) < pow2 (v $COEFFICIENT_BITS))"#))]
-    fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(a: Self) -> Self;
+    fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(a: &mut Self);
 
     // NTT
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
                        Spec.Utils.is_i16b_array (11207+5*3328) (f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) (f_repr $out)"#))]
-    fn ntt_layer_1_step(a: Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) -> Self;
+    fn ntt_layer_1_step(a: &mut Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16);
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                        Spec.Utils.is_i16b_array (11207+4*3328) (f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) (f_repr $out)"#))]
-    fn ntt_layer_2_step(a: Self, zeta0: i16, zeta1: i16) -> Self;
+    fn ntt_layer_2_step(a: &mut Self, zeta0: i16, zeta1: i16);
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
                        Spec.Utils.is_i16b_array (11207+3*3328) (f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) (f_repr $out)"#))]
-    fn ntt_layer_3_step(a: Self, zeta: i16) -> Self;
+    fn ntt_layer_3_step(a: &mut Self, zeta: i16);
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
                        Spec.Utils.is_i16b_array (4 * 3328) (f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#))]
-    fn inv_ntt_layer_1_step(a: Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) -> Self;
+    fn inv_ntt_layer_1_step(a: &mut Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16);
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                        Spec.Utils.is_i16b_array 3328 (f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#))]
-    fn inv_ntt_layer_2_step(a: Self, zeta0: i16, zeta1: i16) -> Self;
+    fn inv_ntt_layer_2_step(a: &mut Self, zeta0: i16, zeta1: i16);
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta/\
                        Spec.Utils.is_i16b_array 3328 (f_repr ${a})"#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#))]
-    fn inv_ntt_layer_3_step(a: Self, zeta: i16) -> Self;
+    fn inv_ntt_layer_3_step(a: &mut Self, zeta: i16);
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
                        Spec.Utils.is_i16b_array 3328 (f_repr ${lhs}) /\
                        Spec.Utils.is_i16b_array 3328 (f_repr ${rhs}) "#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#))]
-    fn ntt_multiply(lhs: &Self, rhs: &Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16)
-        -> Self;
+    fn ntt_multiply(
+        lhs: &Self,
+        rhs: &Self,
+        out: &mut Self,
+        zeta0: i16,
+        zeta1: i16,
+        zeta2: i16,
+        zeta3: i16,
+    );
 
     // Serialization and deserialization
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (f_repr $a)"#))]
     #[ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 1 (f_repr $a) ==> Spec.MLKEM.serialize_post 1 (f_repr $a) $result"#))]
-    fn serialize_1(a: Self) -> [u8; 2];
+    fn serialize_1(a: Self, out: &mut [u8]);
     #[requires(a.len() == 2)]
     #[ensures(|result| fstar!(r#"sz (Seq.length $a) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $a (f_repr $result)"#))]
-    fn deserialize_1(a: &[u8]) -> Self;
+    fn deserialize_1(a: &[u8], out: &mut Self);
 
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (f_repr $a)"#))]
     #[ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 4 (f_repr $a) ==> Spec.MLKEM.serialize_post 4 (f_repr $a) $result"#))]
-    fn serialize_4(a: Self) -> [u8; 8];
+    fn serialize_4(a: Self, out: &mut [u8]);
     #[requires(a.len() == 8)]
     #[ensures(|result| fstar!(r#"sz (Seq.length $a) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $a (f_repr $result)"#))]
-    fn deserialize_4(a: &[u8]) -> Self;
+    fn deserialize_4(a: &[u8], out: &mut Self);
 
-    fn serialize_5(a: Self) -> [u8; 10];
+    fn serialize_5(a: Self, out: &mut [u8]);
     #[requires(a.len() == 10)]
-    fn deserialize_5(a: &[u8]) -> Self;
+    fn deserialize_5(a: &[u8], out: &mut Self);
 
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (f_repr $a)"#))]
     #[ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 10 (f_repr $a) ==> Spec.MLKEM.serialize_post 10 (f_repr $a) $result"#))]
-    fn serialize_10(a: Self) -> [u8; 20];
+    fn serialize_10(a: Self, out: &mut [u8]);
     #[requires(a.len() == 20)]
     #[ensures(|result| fstar!(r#"sz (Seq.length $a) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $a (f_repr $result)"#))]
-    fn deserialize_10(a: &[u8]) -> Self;
+    fn deserialize_10(a: &[u8], out: &mut Self);
 
-    fn serialize_11(a: Self) -> [u8; 22];
+    fn serialize_11(a: Self, out: &mut [u8]);
     #[requires(a.len() == 22)]
-    fn deserialize_11(a: &[u8]) -> Self;
+    fn deserialize_11(a: &[u8], out: &mut Self);
 
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (f_repr $a)"#))]
     #[ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 12 (f_repr $a) ==> Spec.MLKEM.serialize_post 12 (f_repr $a) $result"#))]
-    fn serialize_12(a: Self) -> [u8; 24];
+    fn serialize_12(a: Self, out: &mut [u8]);
     #[requires(a.len() == 24)]
     #[ensures(|result| fstar!(r#"sz (Seq.length $a) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $a (f_repr $result)"#))]
-    fn deserialize_12(a: &[u8]) -> Self;
+    fn deserialize_12(a: &[u8], out: &mut Self);
 
     #[requires(a.len() == 24 && out.len() == 16)]
     #[ensures(|result|
@@ -231,12 +240,12 @@ pub trait Operations: Copy + Clone {
 // hax does not support trait with default implementations, so we use the following pattern
 #[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 $fer"#))]
 #[inline(always)]
-pub fn montgomery_multiply_fe<T: Operations>(v: T, fer: i16) -> T {
+pub fn montgomery_multiply_fe<T: Operations>(v: &mut T, fer: i16) {
     T::montgomery_multiply_by_constant(v, fer)
 }
 
 #[inline(always)]
-pub fn to_standard_domain<T: Operations>(v: T) -> T {
+pub fn to_standard_domain<T: Operations>(v: &mut T) {
     T::montgomery_multiply_by_constant(v, MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS as i16)
 }
 
@@ -247,18 +256,20 @@ pub fn to_standard_domain<T: Operations>(v: T) -> T {
                                         let y = Seq.index (i1._super_12682756204189288427.f_repr ${result}) i in
                                         (v y >= 0 /\ v y <= 3328 /\ (v y % 3329 == v x % 3329)))"#))]
 #[inline(always)]
-pub fn to_unsigned_representative<T: Operations>(a: T) -> T {
-    let t = T::shift_right::<15>(a);
-    let fm = T::bitwise_and_with_constant(t, FIELD_MODULUS);
-    T::add(a, &fm)
+pub fn to_unsigned_representative<T: Operations>(a: &T, out: &mut T) {
+    *out = a.clone(); // XXX: We need a copy of `a` here. At least
+                       // the allocation becomes apparent on the
+                       // outside.
+    T::shift_right::<15>(out);
+    T::bitwise_and_with_constant(out, FIELD_MODULUS);
+    T::add(out, a)
 }
 
 #[hax_lib::fstar::options("--z3rlimit 200 --split_queries always")]
 #[hax_lib::requires(fstar!(r#"forall i. let x = Seq.index (i1._super_12682756204189288427.f_repr ${vec}) i in 
                                       (x == mk_i16 0 \/ x == mk_i16 1)"#))]
 #[inline(always)]
-pub fn decompress_1<T: Operations>(vec: T) -> T {
-    let z = T::ZERO();
+pub fn decompress_1<T: Operations>(vec: &mut T) {
     hax_lib::fstar!(
         "assert(forall i. Seq.index (i1._super_12682756204189288427.f_repr ${z}) i == mk_i16 0)"
     );
@@ -272,12 +283,11 @@ pub fn decompress_1<T: Operations>(vec: T) -> T {
                                         (0 - v (Seq.index (i1._super_12682756204189288427.f_repr ${vec}) i)))"#
     );
 
-    let s = T::sub(z, &vec);
+    T::negate(vec);
     hax_lib::fstar!(
         r#"assert(forall i. Seq.index (i1._super_12682756204189288427.f_repr ${s}) i == mk_i16 0 \/ 
                                       Seq.index (i1._super_12682756204189288427.f_repr ${s}) i == mk_i16 (-1))"#
     );
     hax_lib::fstar!(r#"assert (i1.f_bitwise_and_with_constant_pre ${s} (mk_i16 1665))"#);
-    let res = T::bitwise_and_with_constant(s, 1665);
-    res
+    T::bitwise_and_with_constant(vec, 1665);
 }

--- a/libcrux/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/traits.rs
@@ -18,7 +18,7 @@ pub trait Repr: Copy + Clone {
 pub trait Operations: Copy + Clone + Repr {
     #[allow(non_snake_case)]
     #[requires(true)]
-    #[ensures(|result| fstar!(r#"f_repr $result == Seq.create 16 0s"#))]
+    #[ensures(|result| fstar!(r#"f_repr $result == Seq.create 16 (mk_i16 0)"#))]
     fn ZERO() -> Self;
 
     #[requires(array.len() == 16)]
@@ -28,6 +28,12 @@ pub trait Operations: Copy + Clone + Repr {
     #[requires(true)]
     #[ensures(|result| fstar!(r#"f_repr $x == $result"#))]
     fn to_i16_array(x: Self) -> [i16; 16];
+
+    #[requires(array.len() >= 32)]
+    fn from_bytes(array: &[u8]) -> Self;
+
+    #[requires(bytes.len() >= 32)]
+    fn to_bytes(x: Self, bytes: &mut [u8]);
 
     // Basic arithmetic
     #[requires(fstar!(r#"forall i. i < 16 ==> 
@@ -57,13 +63,13 @@ pub trait Operations: Copy + Clone + Repr {
     fn bitwise_and_with_constant(v: Self, c: i16) -> Self;
 
     #[requires(SHIFT_BY >= 0 && SHIFT_BY < 16)]
-    #[ensures(|result| fstar!(r#"(v_SHIFT_BY >=. 0l /\ v_SHIFT_BY <. 16l) ==> f_repr $result == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (f_repr $v)"#))]
+    #[ensures(|result| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> f_repr $result == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (f_repr $v)"#))]
     fn shift_right<const SHIFT_BY: i32>(v: Self) -> Self;
     // fn shift_left<const SHIFT_BY: i32>(v: Self) -> Self;
 
     // Modular operations
     #[requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (f_repr $v)"#))]
-    #[ensures(|result| fstar!(r#"f_repr $result == Spec.Utils.map_array (fun x -> if x >=. 3329s then x -! 3329s else x) (f_repr $v)"#))]
+    #[ensures(|result| fstar!(r#"f_repr $result == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (f_repr $v)"#))]
     fn cond_subtract_3329(v: Self) -> Self;
 
     #[requires(fstar!(r#"Spec.Utils.is_i16b_array 28296 (f_repr $vector)"#))]
@@ -186,6 +192,8 @@ pub trait Operations: Copy + Clone {
     fn ZERO() -> Self;
     fn from_i16_array(array: &[i16]) -> Self;
     fn to_i16_array(x: Self) -> [i16; 16];
+    fn from_bytes(array: &[u8]) -> Self;
+    fn to_bytes(x: Self, bytes: &mut [u8]);
     fn add(lhs: Self, rhs: &Self) -> Self;
     fn sub(lhs: Self, rhs: &Self) -> Self;
     fn multiply_by_constant(v: Self, c: i16) -> Self;
@@ -247,12 +255,12 @@ pub fn to_unsigned_representative<T: Operations>(a: T) -> T {
 
 #[hax_lib::fstar::options("--z3rlimit 200 --split_queries always")]
 #[hax_lib::requires(fstar!(r#"forall i. let x = Seq.index (i1._super_12682756204189288427.f_repr ${vec}) i in 
-                                      (x == 0s \/ x == 1s)"#))]
+                                      (x == mk_i16 0 \/ x == mk_i16 1)"#))]
 #[inline(always)]
 pub fn decompress_1<T: Operations>(vec: T) -> T {
     let z = T::ZERO();
     hax_lib::fstar!(
-        "assert(forall i. Seq.index (i1._super_12682756204189288427.f_repr ${z}) i == 0s)"
+        "assert(forall i. Seq.index (i1._super_12682756204189288427.f_repr ${z}) i == mk_i16 0)"
     );
     hax_lib::fstar!(
         r#"assert(forall i. let x = Seq.index (i1._super_12682756204189288427.f_repr ${vec}) i in 
@@ -266,10 +274,10 @@ pub fn decompress_1<T: Operations>(vec: T) -> T {
 
     let s = T::sub(z, &vec);
     hax_lib::fstar!(
-        r#"assert(forall i. Seq.index (i1._super_12682756204189288427.f_repr ${s}) i == 0s \/ 
-                                      Seq.index (i1._super_12682756204189288427.f_repr ${s}) i == -1s)"#
+        r#"assert(forall i. Seq.index (i1._super_12682756204189288427.f_repr ${s}) i == mk_i16 0 \/ 
+                                      Seq.index (i1._super_12682756204189288427.f_repr ${s}) i == mk_i16 (-1))"#
     );
-    hax_lib::fstar!(r#"assert (i1.f_bitwise_and_with_constant_pre ${s} 1665s)"#);
+    hax_lib::fstar!(r#"assert (i1.f_bitwise_and_with_constant_pre ${s} (mk_i16 1665))"#);
     let res = T::bitwise_and_with_constant(s, 1665);
     res
 }

--- a/libcrux/libcrux-ml-kem/tests/nistkats.rs
+++ b/libcrux/libcrux-ml-kem/tests/nistkats.rs
@@ -131,3 +131,94 @@ impl_nist_known_answer_tests!(
     1024,
     libcrux_ml_kem::kyber1024
 );
+
+// Testing multiplexing APIs
+
+macro_rules! impl_kats {
+    ($name:ident, $variant:literal, $parameter_set:literal, $module:path) => {
+        #[test]
+        fn $name() {
+            use $module::*;
+
+            let katfile_path = Path::new("tests")
+                .join("kats")
+            .join(format!("nistkats_{}_{}.json", $variant, $parameter_set));
+            let katfile = File::open(katfile_path).expect("Could not open KAT file.");
+            let reader = BufReader::new(katfile);
+
+            let nist_kats: Vec<MlKemNISTKAT> =
+                serde_json::from_reader(reader).expect("Could not deserialize KAT file.");
+
+            for kat in nist_kats {
+                let key_pair = generate_key_pair(kat.key_generation_seed);
+                #[cfg(all(feature = "alloc", feature = "incremental"))]
+                let incremental_key_pair = incremental::alloc::generate_key_pair(kat.key_generation_seed);
+
+                assert!(validate_public_key(key_pair.public_key()));
+
+                let public_key_hash = sha256(key_pair.pk());
+                let secret_key_hash = sha256(key_pair.sk());
+
+                assert_eq!(public_key_hash, kat.sha3_256_hash_of_public_key, "lhs: computed public key hash, rhs: hash from kat");
+                assert_eq!(secret_key_hash, kat.sha3_256_hash_of_secret_key, "lhs: computed secret key hash, rhs: hash from kat");
+
+                // Encapsulate
+                let (ciphertext, shared_secret) =
+                encapsulate(key_pair.public_key(), kat.encapsulation_seed);
+                let ciphertext_hash = sha256(ciphertext.as_ref());
+
+                assert_eq!(ciphertext_hash, kat.sha3_256_hash_of_ciphertext, "lhs: computed ciphertext hash, rhs: hash from akt");
+                assert_eq!(shared_secret.as_ref(), kat.shared_secret, "lhs: computed shared secret from encapsulate, rhs: shared secret from kat");
+
+                // Decapsulate
+                assert!(validate_private_key(key_pair.private_key(), &ciphertext));
+
+                let shared_secret_from_decapsulate =
+                decapsulate(key_pair.private_key(), &ciphertext);
+                assert_eq!(shared_secret_from_decapsulate, shared_secret.as_ref(), "lhs: shared secret computed via decapsulation, rhs: shared secret computed via encapsulation");
+
+                // Incremental encapsulate
+                #[cfg(all(feature = "alloc", feature = "incremental"))]
+                {
+                    let mut pk1_bytes = [0u8; 64];
+                    incremental_key_pair.pk1_bytes(&mut pk1_bytes).unwrap();
+
+                    let mut pk2_bytes = [0u8; incremental::pk2_len()];
+                    incremental_key_pair.pk2_bytes(&mut pk2_bytes);
+
+                    let (ct1, ct2, incremental_shared_secret) = {
+                        let pk1 = incremental::PublicKey1::try_from(&pk1_bytes as &[u8]).unwrap();
+                        let (ct1, state, ss) = incremental::alloc::encapsulate1(&pk1,  kat.encapsulation_seed);
+
+                        assert!(incremental::validate_pk(&pk1, &pk2_bytes).is_ok());
+
+                        // ... and then to pk2.
+                        // pk2 is passed in as bytes because the deserializaiton is runtime
+                        // platform dependent.
+                        let ct2 = incremental::alloc::encapsulate2(state.as_ref(), &pk2_bytes).unwrap();
+
+                        (ct1, ct2, ss)
+                    };
+
+                    let incremental_shared_secret_decaps = incremental::alloc::decapsulate(incremental_key_pair.as_ref(), &ct1, &ct2);
+                    assert_eq!(incremental_shared_secret, shared_secret.as_ref());
+                    assert_eq!(incremental_shared_secret_decaps, shared_secret.as_ref());
+                }
+            }
+        }
+    };
+}
+
+#[cfg(all(feature = "mlkem512"))]
+impl_kats!(mlkem512_nist_kats, "mlkem", 512, libcrux_ml_kem::mlkem512);
+
+#[cfg(all(feature = "mlkem768"))]
+impl_kats!(mlkem768_nist_kat, "mlkem", 768, libcrux_ml_kem::mlkem768);
+
+#[cfg(all(feature = "mlkem1024"))]
+impl_kats!(
+    mlkem1024_nist_kats,
+    "mlkem",
+    1024,
+    libcrux_ml_kem::mlkem1024
+);

--- a/libcrux/libcrux-ml-kem/tests/self.rs
+++ b/libcrux/libcrux-ml-kem/tests/self.rs
@@ -1,7 +1,7 @@
 use libcrux_ml_kem::{MlKemCiphertext, MlKemPrivateKey};
 
 use libcrux_sha3::shake256;
-use rand::{rngs::OsRng, thread_rng, RngCore};
+use rand::{rng, rngs::OsRng, TryRngCore};
 
 const SHARED_SECRET_SIZE: usize = 32;
 
@@ -131,11 +131,129 @@ macro_rules! impl_consistency_unpacked {
     };
 }
 
+#[cfg(feature = "incremental")]
+macro_rules! impl_consistency_incremental {
+    ($name:ident, $modp:path) => {
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+        #[cfg(feature = "alloc")]
+        #[test]
+        fn $name() {
+            use $modp::{incremental::*, portable::unpacked};
+
+            let key_gen_randomness = random_array();
+
+            // Generate key pair.
+            // Alloc (platform dependent keys)
+            let key_pair = alloc::generate_key_pair(key_gen_randomness);
+            // Serialized keys
+            let mut key_pair_bytes = [0u8; key_pair_len()];
+            generate_key_pair(key_gen_randomness, &mut key_pair_bytes).unwrap();
+            // Compressed, serialized keys
+            let key_pair_bytes_compressed = KeyPairCompressedBytes::from_seed(key_gen_randomness);
+
+            // Get pk1 and pk2 to send out.
+            let mut pk1_bytes = [0u8; 64];
+            key_pair.pk1_bytes(&mut pk1_bytes).unwrap();
+
+            let mut pk2_bytes = [0u8; pk2_len()];
+            key_pair.pk2_bytes(&mut pk2_bytes);
+
+            // Check that the keys are the same
+            assert_eq!(pk1_bytes, pk1(&key_pair_bytes));
+            assert_eq!(pk2_bytes, pk2(&key_pair_bytes));
+            // Same for the compressed key pair
+            assert_eq!(&pk1_bytes, key_pair_bytes_compressed.pk1());
+            assert_eq!(&pk2_bytes, key_pair_bytes_compressed.pk2());
+
+            // The other party encapsulates to pk1 ...
+            let encaps_randomness = random_array();
+            let (ct1, ct2, shared_secret) = {
+                let pk1 = PublicKey1::try_from(&pk1_bytes as &[u8]).unwrap();
+                let (ct1, state, dyn_ss) = alloc::encapsulate1(&pk1, encaps_randomness);
+                debug_assert_eq!(ct1.value.len(), Ciphertext1::len());
+
+                // encaps1 with serialized state
+                let mut serialized_state = [0u8; encaps_state_len()];
+                let mut shared_secret_serialized = [0u8; SHARED_SECRET_SIZE];
+                let ct12 = encapsulate1(
+                    &pk1_bytes,
+                    encaps_randomness,
+                    &mut serialized_state,
+                    &mut shared_secret_serialized,
+                )
+                .unwrap();
+                assert_eq!(ct1.value, ct12.value);
+
+                // Check the public key for consistency.
+                assert!(validate_pk(&pk1, &pk2_bytes).is_ok());
+
+                // ... and then to pk2.
+                // pk2 is passed in as bytes because the deserializaiton is runtime
+                // platform dependent.
+                let ct2 = alloc::encapsulate2(state.as_ref(), &pk2_bytes).unwrap();
+                debug_assert_eq!(ct2.value.len(), Ciphertext2::len());
+
+                // encaps2 with serialized state
+                let ct22 = encapsulate2(&serialized_state, &pk2_bytes);
+                assert_eq!(ct2.value, ct22.value);
+
+                assert_eq!(dyn_ss, shared_secret_serialized);
+                (ct1, ct2, dyn_ss)
+            };
+
+            // The initiator decapsulates the two ciphertexts.
+            // Alloc (platform dependent keys)
+            let shared_secret_decaps = alloc::decapsulate(key_pair.as_ref(), &ct1, &ct2);
+            // Serialized key
+            let shared_secret_decaps2 =
+                decapsulate_incremental_key(&key_pair_bytes, &ct1, &ct2).unwrap();
+            // Compressed, serialized key
+            let sk = key_pair_bytes_compressed.sk();
+            let shared_secret_decaps3 = decapsulate_compressed_key(sk, &ct1, &ct2);
+
+            // Check the shared secret.
+            assert_eq!(shared_secret_decaps, shared_secret);
+            assert_eq!(shared_secret_decaps2, shared_secret);
+            assert_eq!(shared_secret_decaps3, shared_secret);
+
+            // Compute comparison shared secrets and ciphertexts with the other APIs
+            let key_pair = unpacked::generate_key_pair(key_gen_randomness);
+            let (ciphertext_unpacked, shared_secret_unpacked) =
+                unpacked::encapsulate(&key_pair.public_key, encaps_randomness);
+
+            // Check c1 and c2
+            let mut combined_ct = vec![0u8; ciphertext_unpacked.as_ref().len()];
+            combined_ct[0..ct1.value.len()].copy_from_slice(&ct1.value);
+            combined_ct[ct1.value.len()..].copy_from_slice(&ct2.value);
+            assert_eq!(
+                ciphertext_unpacked.as_ref(),
+                &combined_ct,
+                "Invalid ciphertexts"
+            );
+
+            // Check API consistency
+            assert_eq!(
+                shared_secret_unpacked, shared_secret,
+                "Invalid encaps shared secret"
+            );
+        }
+    };
+}
+
+#[cfg(all(feature = "mlkem512", feature = "incremental"))]
+impl_consistency_incremental!(consistency_incremental_512, libcrux_ml_kem::mlkem512);
+
+#[cfg(all(feature = "mlkem768", feature = "incremental"))]
+impl_consistency_incremental!(consistency_incremental_768, libcrux_ml_kem::mlkem768);
+
+#[cfg(all(feature = "mlkem1024", feature = "incremental"))]
+impl_consistency_incremental!(consistency_incremental_1024, libcrux_ml_kem::mlkem1024);
+
 fn modify_ciphertext<const LEN: usize>(ciphertext: MlKemCiphertext<LEN>) -> MlKemCiphertext<LEN> {
     let mut raw_ciphertext = [0u8; LEN];
     raw_ciphertext.copy_from_slice(ciphertext.as_ref());
 
-    let mut random_u32: usize = thread_rng().next_u32().try_into().unwrap();
+    let mut random_u32: usize = rng().try_next_u32().unwrap().try_into().unwrap();
 
     let mut random_byte: u8 = (random_u32 & 0xFF) as u8;
     if random_byte == 0 {
@@ -182,7 +300,7 @@ fn modify_secret_key<const LEN: usize>(
     let mut raw_secret_key = [0u8; LEN];
     raw_secret_key.copy_from_slice(secret_key.as_slice());
 
-    let mut random_u32: usize = thread_rng().next_u32().try_into().unwrap();
+    let mut random_u32: usize = rng().try_next_u32().unwrap().try_into().unwrap();
 
     let mut random_byte: u8 = (random_u32 & 0xFF) as u8;
     if random_byte == 0 {


### PR DESCRIPTION
This PR repesents a sync with the [`jonas/mlkem-mut-cca`](https://github.com/cryspen/libcrux/tree/jonas/mlkem-mut-cca) branch of mainline libcrux, which is a WIP branch for applying `&mut` style throughout ML-KEM.

In mainline libcrux there is much more work to be done on maintaining verification status and propagating the changes to all features, but for IoT we only care about the portable version and have no verification status to maintain. Therefore, after cleanup, this should be able to get merged here.

From my measurements it results in a 5-9% improvement in cycles spent for KEM operations.