### PR TITLE
[L4R5ZI] Local benchmarks for SHA3/SHAKE input & output sizes as required by ML-KEM

### DIFF
--- a/libcrux-nucleo-l4r5zi/Cargo.toml
+++ b/libcrux-nucleo-l4r5zi/Cargo.toml
@@ -25,6 +25,10 @@ embassy-stm32 = { version = "0.2.0", features = [ "stm32l4r5zi", "defmt", ] }
 embedded-alloc = "0.6.0"
 libcrux-sha3 = { path = "../libcrux/libcrux-sha3" }
 libcrux-pqm4 = { path = "../sys/pqm4" }
+rand_core = {version = "0.6.4"} # This is the version of rand_core
+                                # that embassy_stm32.0.2.0 depends
+                                # on. We need it to get the right
+                                # RngCore trait for the on-device RNG.
 
 [dev-dependencies]
 defmt-test = "0.3"

--- a/libcrux-nucleo-l4r5zi/Cargo.toml
+++ b/libcrux-nucleo-l4r5zi/Cargo.toml
@@ -23,6 +23,7 @@ libcrux-iot-testutil = { path = "../libcrux-iot-testutil" }
 libcrux-testbench = { path = "../libcrux-testbench" }
 embassy-stm32 = { version = "0.2.0", features = [ "stm32l4r5zi", "defmt", ] }
 embedded-alloc = "0.6.0"
+libcrux-sha3 = { path = "../libcrux/libcrux-sha3" }
 libcrux-pqm4 = { path = "../sys/pqm4" }
 
 [dev-dependencies]

--- a/libcrux-nucleo-l4r5zi/src/bin/pqm4.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/pqm4.rs
@@ -45,6 +45,13 @@ fn main() -> ! {
     });
     CycleCounter::end_measurement("pqm4: Decapsulate ML-KEM 1024", start);
 
+    let mut sha3_output = [0u8; 64];
+    let sha3_input = [1,2,3,4];
+    unsafe {
+        libcrux_pqm4::sha3_512(addr_of_mut!(sha3_output[0]), addr_of!(sha3_input[0]), 4);
+    }
+    defmt::println!("SHA3-512([1,2,3,4]): {=[u8]}", sha3_output);
+    
     assert_eq!(ss_enc, ss_dec);
 
     board::exit()

--- a/libcrux-nucleo-l4r5zi/src/bin/sha3_cycles.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/sha3_cycles.rs
@@ -1,0 +1,277 @@
+#![no_main]
+#![no_std]
+
+use board::cycle_counter::CycleCounter;
+use board::init::setup_cycle_counter;
+
+use libcrux_nucleo_l4r5zi::{self as board, init::ClockConfig}; // global logger + panicking-behavior + memory layout
+
+// G aka SHA3-512
+const G_DIGEST_SIZE: usize = 64;
+const G_INPUT_SIZE_1: usize = 32; // CPA_PKE_KEY_GENERATION_SEED_SIZE
+const G_INPUT_SIZE_2: usize = 2 * H_DIGEST_SIZE; // ind_cca::encapsulate,decapsulate
+
+// H aka SHA3-256
+const H_DIGEST_SIZE: usize = 32;
+const H_INPUT_RANDOMNESS_SIZE: usize = 32; // SHARED_SECRET_SIZE
+
+// Dependent on parameter set
+const H_INPUT_CIPHERTEXT_SIZE_512: usize = 768; // CIPHERTEXT_SIZE
+const H_INPUT_CIPHERTEXT_SIZE_768: usize = 1088; // CIPHERTEXT_SIZE
+const H_INPUT_CIPHERTEXT_SIZE_1024: usize = 1568; // CIPHERTEXT_SIZE
+const H_INPUT_PUBLIC_KEY_SIZE_512: usize = 800; // PUBLIC_KEY_SIZE
+const H_INPUT_PUBLIC_KEY_SIZE_768: usize = 1184; // PUBLIC_KEY_SIZE
+const H_INPUT_PUBLIC_KEY_SIZE_1024: usize = 1568; // PUBLIC_KEY_SIZE
+
+// For XOFs we pair occurring (input, output) sizes
+
+// PRF aka SHAKE256
+const PRF_KDF: (usize, usize) = (2 * H_DIGEST_SIZE, 32);
+const PRF_IMPLICIT_REJECTION_SHARED_SECRET_512: (usize, usize) = (800, 32); // Dependent on parameter set
+const PRF_IMPLICIT_REJECTION_SHARED_SECRET_768: (usize, usize) = (1120, 32); // Dependent on parameter set
+const PRF_IMPLICIT_REJECTION_SHARED_SECRET_1024: (usize, usize) = (1600, 32); // Dependent on parameter set
+const PRF_ETA2_RANDOMNESS_512: (usize, usize) = (33, 128); // Dependent on parameter set
+const PRF_ETA2_RANDOMNESS_768: (usize, usize) = (33, 128); // Dependent on parameter set
+const PRF_ETA2_RANDOMNESS_1024: (usize, usize) = (33, 128); // Dependent on parameter set
+const PRF_ETA1_RANDOMNESS_512: (usize, usize) = (33, 192); // Dependent on parameter set
+const PRF_ETA1_RANDOMNESS_768: (usize, usize) = (33, 128); // Dependent on parameter set
+const PRF_ETA1_RANDOMNESS_1024: (usize, usize) = (33, 128); // Dependent on parameter set
+
+// SHAKE128
+const INIT_ABSORB_FINAL_INPUT_SIZE: usize = 34;
+const BLOCK_SIZE: usize = 168;
+const THREE_BLOCKS: usize = BLOCK_SIZE * 3;
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    // Set up the system clock.
+    let clock_config = ClockConfig::CycleBenchmark;
+    board::init::setup_clock(clock_config);
+
+    setup_cycle_counter();
+
+    // G aka SHA3-512
+    let mut g_digest = [0u8; G_DIGEST_SIZE];
+
+    {
+        let g_input_1 = [1u8; G_INPUT_SIZE_1];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::sha512(&mut g_digest, &g_input_1));
+        CycleCounter::end_measurement("SHA3-512 (G_INPUT_SIZE_1)", start);
+    }
+
+    {
+        let g_input_2 = [2u8; G_INPUT_SIZE_2];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::sha512(&mut g_digest, &g_input_2));
+        CycleCounter::end_measurement("SHA3-512 (G_INPUT_SIZE_2)", start);
+    }
+
+    // H aka SHA3-256
+    let mut h_digest = [0u8; H_DIGEST_SIZE];
+    {
+        let h_input = [1u8; H_INPUT_RANDOMNESS_SIZE];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::sha256(&mut h_digest, &h_input));
+        CycleCounter::end_measurement("SHA3-256 (H_INPUT_RANDOMNESS_SIZE)", start);
+    }
+
+    {
+        let h_input = [1u8; H_INPUT_CIPHERTEXT_SIZE_512];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::sha256(&mut h_digest, &h_input));
+        CycleCounter::end_measurement("SHA3-256 (H_INPUT_CIPHERTEXT_SIZE_512)", start);
+    }
+
+    {
+        let h_input = [1u8; H_INPUT_CIPHERTEXT_SIZE_768];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::sha256(&mut h_digest, &h_input));
+        CycleCounter::end_measurement("SHA3-256 (H_INPUT_CIPHERTEXT_SIZE_768)", start);
+    }
+
+    {
+        let h_input = [1u8; H_INPUT_CIPHERTEXT_SIZE_1024];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::sha256(&mut h_digest, &h_input));
+        CycleCounter::end_measurement("SHA3-256 (H_INPUT_CIPHERTEXT_SIZE_1024)", start);
+    }
+
+    {
+        let h_input = [1u8; H_INPUT_PUBLIC_KEY_SIZE_512];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::sha256(&mut h_digest, &h_input));
+        CycleCounter::end_measurement("SHA3-256 (H_INPUT_PUBLIC_KEY_SIZE_512)", start);
+    }
+
+    {
+        let h_input = [1u8; H_INPUT_PUBLIC_KEY_SIZE_768];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::sha256(&mut h_digest, &h_input));
+        CycleCounter::end_measurement("SHA3-256 (H_INPUT_PUBLIC_KEY_SIZE_768)", start);
+    }
+
+    {
+        let h_input = [1u8; H_INPUT_PUBLIC_KEY_SIZE_1024];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::sha256(&mut h_digest, &h_input));
+        CycleCounter::end_measurement("SHA3-256 (H_INPUT_PUBLIC_KEY_SIZE_1024)", start);
+    }
+
+    // SHAKE256
+    {
+        let prf_input = [1u8; PRF_KDF.0];
+        let mut prf_output = [0u8; PRF_KDF.1];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::shake256(
+            &mut prf_output,
+            &prf_input,
+        ));
+        CycleCounter::end_measurement("SHAKE256 (PRF_KDF)", start);
+    }
+
+    {
+        let prf_input = [1u8; PRF_IMPLICIT_REJECTION_SHARED_SECRET_512.0];
+        let mut prf_output = [0u8; PRF_IMPLICIT_REJECTION_SHARED_SECRET_512.1];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::shake256(
+            &mut prf_output,
+            &prf_input,
+        ));
+        CycleCounter::end_measurement("SHAKE256 (PRF_IMPLICIT_REJECTION_SHARED_SECRET_512)", start);
+    }
+
+    {
+        let prf_input = [1u8; PRF_IMPLICIT_REJECTION_SHARED_SECRET_768.0];
+        let mut prf_output = [0u8; PRF_IMPLICIT_REJECTION_SHARED_SECRET_768.1];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::shake256(
+            &mut prf_output,
+            &prf_input,
+        ));
+        CycleCounter::end_measurement("SHAKE256 (PRF_IMPLICIT_REJECTION_SHARED_SECRET_768)", start);
+    }
+
+    {
+        let prf_input = [1u8; PRF_IMPLICIT_REJECTION_SHARED_SECRET_1024.0];
+        let mut prf_output = [0u8; PRF_IMPLICIT_REJECTION_SHARED_SECRET_1024.1];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::shake256(
+            &mut prf_output,
+            &prf_input,
+        ));
+        CycleCounter::end_measurement(
+            "SHAKE256 (PRF_IMPLICIT_REJECTION_SHARED_SECRET_1024)",
+            start,
+        );
+    }
+
+    {
+        let prf_input = [1u8; PRF_ETA2_RANDOMNESS_512.0];
+        let mut prf_output = [0u8; PRF_ETA2_RANDOMNESS_512.1];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::shake256(
+            &mut prf_output,
+            &prf_input,
+        ));
+        CycleCounter::end_measurement("SHAKE256 (PRF_ETA2_RANDOMNESS_512)", start);
+    }
+
+    {
+        let prf_input = [1u8; PRF_ETA2_RANDOMNESS_768.0];
+        let mut prf_output = [0u8; PRF_ETA2_RANDOMNESS_768.1];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::shake256(
+            &mut prf_output,
+            &prf_input,
+        ));
+        CycleCounter::end_measurement("SHAKE256 (PRF_ETA2_RANDOMNESS_768)", start);
+    }
+
+    {
+        let prf_input = [1u8; PRF_ETA2_RANDOMNESS_1024.0];
+        let mut prf_output = [0u8; PRF_ETA2_RANDOMNESS_1024.1];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::shake256(
+            &mut prf_output,
+            &prf_input,
+        ));
+        CycleCounter::end_measurement("SHAKE256 (PRF_ETA2_RANDOMNESS_1024)", start);
+    }
+
+    {
+        let prf_input = [1u8; PRF_ETA1_RANDOMNESS_512.0];
+        let mut prf_output = [0u8; PRF_ETA1_RANDOMNESS_512.1];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::shake256(
+            &mut prf_output,
+            &prf_input,
+        ));
+        CycleCounter::end_measurement("SHAKE256 (PRF_ETA1_RANDOMNESS_512)", start);
+    }
+
+    {
+        let prf_input = [1u8; PRF_ETA1_RANDOMNESS_768.0];
+        let mut prf_output = [0u8; PRF_ETA1_RANDOMNESS_768.1];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::shake256(
+            &mut prf_output,
+            &prf_input,
+        ));
+        CycleCounter::end_measurement("SHAKE256 (PRF_ETA1_RANDOMNESS_768)", start);
+    }
+
+    {
+        let prf_input = [1u8; PRF_ETA1_RANDOMNESS_1024.0];
+        let mut prf_output = [0u8; PRF_ETA1_RANDOMNESS_1024.1];
+        let start = CycleCounter::start_measurement();
+        core::hint::black_box(libcrux_sha3::portable::shake256(
+            &mut prf_output,
+            &prf_input,
+        ));
+        CycleCounter::end_measurement("SHAKE256 (PRF_ETA1_RANDOMNESS_1024)", start);
+    }
+
+    // SHAKE128
+    {
+        let start = CycleCounter::start_measurement();
+        let mut shake128_state =
+            core::hint::black_box(libcrux_sha3::portable::incremental::shake128_init());
+        CycleCounter::end_measurement("SHAKE128 Init", start);
+
+        {
+            let init_absorb_final_input = [1u8; INIT_ABSORB_FINAL_INPUT_SIZE];
+            let start = CycleCounter::start_measurement();
+            core::hint::black_box(libcrux_sha3::portable::incremental::shake128_absorb_final(
+                &mut shake128_state,
+                &init_absorb_final_input,
+            ));
+            CycleCounter::end_measurement("SHAKE128 Absorb final", start);
+        }
+
+        {
+            let mut one_block = [0u8; BLOCK_SIZE];
+            let start = CycleCounter::start_measurement();
+            core::hint::black_box(
+                libcrux_sha3::portable::incremental::shake128_squeeze_next_block(
+                    &mut shake128_state,
+                    &mut one_block,
+                ),
+            );
+            CycleCounter::end_measurement("SHAKE128 Squeeze one block", start);
+        }
+
+        {
+            let mut three_blocks = [0u8; THREE_BLOCKS];
+            let start = CycleCounter::start_measurement();
+            core::hint::black_box(
+                libcrux_sha3::portable::incremental::shake128_squeeze_first_three_blocks(
+                    &mut shake128_state,
+                    &mut three_blocks,
+                ),
+            );
+            CycleCounter::end_measurement("SHAKE128 Squeeze first three blocks", start);
+        }
+    }
+    board::exit()
+}

--- a/libcrux-nucleo-l4r5zi/src/init.rs
+++ b/libcrux-nucleo-l4r5zi/src/init.rs
@@ -91,8 +91,8 @@ pub fn setup_clock(c: ClockConfig) -> embassy_stm32::Peripherals {
     embassy_stm32::init(config)
 }
 
-use embassy_stm32::rng::{Instance, Rng};
-use embassy_stm32::{bind_interrupts, peripherals, rng, Config, Peripheral, Peripherals};
+use embassy_stm32::rng::Rng;
+use embassy_stm32::{bind_interrupts, peripherals, rng, Peripherals};
 
 bind_interrupts!(struct Irqs {
     RNG => rng::InterruptHandler<peripherals::RNG>;

--- a/libcrux-nucleo-l4r5zi/src/init.rs
+++ b/libcrux-nucleo-l4r5zi/src/init.rs
@@ -52,7 +52,7 @@ impl ClockConfig {
 ///
 /// For reference:
 /// https://github.com/mupq/pqm4/blob/1a04a91573096aa79e6e8f1394bf804c9a89a1a5/common/hal-opencm3.c#L177
-pub fn setup_clock(c: ClockConfig) {
+pub fn setup_clock(c: ClockConfig) -> embassy_stm32::Peripherals {
     let mut config = embassy_stm32::Config::default();
     use embassy_stm32::rcc::*;
 
@@ -88,5 +88,16 @@ pub fn setup_clock(c: ClockConfig) {
         }
     }
 
-    let _p = embassy_stm32::init(config);
+    embassy_stm32::init(config)
+}
+
+use embassy_stm32::rng::{Instance, Rng};
+use embassy_stm32::{bind_interrupts, peripherals, rng, Config, Peripheral, Peripherals};
+
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<peripherals::RNG>;
+});
+
+pub fn init_rng(p: Peripherals) -> Rng<'static, embassy_stm32::peripherals::RNG> {
+    Rng::new(p.RNG, Irqs)
 }

--- a/libcrux/libcrux-sha3/src/lib.rs
+++ b/libcrux/libcrux-sha3/src/lib.rs
@@ -214,7 +214,7 @@ pub mod portable {
     }
 
     #[inline(always)]
-    fn keccakx1<const RATE: usize, const DELIM: u8>(data: [&[u8]; 1], out: [&mut [u8]; 1]) {
+    fn keccakx1<const RATE: usize, const DELIM: u8>(data: &[&[u8]; 1], out: [&mut [u8]; 1]) {
         // generic_keccak::keccak_xof::<1, u64, RATE, DELIM>(data, out);
         // or
         generic_keccak::keccak::<1, u64, RATE, DELIM>(data, out);
@@ -223,37 +223,37 @@ pub mod portable {
     /// A portable SHA3 224 implementation.
     #[inline(always)]
     pub fn sha224(digest: &mut [u8], data: &[u8]) {
-        keccakx1::<144, 0x06u8>([data], [digest]);
+        keccakx1::<144, 0x06u8>(&[data], [digest]);
     }
 
     /// A portable SHA3 256 implementation.
     #[inline(always)]
     pub fn sha256(digest: &mut [u8], data: &[u8]) {
-        keccakx1::<136, 0x06u8>([data], [digest]);
+        keccakx1::<136, 0x06u8>(&[data], [digest]);
     }
 
     /// A portable SHA3 384 implementation.
     #[inline(always)]
     pub fn sha384(digest: &mut [u8], data: &[u8]) {
-        keccakx1::<104, 0x06u8>([data], [digest]);
+        keccakx1::<104, 0x06u8>(&[data], [digest]);
     }
 
     /// A portable SHA3 512 implementation.
     #[inline(always)]
     pub fn sha512(digest: &mut [u8], data: &[u8]) {
-        keccakx1::<72, 0x06u8>([data], [digest]);
+        keccakx1::<72, 0x06u8>(&[data], [digest]);
     }
 
     /// A portable SHAKE128 implementation.
     #[inline(always)]
     pub fn shake128(digest: &mut [u8], data: &[u8]) {
-        keccakx1::<168, 0x1fu8>([data], [digest]);
+        keccakx1::<168, 0x1fu8>(&[data], [digest]);
     }
 
     /// A portable SHAKE256 implementation.
     #[inline(always)]
     pub fn shake256(digest: &mut [u8], data: &[u8]) {
-        keccakx1::<136, 0x1fu8>([data], [digest]);
+        keccakx1::<136, 0x1fu8>(&[data], [digest]);
     }
 
     /// An incremental API for SHAKE
@@ -303,11 +303,11 @@ pub mod portable {
             }
 
             fn absorb(&mut self, input: &[u8]) {
-                self.state.absorb([input]);
+                self.state.absorb(&[input]);
             }
 
             fn absorb_final(&mut self, input: &[u8]) {
-                self.state.absorb_final::<0x1fu8>([input]);
+                self.state.absorb_final::<0x1fu8>(&[input]);
             }
 
             /// Shake128 squeeze
@@ -327,12 +327,12 @@ pub mod portable {
 
             /// Shake256 absorb
             fn absorb(&mut self, input: &[u8]) {
-                self.state.absorb([input]);
+                self.state.absorb(&[input]);
             }
 
             /// Shake256 absorb final
             fn absorb_final(&mut self, input: &[u8]) {
-                self.state.absorb_final::<0x1fu8>([input]);
+                self.state.absorb_final::<0x1fu8>(&[input]);
             }
 
             /// Shake256 squeeze
@@ -352,7 +352,7 @@ pub mod portable {
         /// Absorb
         #[inline(always)]
         pub fn shake128_absorb_final(s: &mut KeccakState, data0: &[u8]) {
-            absorb_final::<1, u64, 168, 0x1fu8>(&mut s.state, [data0]);
+            absorb_final::<1, u64, 168, 0x1fu8>(&mut s.state, &[data0], 0, data0.len());
         }
 
         /// Squeeze three blocks
@@ -370,7 +370,7 @@ pub mod portable {
         /// Squeeze another block
         #[inline(always)]
         pub fn shake128_squeeze_next_block(s: &mut KeccakState, out0: &mut [u8]) {
-            squeeze_next_block::<1, u64, 168>(&mut s.state, [out0])
+            squeeze_next_block::<1, u64, 168>(&mut s.state, &mut [out0])
         }
 
         /// Create a new SHAKE-256 state object.
@@ -384,19 +384,19 @@ pub mod portable {
         /// Absorb some data for SHAKE-256 for the last time
         #[inline(always)]
         pub fn shake256_absorb_final(s: &mut KeccakState, data: &[u8]) {
-            absorb_final::<1, u64, 136, 0x1fu8>(&mut s.state, [data]);
+            absorb_final::<1, u64, 136, 0x1fu8>(&mut s.state, &[data], 0, data.len());
         }
 
         /// Squeeze the first SHAKE-256 block
         #[inline(always)]
         pub fn shake256_squeeze_first_block(s: &mut KeccakState, out: &mut [u8]) {
-            squeeze_first_block::<1, u64, 136>(&mut s.state, [out])
+            squeeze_first_block::<1, u64, 136>(&mut s.state, &mut [out])
         }
 
         /// Squeeze the next SHAKE-256 block
         #[inline(always)]
         pub fn shake256_squeeze_next_block(s: &mut KeccakState, out: &mut [u8]) {
-            squeeze_next_block::<1, u64, 136>(&mut s.state, [out])
+            squeeze_next_block::<1, u64, 136>(&mut s.state, &mut [out])
         }
     }
 }
@@ -408,13 +408,13 @@ pub mod portable {
 /// functions and compile them in.
 ///
 /// Feature `simd128` enables the implementations in this module.
+#[cfg(feature = "simd128")]
 pub mod neon {
-    #[cfg(feature = "simd128")]
     use crate::generic_keccak::keccak;
 
     #[cfg(feature = "simd128")]
     #[inline(always)]
-    fn keccakx2<const RATE: usize, const DELIM: u8>(data: [&[u8]; 2], out: [&mut [u8]; 2]) {
+    fn keccakx2<const RATE: usize, const DELIM: u8>(data: &[&[u8]; 2], out: [&mut [u8]; 2]) {
         keccak::<2, crate::simd::arm64::uint64x2_t, RATE, DELIM>(data, out)
     }
 
@@ -422,83 +422,52 @@ pub mod neon {
     #[allow(unused_variables)]
     #[inline(always)]
     pub fn sha224(digest: &mut [u8], data: &[u8]) {
-        #[cfg(not(feature = "simd128"))]
-        unimplemented!();
-        #[cfg(feature = "simd128")]
-        {
-            let mut dummy = [0u8; 28];
-            keccakx2::<144, 0x06u8>([data, data], [digest, &mut dummy]);
-        }
+        let mut dummy = [0u8; 28];
+        keccakx2::<144, 0x06u8>(&[data, data], [digest, &mut dummy]);
     }
 
     /// A portable SHA3 256 implementation.
     #[allow(unused_variables)]
     #[inline(always)]
     pub fn sha256(digest: &mut [u8], data: &[u8]) {
-        #[cfg(not(feature = "simd128"))]
-        unimplemented!();
-        #[cfg(feature = "simd128")]
-        {
-            let mut dummy = [0u8; 32];
-            keccakx2::<136, 0x06u8>([data, data], [digest, &mut dummy]);
-        }
+        let mut dummy = [0u8; 32];
+        keccakx2::<136, 0x06u8>(&[data, data], [digest, &mut dummy]);
     }
 
     /// A portable SHA3 384 implementation.
     #[allow(unused_variables)]
     #[inline(always)]
     pub fn sha384(digest: &mut [u8], data: &[u8]) {
-        #[cfg(not(feature = "simd128"))]
-        unimplemented!();
-        #[cfg(feature = "simd128")]
-        {
-            let mut dummy = [0u8; 48];
-            keccakx2::<104, 0x06u8>([data, data], [digest, &mut dummy]);
-        }
+        let mut dummy = [0u8; 48];
+        keccakx2::<104, 0x06u8>(&[data, data], [digest, &mut dummy]);
     }
 
     /// A portable SHA3 512 implementation.
     #[allow(unused_variables)]
     #[inline(always)]
     pub fn sha512(digest: &mut [u8], data: &[u8]) {
-        #[cfg(not(feature = "simd128"))]
-        unimplemented!();
-        #[cfg(feature = "simd128")]
-        {
-            let mut dummy = [0u8; 64];
-            keccakx2::<72, 0x06u8>([data, data], [digest, &mut dummy]);
-        }
+        let mut dummy = [0u8; 64];
+        keccakx2::<72, 0x06u8>(&[data, data], [digest, &mut dummy]);
     }
 
     /// A portable SHAKE128 implementation.
     #[allow(unused_variables)]
     #[inline(always)]
     pub fn shake128<const LEN: usize>(digest: &mut [u8; LEN], data: &[u8]) {
-        #[cfg(not(feature = "simd128"))]
-        unimplemented!();
-        #[cfg(feature = "simd128")]
-        {
-            let mut dummy = [0u8; LEN];
-            keccakx2::<168, 0x1fu8>([data, data], [digest, &mut dummy]);
-        }
+        let mut dummy = [0u8; LEN];
+        keccakx2::<168, 0x1fu8>(&[data, data], [digest, &mut dummy]);
     }
 
     /// A portable SHAKE256 implementation.
     #[allow(unused_variables)]
     #[inline(always)]
     pub fn shake256<const LEN: usize>(digest: &mut [u8; LEN], data: &[u8]) {
-        #[cfg(not(feature = "simd128"))]
-        unimplemented!();
-        #[cfg(feature = "simd128")]
-        {
-            let mut dummy = [0u8; LEN];
-            keccakx2::<136, 0x1fu8>([data, data], [digest, &mut dummy]);
-        }
+        let mut dummy = [0u8; LEN];
+        keccakx2::<136, 0x1fu8>(&[data, data], [digest, &mut dummy]);
     }
 
     /// Performing 2 operations in parallel
     pub mod x2 {
-        #[cfg(feature = "simd128")]
         use super::*;
 
         /// Run SHAKE256 on both inputs in parallel.
@@ -508,10 +477,7 @@ pub mod neon {
         #[inline(always)]
         pub fn shake256(input0: &[u8], input1: &[u8], out0: &mut [u8], out1: &mut [u8]) {
             // TODO: make argument ordering consistent
-            #[cfg(not(feature = "simd128"))]
-            unimplemented!();
-            #[cfg(feature = "simd128")]
-            keccakx2::<136, 0x1fu8>([input0, input1], [out0, out1]);
+            keccakx2::<136, 0x1fu8>(&[input0, input1], [out0, out1]);
         }
 
         /// Run up to 4 SHAKE256 operations in parallel.
@@ -549,33 +515,21 @@ pub mod neon {
 
         /// An incremental API to perform 2 operations in parallel
         pub mod incremental {
-            #[cfg(feature = "simd128")]
             use crate::generic_keccak::{
                 absorb_final, squeeze_first_block, squeeze_first_five_blocks,
                 squeeze_first_three_blocks, squeeze_next_block, KeccakState as GenericState,
             };
 
             /// The Keccak state for the incremental API.
-            #[cfg(feature = "simd128")]
             pub struct KeccakState {
                 state: GenericState<2, crate::simd::arm64::uint64x2_t>,
             }
 
-            #[cfg(feature = "simd128")]
             type KeccakState2Internal = GenericState<2, crate::simd::arm64::uint64x2_t>;
-
-            /// The Keccak state for the incremental API.
-            #[allow(dead_code)]
-            #[cfg(not(feature = "simd128"))]
-            pub struct KeccakState {
-                state: [crate::portable::KeccakState; 2],
-            }
 
             /// Initialise the `KeccakState2`.
             #[inline(always)]
             pub fn init() -> KeccakState {
-                #[cfg(not(feature = "simd128"))]
-                unimplemented!();
                 // XXX: These functions could alternatively implement the same with
                 //      the portable implementation
                 // {
@@ -583,7 +537,6 @@ pub mod neon {
                 //     let s1 = KeccakState::new();
                 //     [s0, s1]
                 // }
-                #[cfg(feature = "simd128")]
                 KeccakState {
                     state: KeccakState2Internal::new(),
                 }
@@ -591,10 +544,7 @@ pub mod neon {
 
             /// Shake128 absorb `data0` and `data1` in the [`KeccakState`] `s`.
             #[inline(always)]
-            #[allow(unused_variables)]
             pub fn shake128_absorb_final(s: &mut KeccakState, data0: &[u8], data1: &[u8]) {
-                #[cfg(not(feature = "simd128"))]
-                unimplemented!();
                 // XXX: These functions could alternatively implement the same with
                 //      the portable implementation
                 // {
@@ -602,19 +552,17 @@ pub mod neon {
                 //     shake128_absorb_final(&mut s0, data0);
                 //     shake128_absorb_final(&mut s1, data1);
                 // }
-                #[cfg(feature = "simd128")]
                 absorb_final::<2, crate::simd::arm64::uint64x2_t, 168, 0x1fu8>(
                     &mut s.state,
-                    [data0, data1],
+                    &[data0, data1],
+                    0,
+                    data0.len(),
                 );
             }
 
             /// Shake256 absorb `data0` and `data1` in the [`KeccakState`] `s`.
             #[inline(always)]
-            #[allow(unused_variables)]
             pub fn shake256_absorb_final(s: &mut KeccakState, data0: &[u8], data1: &[u8]) {
-                #[cfg(not(feature = "simd128"))]
-                unimplemented!();
                 // XXX: These functions could alternatively implement the same with
                 //      the portable implementation
                 // {
@@ -622,10 +570,11 @@ pub mod neon {
                 //     shake128_absorb_final(&mut s0, data0);
                 //     shake128_absorb_final(&mut s1, data1);
                 // }
-                #[cfg(feature = "simd128")]
                 absorb_final::<2, crate::simd::arm64::uint64x2_t, 136, 0x1fu8>(
                     &mut s.state,
-                    [data0, data1],
+                    &[data0, data1],
+                    0,
+                    data0.len(),
                 );
             }
 
@@ -633,7 +582,7 @@ pub mod neon {
             /// using two [`KeccakState2`].
             ///
             /// **PANICS** when `N` is not 2, 3, or 4.
-            #[allow(unused_variables, non_snake_case)]
+            #[allow(non_snake_case)]
             #[inline(always)]
             fn _shake128_absorb_finalxN<const N: usize>(input: [[u8; 34]; N]) -> [KeccakState; 2] {
                 debug_assert!(N == 2 || N == 3 || N == 4);
@@ -659,15 +608,12 @@ pub mod neon {
 
             /// Squeeze 2 times the first three blocks in parallel in the
             /// [`KeccakState`] and return the output in `out0` and `out1`.
-            #[allow(unused_variables)]
             #[inline(always)]
             pub fn shake128_squeeze_first_three_blocks(
                 s: &mut KeccakState,
                 out0: &mut [u8],
                 out1: &mut [u8],
             ) {
-                #[cfg(not(feature = "simd128"))]
-                unimplemented!();
                 // XXX: These functions could alternatively implement the same with
                 //      the portable implementation
                 // {
@@ -675,7 +621,6 @@ pub mod neon {
                 //     shake128_squeeze_first_three_blocks(&mut s0, out0);
                 //     shake128_squeeze_first_three_blocks(&mut s1, out1);
                 // }
-                #[cfg(feature = "simd128")]
                 squeeze_first_three_blocks::<2, crate::simd::arm64::uint64x2_t, 168>(
                     &mut s.state,
                     [out0, out1],
@@ -683,16 +628,12 @@ pub mod neon {
             }
 
             /// Squeeze five blocks
-            #[allow(unused_variables)]
             #[inline(always)]
             pub fn shake128_squeeze_first_five_blocks(
                 s: &mut KeccakState,
                 out0: &mut [u8],
                 out1: &mut [u8],
             ) {
-                #[cfg(not(feature = "simd128"))]
-                unimplemented!();
-                #[cfg(feature = "simd128")]
                 squeeze_first_five_blocks::<2, crate::simd::arm64::uint64x2_t, 168>(
                     &mut s.state,
                     [out0, out1],
@@ -701,35 +642,27 @@ pub mod neon {
 
             /// Squeeze block
             #[inline(always)]
-            #[allow(unused_variables)] // TODO: decide if we want to fall back here
             pub fn shake256_squeeze_first_block(
                 s: &mut KeccakState,
                 out0: &mut [u8],
                 out1: &mut [u8],
             ) {
-                #[cfg(not(feature = "simd128"))]
-                unimplemented!();
-                #[cfg(feature = "simd128")]
                 squeeze_first_block::<2, crate::simd::arm64::uint64x2_t, 136>(
                     &mut s.state,
-                    [out0, out1],
+                    &mut [out0, out1],
                 );
             }
 
             /// Squeeze next block
             #[inline(always)]
-            #[allow(unused_variables)] // TODO: decide if we want to fall back here
             pub fn shake256_squeeze_next_block(
                 s: &mut KeccakState,
                 out0: &mut [u8],
                 out1: &mut [u8],
             ) {
-                #[cfg(not(feature = "simd128"))]
-                unimplemented!();
-                #[cfg(feature = "simd128")]
                 squeeze_next_block::<2, crate::simd::arm64::uint64x2_t, 136>(
                     &mut s.state,
-                    [out0, out1],
+                    &mut [out0, out1],
                 );
             }
 
@@ -737,7 +670,7 @@ pub mod neon {
             /// Each block is of size `LEN`.
             ///
             /// **PANICS** when `N` is not 2, 3, or 4.
-            #[allow(unused_variables, non_snake_case)]
+            #[allow(non_snake_case)]
             #[inline(always)]
             fn _shake128_squeeze3xN<const LEN: usize, const N: usize>(
                 state: &mut [KeccakState; 2],
@@ -791,15 +724,12 @@ pub mod neon {
 
             /// Squeeze 2 times the next block in parallel in the
             /// [`KeccakState`] and return the output in `out0` and `out1`.
-            #[allow(unused_variables)]
             #[inline(always)]
             pub fn shake128_squeeze_next_block(
                 s: &mut KeccakState,
                 out0: &mut [u8],
                 out1: &mut [u8],
             ) {
-                #[cfg(not(feature = "simd128"))]
-                unimplemented!();
                 // XXX: These functions could alternatively implement the same with
                 //      the portable implementation
                 // {
@@ -807,10 +737,9 @@ pub mod neon {
                 //     shake128_squeeze_next_block(&mut s0, out0);
                 //     shake128_squeeze_next_block(&mut s1, out1);
                 // }
-                #[cfg(feature = "simd128")]
                 squeeze_next_block::<2, crate::simd::arm64::uint64x2_t, 168>(
                     &mut s.state,
-                    [out0, out1],
+                    &mut [out0, out1],
                 )
             }
 
@@ -818,7 +747,7 @@ pub mod neon {
             /// Each block is of size `LEN`.
             ///
             /// **PANICS** when `N` is not 2, 3, or 4.
-            #[allow(unused_variables, non_snake_case)]
+            #[allow(non_snake_case)]
             #[inline(always)]
             fn _shake128_squeezexN<const LEN: usize, const N: usize>(
                 state: &mut [KeccakState; 2],
@@ -872,17 +801,15 @@ pub mod neon {
 /// functions and compile them in.
 ///
 /// Feature `simd256` enables the implementations in this module.
+#[cfg(feature = "simd256")]
 pub mod avx2 {
-
     /// Performing 4 operations in parallel
     pub mod x4 {
-        #[cfg(feature = "simd256")]
         use crate::generic_keccak::keccak;
-        #[cfg(feature = "simd256")]
         use libcrux_intrinsics::avx2::*;
 
         /// Perform 4 SHAKE256 operations in parallel
-        #[allow(unused_variables, clippy::too_many_arguments)] // TODO: decide if we want to fall back here
+        #[allow(clippy::too_many_arguments)]
         #[inline(always)]
         pub fn shake256(
             input0: &[u8],
@@ -894,8 +821,6 @@ pub mod avx2 {
             out2: &mut [u8],
             out3: &mut [u8],
         ) {
-            #[cfg(not(feature = "simd256"))]
-            unimplemented!();
             // XXX: These functions could alternatively implement the same with
             //      the portable implementation
             // #[cfg(feature = "simd128")]
@@ -909,9 +834,8 @@ pub mod avx2 {
             //     keccakx1::<136, 0x1fu8>([input2], [out2]);
             //     keccakx1::<136, 0x1fu8>([input3], [out3]);
             // }
-            #[cfg(feature = "simd256")]
             keccak::<4, Vec256, 136, 0x1fu8>(
-                [input0, input1, input2, input3],
+                &[input0, input1, input2, input3],
                 [out0, out1, out2, out3],
             );
         }
@@ -919,7 +843,7 @@ pub mod avx2 {
         /// Run up to 4 SHAKE256 operations in parallel.
         ///
         /// **PANICS** when `N` is not 2, 3, or 4.
-        #[allow(unused_variables, non_snake_case)]
+        #[allow(non_snake_case)]
         #[inline(always)]
         fn _shake256xN<const LEN: usize, const N: usize>(input: &[[u8; 33]; N]) -> [[u8; LEN]; N] {
             debug_assert!(N == 2 || N == 3 || N == 4);
@@ -978,14 +902,11 @@ pub mod avx2 {
 
         /// An incremental API to perform 4 operations in parallel
         pub mod incremental {
-            #[cfg(feature = "simd256")]
             use crate::generic_keccak::{
                 absorb_final, squeeze_first_three_blocks, squeeze_next_block,
                 KeccakState as GenericState,
             };
-            #[cfg(feature = "simd256")]
             use crate::generic_keccak::{squeeze_first_block, squeeze_first_five_blocks};
-            #[cfg(feature = "simd256")]
             use libcrux_intrinsics::avx2::*;
 
             /// The Keccak state for the incremental API.
@@ -994,39 +915,9 @@ pub mod avx2 {
                 state: GenericState<4, Vec256>,
             }
 
-            /// The Keccak state for the incremental API.
-            #[allow(dead_code)]
-            #[cfg(all(feature = "simd128", not(feature = "simd256")))]
-            pub struct KeccakState {
-                state: [crate::neon::x2::incremental::KeccakState; 2],
-            }
-
-            /// The Keccak state for the incremental API.
-            #[cfg(not(any(feature = "simd256", feature = "simd128")))]
-            pub type KeccakState = [crate::portable::KeccakState; 4];
-
             /// Initialise the [`KeccakState`].
             #[inline(always)]
             pub fn init() -> KeccakState {
-                #[cfg(not(feature = "simd256"))]
-                unimplemented!();
-                // XXX: These functions could alternatively implement the same with
-                //      the portable implementation
-                // #[cfg(feature = "simd128")]
-                // {
-                //     let s0 = KeccakState2::new();
-                //     let s1 = KeccakState2::new();
-                //     [s0, s1]
-                // }
-                // #[cfg(not(any(feature = "simd128", feature = "simd256")))]
-                // {
-                //     let s0 = KeccakState::new();
-                //     let s1 = KeccakState::new();
-                //     let s2 = KeccakState::new();
-                //     let s3 = KeccakState::new();
-                //     [s0, s1, s2, s3]
-                // }
-                #[cfg(feature = "simd256")]
                 KeccakState {
                     state: GenericState::new(),
                 }
@@ -1034,7 +925,6 @@ pub mod avx2 {
 
             /// Absorb
             #[inline(always)]
-            #[allow(unused_variables)] // TODO: decide if we want to fall back here
             pub fn shake128_absorb_final(
                 s: &mut KeccakState,
                 data0: &[u8],
@@ -1042,37 +932,16 @@ pub mod avx2 {
                 data2: &[u8],
                 data3: &[u8],
             ) {
-                #[cfg(not(feature = "simd256"))]
-                unimplemented!();
-                // XXX: These functions could alternatively implement the same with
-                //      the portable implementation
-                // #[cfg(feature = "simd128")]
-                // {
-                //     let [mut s0, mut s1] = s;
-                //     absorb_final::<2, crate::simd::arm64::uint64x2_t, 168, 0x1fu8>(
-                //         &mut s0,
-                //         [data0, data1],
-                //     );
-                //     absorb_final::<2, crate::simd::arm64::uint64x2_t, 168, 0x1fu8>(
-                //         &mut s1,
-                //         [data2, data3],
-                //     );
-                // }
-                // #[cfg(not(any(feature = "simd128", feature = "simd256")))]
-                // {
-                //     let [mut s0, mut s1, mut s2, mut s3] = s;
-                //     shake128_absorb_final(&mut s0, data0);
-                //     shake128_absorb_final(&mut s1, data1);
-                //     shake128_absorb_final(&mut s2, data2);
-                //     shake128_absorb_final(&mut s3, data3);
-                // }
-                #[cfg(feature = "simd256")]
-                absorb_final::<4, Vec256, 168, 0x1fu8>(&mut s.state, [data0, data1, data2, data3]);
+                absorb_final::<4, Vec256, 168, 0x1fu8>(
+                    &mut s.state,
+                    &[data0, data1, data2, data3],
+                    0,
+                    data0.len(),
+                );
             }
 
             /// Absorb
             #[inline(always)]
-            #[allow(unused_variables)] // TODO: decide if we want to fall back here
             pub fn shake256_absorb_final(
                 s: &mut KeccakState,
                 data0: &[u8],
@@ -1080,15 +949,16 @@ pub mod avx2 {
                 data2: &[u8],
                 data3: &[u8],
             ) {
-                #[cfg(not(feature = "simd256"))]
-                unimplemented!();
-                #[cfg(feature = "simd256")]
-                absorb_final::<4, Vec256, 136, 0x1fu8>(&mut s.state, [data0, data1, data2, data3]);
+                absorb_final::<4, Vec256, 136, 0x1fu8>(
+                    &mut s.state,
+                    &[data0, data1, data2, data3],
+                    0,
+                    data0.len(),
+                );
             }
 
             /// Squeeze block
             #[inline(always)]
-            #[allow(unused_variables)] // TODO: decide if we want to fall back here
             pub fn shake256_squeeze_first_block(
                 s: &mut KeccakState,
                 out0: &mut [u8],
@@ -1096,15 +966,11 @@ pub mod avx2 {
                 out2: &mut [u8],
                 out3: &mut [u8],
             ) {
-                #[cfg(not(feature = "simd256"))]
-                unimplemented!();
-                #[cfg(feature = "simd256")]
-                squeeze_first_block::<4, Vec256, 136>(&mut s.state, [out0, out1, out2, out3]);
+                squeeze_first_block::<4, Vec256, 136>(&mut s.state, &mut [out0, out1, out2, out3]);
             }
 
             /// Squeeze next block
             #[inline(always)]
-            #[allow(unused_variables)] // TODO: decide if we want to fall back here
             pub fn shake256_squeeze_next_block(
                 s: &mut KeccakState,
                 out0: &mut [u8],
@@ -1112,10 +978,7 @@ pub mod avx2 {
                 out2: &mut [u8],
                 out3: &mut [u8],
             ) {
-                #[cfg(not(feature = "simd256"))]
-                unimplemented!();
-                #[cfg(feature = "simd256")]
-                squeeze_next_block::<4, Vec256, 136>(&mut s.state, [out0, out1, out2, out3]);
+                squeeze_next_block::<4, Vec256, 136>(&mut s.state, &mut [out0, out1, out2, out3]);
             }
 
             /// Initialise the state and perform up to 4 absorbs at the same time,
@@ -1123,7 +986,7 @@ pub mod avx2 {
             ///
             /// **PANICS** when `N` is not 2, 3, or 4.
             #[inline(always)]
-            #[allow(unused_variables, non_snake_case)]
+            #[allow(non_snake_case)]
             fn _shake128_absorb_finalxN<const N: usize>(input: [[u8; 34]; N]) -> KeccakState {
                 debug_assert!(N == 2 || N == 3 || N == 4);
                 let mut state = init();
@@ -1152,7 +1015,6 @@ pub mod avx2 {
 
             /// Squeeze three blocks
             #[inline(always)]
-            #[allow(unused_variables)] // TODO: decide if we want to fall back here
             pub fn shake128_squeeze_first_three_blocks(
                 s: &mut KeccakState,
                 out0: &mut [u8],
@@ -1160,31 +1022,6 @@ pub mod avx2 {
                 out2: &mut [u8],
                 out3: &mut [u8],
             ) {
-                #[cfg(not(feature = "simd256"))]
-                unimplemented!();
-                // XXX: These functions could alternatively implement the same with
-                //      the portable implementation
-                // #[cfg(feature = "simd128")]
-                // {
-                //     let [mut s0, mut s1] = s;
-                //     squeeze_first_three_blocks::<2, crate::simd::arm64::uint64x2_t, 168>(
-                //         &mut s0,
-                //         [out0, out1],
-                //     );
-                //     squeeze_first_three_blocks::<2, crate::simd::arm64::uint64x2_t, 168>(
-                //         &mut s1,
-                //         [out2, out3],
-                //     );
-                // }
-                // #[cfg(not(any(feature = "simd128", feature = "simd256")))]
-                // {
-                //     let [mut s0, mut s1, mut s2, mut s3] = s;
-                //     shake128_squeeze_first_three_blocks(&mut s0, out0);
-                //     shake128_squeeze_first_three_blocks(&mut s1, out1);
-                //     shake128_squeeze_first_three_blocks(&mut s2, out2);
-                //     shake128_squeeze_first_three_blocks(&mut s3, out3);
-                // }
-                #[cfg(feature = "simd256")]
                 squeeze_first_three_blocks::<4, Vec256, 168>(
                     &mut s.state,
                     [out0, out1, out2, out3],
@@ -1193,7 +1030,6 @@ pub mod avx2 {
 
             /// Squeeze five blocks
             #[inline(always)]
-            #[allow(unused_variables)] // TODO: decide if we want to fall back here
             pub fn shake128_squeeze_first_five_blocks(
                 s: &mut KeccakState,
                 out0: &mut [u8],
@@ -1201,9 +1037,6 @@ pub mod avx2 {
                 out2: &mut [u8],
                 out3: &mut [u8],
             ) {
-                #[cfg(not(feature = "simd256"))]
-                unimplemented!();
-                #[cfg(feature = "simd256")]
                 squeeze_first_five_blocks::<4, Vec256, 168>(&mut s.state, [out0, out1, out2, out3]);
             }
 
@@ -1212,7 +1045,7 @@ pub mod avx2 {
             ///
             /// **PANICS** when `N` is not 2, 3, or 4.
             #[inline(always)]
-            #[allow(unused_variables, non_snake_case)]
+            #[allow(non_snake_case)]
             fn _shake128_squeeze3xN<const LEN: usize, const N: usize>(
                 state: &mut KeccakState,
             ) -> [[u8; LEN]; N] {
@@ -1263,7 +1096,6 @@ pub mod avx2 {
 
             /// Squeeze another block
             #[inline(always)]
-            #[allow(unused_variables)] // TODO: decide if we want to fall back here
             pub fn shake128_squeeze_next_block(
                 s: &mut KeccakState,
                 out0: &mut [u8],
@@ -1271,39 +1103,14 @@ pub mod avx2 {
                 out2: &mut [u8],
                 out3: &mut [u8],
             ) {
-                #[cfg(not(feature = "simd256"))]
-                unimplemented!();
-                // XXX: These functions could alternatively implement the same with
-                //      the portable implementation
-                // #[cfg(feature = "simd128")]
-                // {
-                //     let [mut s0, mut s1] = s;
-                //     squeeze_next_block::<2, crate::simd::arm64::uint64x2_t, 168>(
-                //         &mut s0,
-                //         [out0, out1],
-                //     );
-                //     squeeze_next_block::<2, crate::simd::arm64::uint64x2_t, 168>(
-                //         &mut s1,
-                //         [out2, out3],
-                //     );
-                // }
-                // #[cfg(not(any(feature = "simd128", feature = "simd256")))]
-                // {
-                //     let [mut s0, mut s1, mut s2, mut s3] = s;
-                //     shake128_squeeze_next_block(&mut s0, out0);
-                //     shake128_squeeze_next_block(&mut s1, out1);
-                //     shake128_squeeze_next_block(&mut s2, out2);
-                //     shake128_squeeze_next_block(&mut s3, out3);
-                // }
-                #[cfg(feature = "simd256")]
-                squeeze_next_block::<4, Vec256, 168>(&mut s.state, [out0, out1, out2, out3]);
+                squeeze_next_block::<4, Vec256, 168>(&mut s.state, &mut [out0, out1, out2, out3]);
             }
 
             /// Squeeze up to 4 (N) blocks in parallel, using two [`KeccakState`].
             /// Each block is of size `LEN`.
             ///
             /// **PANICS** when `N` is not 2, 3, or 4.
-            #[allow(unused_variables, non_snake_case)]
+            #[allow(non_snake_case)]
             #[inline(always)]
             fn _shake128_squeezexN<const LEN: usize, const N: usize>(
                 state: &mut KeccakState,

--- a/libcrux/libcrux-sha3/src/lib.rs
+++ b/libcrux/libcrux-sha3/src/lib.rs
@@ -227,7 +227,7 @@ pub mod portable {
     }
 
     /// A portable SHA3 256 implementation.
-    #[inline(always)]
+    #[inline(never)]
     pub fn sha256(digest: &mut [u8], data: &[u8]) {
         keccakx1::<136, 0x06u8>(&[data], [digest]);
     }
@@ -239,7 +239,7 @@ pub mod portable {
     }
 
     /// A portable SHA3 512 implementation.
-    #[inline(always)]
+    #[inline(never)]
     pub fn sha512(digest: &mut [u8], data: &[u8]) {
         keccakx1::<72, 0x06u8>(&[data], [digest]);
     }
@@ -251,7 +251,7 @@ pub mod portable {
     }
 
     /// A portable SHAKE256 implementation.
-    #[inline(always)]
+    #[inline(never)]
     pub fn shake256(digest: &mut [u8], data: &[u8]) {
         keccakx1::<136, 0x1fu8>(&[data], [digest]);
     }
@@ -342,7 +342,7 @@ pub mod portable {
         }
 
         /// Create a new SHAKE-128 state object.
-        #[inline(always)]
+        #[inline(never)]
         pub fn shake128_init() -> KeccakState {
             KeccakState {
                 state: GenericState::<1, u64>::new(),
@@ -350,7 +350,7 @@ pub mod portable {
         }
 
         /// Absorb
-        #[inline(always)]
+        #[inline(never)]
         pub fn shake128_absorb_final(s: &mut KeccakState, data0: &[u8]) {
             absorb_final::<1, u64, 168, 0x1fu8>(&mut s.state, &[data0], 0, data0.len());
         }
@@ -368,7 +368,7 @@ pub mod portable {
         }
 
         /// Squeeze another block
-        #[inline(always)]
+        #[inline(never)]
         pub fn shake128_squeeze_next_block(s: &mut KeccakState, out0: &mut [u8]) {
             squeeze_next_block::<1, u64, 168>(&mut s.state, &mut [out0])
         }

--- a/libcrux/libcrux-sha3/src/portable_keccak.rs
+++ b/libcrux/libcrux-sha3/src/portable_keccak.rs
@@ -1,19 +1,16 @@
 //! A portable SHA3 implementation using the generic implementation.
 
-use crate::traits::internal::*;
+use crate::traits::{internal::*, *};
 
 #[inline(always)]
 fn rotate_left<const LEFT: i32, const RIGHT: i32>(x: u64) -> u64 {
     debug_assert!(LEFT + RIGHT == 64);
-    (x << LEFT) | (x >> RIGHT)
+    x.rotate_left(LEFT as u32)
 }
 
 #[inline(always)]
 fn _veor5q_u64(a: u64, b: u64, c: u64, d: u64, e: u64) -> u64 {
-    let ab = a ^ b;
-    let cd = c ^ d;
-    let abcd = ab ^ cd;
-    abcd ^ e
+    a ^ b ^ c ^ d ^ e
 }
 
 #[inline(always)]
@@ -23,8 +20,7 @@ fn _vrax1q_u64(a: u64, b: u64) -> u64 {
 
 #[inline(always)]
 fn _vxarq_u64<const LEFT: i32, const RIGHT: i32>(a: u64, b: u64) -> u64 {
-    let ab = a ^ b;
-    rotate_left::<LEFT, RIGHT>(ab)
+    rotate_left::<LEFT, RIGHT>(a ^ b)
 }
 
 #[inline(always)]
@@ -38,41 +34,47 @@ fn _veorq_n_u64(a: u64, c: u64) -> u64 {
 }
 
 #[inline(always)]
-pub(crate) fn load_block<const RATE: usize>(s: &mut [[u64; 5]; 5], blocks: [&[u8]; 1]) {
-    debug_assert!(RATE <= blocks[0].len() && RATE % 8 == 0);
+pub(crate) fn load_block<const RATE: usize>(state: &mut [u64; 25], blocks: &[u8], start: usize) {
+    debug_assert!(RATE <= blocks.len() && RATE % 8 == 0);
+    let mut state_flat = [0u64; 25];
     for i in 0..RATE / 8 {
-        s[i / 5][i % 5] ^= u64::from_le_bytes(blocks[0][8 * i..8 * i + 8].try_into().unwrap());
+        let offset = start + 8 * i;
+        state_flat[i] = u64::from_le_bytes(blocks[offset..offset + 8].try_into().unwrap());
+    }
+    for i in 0..RATE / 8 {
+        set_ij(
+            state,
+            i / 5,
+            i % 5,
+            get_ij(state, i / 5, i % 5) ^ state_flat[i],
+        );
     }
 }
 
 #[inline(always)]
-pub(crate) fn load_block_full<const RATE: usize>(s: &mut [[u64; 5]; 5], blocks: [[u8; 200]; 1]) {
-    load_block::<RATE>(s, [&blocks[0] as &[u8]]);
+pub(crate) fn load_block_full<const RATE: usize>(
+    state: &mut [u64; 25],
+    blocks: &[u8; 200],
+    start: usize,
+) {
+    load_block::<RATE>(state, blocks, start);
 }
 
 #[inline(always)]
-pub(crate) fn store_block<const RATE: usize>(s: &[[u64; 5]; 5], out: [&mut [u8]; 1]) {
+pub(crate) fn store_block<const RATE: usize>(s: &[u64; 25], out: &mut [u8]) {
     for i in 0..RATE / 8 {
-        out[0][8 * i..8 * i + 8].copy_from_slice(&s[i / 5][i % 5].to_le_bytes());
+        out[8 * i..8 * i + 8].copy_from_slice(&get_ij(s, i / 5, i % 5).to_le_bytes());
     }
 }
 
 #[inline(always)]
-pub(crate) fn store_block_full<const RATE: usize>(s: &[[u64; 5]; 5]) -> [[u8; 200]; 1] {
-    let mut out = [0u8; 200];
-    store_block::<RATE>(s, [&mut out]);
-    [out]
+pub(crate) fn store_block_full<const RATE: usize>(s: &[u64; 25], out: &mut [u8; 200]) {
+    store_block::<RATE>(s, out);
 }
 
 #[inline(always)]
-fn slice_1(a: [&[u8]; 1], start: usize, len: usize) -> [&[u8]; 1] {
-    [&a[0][start..start + len]]
-}
-
-#[inline(always)]
-fn split_at_mut_1(out: [&mut [u8]; 1], mid: usize) -> ([&mut [u8]; 1], [&mut [u8]; 1]) {
-    let (out00, out01) = out[0].split_at_mut(mid);
-    ([out00], [out01])
+fn split_at_mut_1(out: &mut [u8], mid: usize) -> (&mut [u8], &mut [u8]) {
+    out.split_at_mut(mid)
 }
 
 impl KeccakItem<1> for u64 {
@@ -105,44 +107,47 @@ impl KeccakItem<1> for u64 {
         a ^ b
     }
     #[inline(always)]
-    fn load_block<const RATE: usize>(a: &mut [[Self; 5]; 5], b: [&[u8]; 1]) {
-        load_block::<RATE>(a, b)
+    fn load_block<const RATE: usize>(state: &mut [Self; 25], blocks: &[&[u8]; 1], start: usize) {
+        load_block::<RATE>(state, blocks[0], start)
     }
     #[inline(always)]
-    fn store_block<const RATE: usize>(a: &[[Self; 5]; 5], b: [&mut [u8]; 1]) {
-        store_block::<RATE>(a, b)
+    fn store_block<const RATE: usize>(state: &[Self; 25], out: &mut [&mut [u8]; 1]) {
+        store_block::<RATE>(state, out[0])
     }
     #[inline(always)]
-    fn load_block_full<const RATE: usize>(a: &mut [[Self; 5]; 5], b: [[u8; 200]; 1]) {
-        load_block_full::<RATE>(a, b)
+    fn load_block_full<const RATE: usize>(
+        state: &mut [Self; 25],
+        blocks: &[[u8; 200]; 1],
+        start: usize,
+    ) {
+        load_block_full::<RATE>(state, &blocks[0], start)
     }
     #[inline(always)]
-    fn store_block_full<const RATE: usize>(a: &[[Self; 5]; 5]) -> [[u8; 200]; 1] {
-        store_block_full::<RATE>(a)
+    fn store_block_full<const RATE: usize>(state: &[Self; 25], out: &mut [[u8; 200]; 1]) {
+        store_block_full::<RATE>(state, &mut out[0]);
     }
-    #[inline(always)]
-    fn slice_n(a: [&[u8]; 1], start: usize, len: usize) -> [&[u8]; 1] {
-        slice_1(a, start, len)
-    }
+
     #[inline(always)]
     fn split_at_mut_n(a: [&mut [u8]; 1], mid: usize) -> ([&mut [u8]; 1], [&mut [u8]; 1]) {
-        split_at_mut_1(a, mid)
+        let (x, y) = split_at_mut_1(a[0], mid);
+        ([x], [y])
     }
 
     /// `out` has the exact size we want here. It must be less than or equal to `RATE`.
     #[inline(always)]
-    fn store<const RATE: usize>(state: &[[Self; 5]; 5], out: [&mut [u8]; 1]) {
+    fn store<const RATE: usize>(state: &[Self; 25], out: [&mut [u8]; 1]) {
         debug_assert!(out.len() <= RATE / 8, "{} > {}", out.len(), RATE);
 
         let num_full_blocks = out[0].len() / 8;
         let last_block_len = out[0].len() % 8;
 
         for i in 0..num_full_blocks {
-            out[0][i * 8..i * 8 + 8].copy_from_slice(&state[i / 5][i % 5].to_le_bytes());
+            out[0][i * 8..i * 8 + 8].copy_from_slice(&get_ij(state, i / 5, i % 5).to_le_bytes());
         }
         if last_block_len != 0 {
             out[0][num_full_blocks * 8..num_full_blocks * 8 + last_block_len].copy_from_slice(
-                &state[num_full_blocks / 5][num_full_blocks % 5].to_le_bytes()[0..last_block_len],
+                &get_ij(state, num_full_blocks / 5, num_full_blocks % 5).to_le_bytes()
+                    [0..last_block_len],
             );
         }
     }

--- a/libcrux/libcrux-sha3/src/simd/arm64.rs
+++ b/libcrux/libcrux-sha3/src/simd/arm64.rs
@@ -1,22 +1,9 @@
 use libcrux_intrinsics::arm64::*;
 
-use crate::traits::internal::KeccakItem;
+use crate::traits::{get_ij, internal::KeccakItem, set_ij};
 
 #[allow(non_camel_case_types)]
 pub type uint64x2_t = _uint64x2_t;
-
-// This file optimizes for the stable Rust Neon Intrinsics
-// If we want to use the unstable neon-sha3 instructions, we could use:
-// veor3q_u64, vrax1q_u64, vxarq_u64, and vbcaxq_u64
-// These instructions might speed up our code even more.
-
-#[inline(always)]
-fn rotate_left<const LEFT: i32, const RIGHT: i32>(x: uint64x2_t) -> uint64x2_t {
-    debug_assert!(LEFT + RIGHT == 64);
-    // The following looks faster but is actually significantly slower
-    //unsafe { vsriq_n_u64::<RIGHT>(vshlq_n_u64::<LEFT>(x), x) }
-    _veorq_u64(_vshlq_n_u64::<LEFT>(x), _vshrq_n_u64::<RIGHT>(x))
-}
 
 #[inline(always)]
 fn _veor5q_u64(
@@ -26,34 +13,22 @@ fn _veor5q_u64(
     d: uint64x2_t,
     e: uint64x2_t,
 ) -> uint64x2_t {
-    let ab = _veorq_u64(a, b);
-    let cd = _veorq_u64(c, d);
-    let abcd = _veorq_u64(ab, cd);
-    _veorq_u64(abcd, e)
-    // Needs nightly+neon-sha3
-    //unsafe {veor3q_u64(veor3q_u64(a,b,c),d,e)}
+    _veor3q_u64(_veor3q_u64(a, b, c), d, e)
 }
 
 #[inline(always)]
 fn _vrax1q_u64(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
-    _veorq_u64(a, rotate_left::<1, 63>(b))
-    // Needs nightly+neon-sha3
-    //unsafe { vrax1q_u64(a, b) }
+    libcrux_intrinsics::arm64::_vrax1q_u64(a, b)
 }
 
 #[inline(always)]
 fn _vxarq_u64<const LEFT: i32, const RIGHT: i32>(a: uint64x2_t, b: uint64x2_t) -> uint64x2_t {
-    let ab = _veorq_u64(a, b);
-    rotate_left::<LEFT, RIGHT>(ab)
-    // Needs nightly+neon-sha3
-    // unsafe { vxarq_u64::<RIGHT>(a,b) }
+    libcrux_intrinsics::arm64::_vxarq_u64::<LEFT, RIGHT>(a, b)
 }
 
 #[inline(always)]
 fn _vbcaxq_u64(a: uint64x2_t, b: uint64x2_t, c: uint64x2_t) -> uint64x2_t {
-    _veorq_u64(a, _vbicq_u64(b, c))
-    // Needs nightly+neon-sha3
-    // unsafe{ vbcaxq_u64(a, b, c) }
+    libcrux_intrinsics::arm64::_vbcaxq_u64(a, b, c)
 }
 
 #[inline(always)]
@@ -63,70 +38,80 @@ fn _veorq_n_u64(a: uint64x2_t, c: u64) -> uint64x2_t {
 }
 
 #[inline(always)]
-pub(crate) fn load_block<const RATE: usize>(s: &mut [[uint64x2_t; 5]; 5], blocks: [&[u8]; 2]) {
-    debug_assert!(RATE <= blocks[0].len() && RATE % 8 == 0);
+pub(crate) fn load_block<const RATE: usize>(
+    s: &mut [uint64x2_t; 25],
+    blocks: &[&[u8]; 2],
+    offset: usize,
+) {
+    debug_assert!(RATE <= blocks[0].len() && RATE % 8 == 0 && blocks[0].len() == blocks[1].len());
     for i in 0..RATE / 16 {
-        let v0 = _vld1q_bytes_u64(&blocks[0][16 * i..16 * (i + 1)]);
-        let v1 = _vld1q_bytes_u64(&blocks[1][16 * i..16 * (i + 1)]);
-        s[(2 * i) / 5][(2 * i) % 5] = _veorq_u64(s[(2 * i) / 5][(2 * i) % 5], _vtrn1q_u64(v0, v1));
-        s[(2 * i + 1) / 5][(2 * i + 1) % 5] =
-            _veorq_u64(s[(2 * i + 1) / 5][(2 * i + 1) % 5], _vtrn2q_u64(v0, v1));
+        let start = offset + 16 * i;
+        let v0 = _vld1q_bytes_u64(&blocks[0][start..start + 16]);
+        let v1 = _vld1q_bytes_u64(&blocks[1][start..start + 16]);
+        let i0 = (2 * i) / 5;
+        let j0 = (2 * i) % 5;
+        let i1 = (2 * i + 1) / 5;
+        let j1 = (2 * i + 1) % 5;
+        set_ij(
+            s,
+            i0,
+            j0,
+            _veorq_u64(get_ij(s, i0, j0), _vtrn1q_u64(v0, v1)),
+        );
+        set_ij(
+            s,
+            i1,
+            j1,
+            _veorq_u64(get_ij(s, i1, j1), _vtrn2q_u64(v0, v1)),
+        );
     }
     if RATE % 16 != 0 {
-        let i = (RATE / 8 - 1) / 5;
-        let j = (RATE / 8 - 1) % 5;
+        let i = RATE / 8 - 1;
         let mut u = [0u64; 2];
-        u[0] = u64::from_le_bytes(blocks[0][RATE - 8..RATE].try_into().unwrap());
-        u[1] = u64::from_le_bytes(blocks[1][RATE - 8..RATE].try_into().unwrap());
+        let start = offset + RATE - 8;
+        u[0] = u64::from_le_bytes(blocks[0][start..start + 8].try_into().unwrap());
+        u[1] = u64::from_le_bytes(blocks[1][start..start + 8].try_into().unwrap());
         let uvec = _vld1q_u64(&u);
-        s[i][j] = _veorq_u64(s[i][j], uvec);
+        set_ij(s, i / 5, i % 5, _veorq_u64(get_ij(s, i / 5, i % 5), uvec));
     }
 }
 
 #[inline(always)]
 pub(crate) fn load_block_full<const RATE: usize>(
-    s: &mut [[uint64x2_t; 5]; 5],
-    blocks: [[u8; 200]; 2],
+    s: &mut [uint64x2_t; 25],
+    blocks: &[[u8; 200]; 2],
+    start: usize,
 ) {
-    load_block::<RATE>(s, [&blocks[0] as &[u8], &blocks[1] as &[u8]]);
+    load_block::<RATE>(s, &[&blocks[0] as &[u8], &blocks[1] as &[u8]], start);
 }
 
 #[inline(always)]
-pub(crate) fn store_block<const RATE: usize>(s: &[[uint64x2_t; 5]; 5], out: [&mut [u8]; 2]) {
+pub(crate) fn store_block<const RATE: usize>(s: &[uint64x2_t; 25], out: &mut [&mut [u8]; 2]) {
     for i in 0..RATE / 16 {
-        let v0 = _vtrn1q_u64(
-            s[(2 * i) / 5][(2 * i) % 5],
-            s[(2 * i + 1) / 5][(2 * i + 1) % 5],
-        );
-        let v1 = _vtrn2q_u64(
-            s[(2 * i) / 5][(2 * i) % 5],
-            s[(2 * i + 1) / 5][(2 * i + 1) % 5],
-        );
+        let i0 = (2 * i) / 5;
+        let j0 = (2 * i) % 5;
+        let i1 = (2 * i + 1) / 5;
+        let j1 = (2 * i + 1) % 5;
+        let v0 = _vtrn1q_u64(get_ij(s, i0, j0), get_ij(s, i1, j1));
+        let v1 = _vtrn2q_u64(get_ij(s, i0, j0), get_ij(s, i1, j1));
         _vst1q_bytes_u64(&mut out[0][16 * i..16 * (i + 1)], v0);
         _vst1q_bytes_u64(&mut out[1][16 * i..16 * (i + 1)], v1);
     }
     if RATE % 16 != 0 {
         debug_assert!(RATE % 8 == 0);
-        let i = (RATE / 8 - 1) / 5;
-        let j = (RATE / 8 - 1) % 5;
+        let i = RATE / 8 - 1;
         let mut u = [0u8; 16];
-        _vst1q_bytes_u64(&mut u, s[i][j]);
+        _vst1q_bytes_u64(&mut u, get_ij(s, i / 5, i % 5));
         out[0][RATE - 8..RATE].copy_from_slice(&u[0..8]);
         out[1][RATE - 8..RATE].copy_from_slice(&u[8..16]);
     }
 }
 
 #[inline(always)]
-pub(crate) fn store_block_full<const RATE: usize>(s: &[[uint64x2_t; 5]; 5]) -> [[u8; 200]; 2] {
-    let mut out0 = [0u8; 200];
-    let mut out1 = [0u8; 200];
-    store_block::<RATE>(s, [&mut out0, &mut out1]);
-    [out0, out1]
-}
+pub(crate) fn store_block_full<const RATE: usize>(s: &[uint64x2_t; 25], out: &mut [[u8; 200]; 2]) {
+    let (out0, out1) = out.split_at_mut(1);
 
-#[inline(always)]
-fn slice_2(a: [&[u8]; 2], start: usize, len: usize) -> [&[u8]; 2] {
-    [&a[0][start..start + len], &a[1][start..start + len]]
+    store_block::<RATE>(s, &mut [&mut out0[0], &mut out1[0]]);
 }
 
 #[inline(always)]
@@ -167,32 +152,33 @@ impl KeccakItem<2> for uint64x2_t {
         _veorq_u64(a, b)
     }
     #[inline(always)]
-    fn load_block<const RATE: usize>(a: &mut [[Self; 5]; 5], b: [&[u8]; 2]) {
-        load_block::<RATE>(a, b)
+    fn load_block<const RATE: usize>(state: &mut [Self; 25], blocks: &[&[u8]; 2], start: usize) {
+        load_block::<RATE>(state, blocks, start)
     }
     #[inline(always)]
-    fn store_block<const RATE: usize>(a: &[[Self; 5]; 5], b: [&mut [u8]; 2]) {
-        store_block::<RATE>(a, b)
+    fn store_block<const RATE: usize>(state: &[Self; 25], blocks: &mut [&mut [u8]; 2]) {
+        store_block::<RATE>(state, blocks)
     }
     #[inline(always)]
-    fn load_block_full<const RATE: usize>(a: &mut [[Self; 5]; 5], b: [[u8; 200]; 2]) {
-        load_block_full::<RATE>(a, b)
+    fn load_block_full<const RATE: usize>(
+        state: &mut [Self; 25],
+        blocks: &[[u8; 200]; 2],
+        start: usize,
+    ) {
+        load_block_full::<RATE>(state, blocks, start)
     }
     #[inline(always)]
-    fn store_block_full<const RATE: usize>(a: &[[Self; 5]; 5]) -> [[u8; 200]; 2] {
-        store_block_full::<RATE>(a)
+    fn store_block_full<const RATE: usize>(state: &[Self; 25], out: &mut [[u8; 200]; 2]) {
+        store_block_full::<RATE>(state, out)
     }
-    #[inline(always)]
-    fn slice_n(a: [&[u8]; 2], start: usize, len: usize) -> [&[u8]; 2] {
-        slice_2(a, start, len)
-    }
+
     #[inline(always)]
     fn split_at_mut_n(a: [&mut [u8]; 2], mid: usize) -> ([&mut [u8]; 2], [&mut [u8]; 2]) {
         split_at_mut_2(a, mid)
     }
 
     // TODO: Do we need this, or not? cf. https://github.com/cryspen/libcrux/issues/482
-    fn store<const RATE: usize>(_state: &[[Self; 5]; 5], _out: [&mut [u8]; 2]) {
+    fn store<const RATE: usize>(_state: &[Self; 25], _out: [&mut [u8]; 2]) {
         todo!()
     }
 }

--- a/libcrux/libcrux-sha3/src/traits.rs
+++ b/libcrux/libcrux-sha3/src/traits.rs
@@ -5,6 +5,23 @@ pub trait KeccakStateItem<const N: usize>: internal::KeccakItem<N> {}
 // Implement the public trait for all items.
 impl<const N: usize, T: internal::KeccakItem<N>> KeccakStateItem<N> for T {}
 
+pub(crate) fn get_ij<const N: usize, T: KeccakStateItem<N>>(
+    arr: &[T; 25],
+    i: usize,
+    j: usize,
+) -> T {
+    arr[5 * j + i]
+}
+
+pub(crate) fn set_ij<const N: usize, T: KeccakStateItem<N>>(
+    arr: &mut [T; 25],
+    i: usize,
+    j: usize,
+    v: T,
+) {
+    arr[5 * j + i] = v;
+}
+
 pub(crate) mod internal {
     /// A trait for multiplexing implementations.
     pub trait KeccakItem<const N: usize>: Clone + Copy {
@@ -15,12 +32,15 @@ pub(crate) mod internal {
         fn and_not_xor(a: Self, b: Self, c: Self) -> Self;
         fn xor_constant(a: Self, c: u64) -> Self;
         fn xor(a: Self, b: Self) -> Self;
-        fn load_block<const RATE: usize>(a: &mut [[Self; 5]; 5], b: [&[u8]; N]);
-        fn store_block<const RATE: usize>(a: &[[Self; 5]; 5], b: [&mut [u8]; N]);
-        fn load_block_full<const RATE: usize>(a: &mut [[Self; 5]; 5], b: [[u8; 200]; N]);
-        fn store_block_full<const RATE: usize>(a: &[[Self; 5]; 5]) -> [[u8; 200]; N];
-        fn slice_n(a: [&[u8]; N], start: usize, len: usize) -> [&[u8]; N];
+        fn load_block<const RATE: usize>(state: &mut [Self; 25], blocks: &[&[u8]; N], start: usize);
+        fn store_block<const RATE: usize>(state: &[Self; 25], blocks: &mut [&mut [u8]; N]);
+        fn load_block_full<const RATE: usize>(
+            state: &mut [Self; 25],
+            blocks: &[[u8; 200]; N],
+            start: usize,
+        );
+        fn store_block_full<const RATE: usize>(a: &[Self; 25], out: &mut [[u8; 200]; N]);
         fn split_at_mut_n(a: [&mut [u8]; N], mid: usize) -> ([&mut [u8]; N], [&mut [u8]; N]);
-        fn store<const RATE: usize>(state: &[[Self; 5]; 5], out: [&mut [u8]; N]);
+        fn store<const RATE: usize>(state: &[Self; 25], out: [&mut [u8]; N]);
     }
 }

--- a/sys/pqm4/build.rs
+++ b/sys/pqm4/build.rs
@@ -2,12 +2,13 @@ use std::{env, path::Path};
 
 #[cfg(not(windows))]
 fn create_bindings(home_dir: &Path) {
-    let c_dir = home_dir.join("pqm4/crypto_kem/ml-kem-1024/m4fspeed/api.h");
-    let clang_args = vec![format!("-I{}", c_dir.display())];
+    let mlkem_dir = home_dir.join("pqm4/crypto_kem/ml-kem-1024/m4fspeed/api.h");
+    let fips202_dir = home_dir.join("pqm4/mupq/common/fips202.h");
+    let clang_args = vec![format!("-I{}", mlkem_dir.display()), format!("-I{}", fips202_dir.display())];
 
     let bindings = bindgen::Builder::default()
         // Header to wrap headers
-        .header("pqm4/crypto_kem/ml-kem-1024/m4fspeed/api.h")
+        .header("wrapper.h")
         // Set include paths for headers
         .clang_args(clang_args)
         // Generate bindings

--- a/sys/pqm4/src/bindings.rs
+++ b/sys/pqm4/src/bindings.rs
@@ -22,6 +22,11 @@ pub const CRYPTO_PUBLICKEYBYTES: u32 = 1568;
 pub const CRYPTO_CIPHERTEXTBYTES: u32 = 1568;
 pub const CRYPTO_BYTES: u32 = 32;
 pub const CRYPTO_ALGNAME: &[u8; 10] = b"Kyber1024\0";
+pub const SHAKE128_RATE: u32 = 168;
+pub const SHAKE256_RATE: u32 = 136;
+pub const SHA3_256_RATE: u32 = 136;
+pub const SHA3_384_RATE: u32 = 104;
+pub const SHA3_512_RATE: u32 = 72;
 unsafe extern "C" {
     pub fn crypto_kem_keypair(
         pk: *mut ::core::ffi::c_uchar,
@@ -41,4 +46,275 @@ unsafe extern "C" {
         ct: *const ::core::ffi::c_uchar,
         sk: *const ::core::ffi::c_uchar,
     ) -> ::core::ffi::c_int;
+}
+pub type wchar_t = ::core::ffi::c_uint;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct max_align_t {
+    pub __clang_max_align_nonce1: ::core::ffi::c_longlong,
+    pub __clang_max_align_nonce2: f64,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of max_align_t"][::core::mem::size_of::<max_align_t>() - 16usize];
+    ["Alignment of max_align_t"][::core::mem::align_of::<max_align_t>() - 8usize];
+    ["Offset of field: max_align_t::__clang_max_align_nonce1"]
+        [::core::mem::offset_of!(max_align_t, __clang_max_align_nonce1) - 0usize];
+    ["Offset of field: max_align_t::__clang_max_align_nonce2"]
+        [::core::mem::offset_of!(max_align_t, __clang_max_align_nonce2) - 8usize];
+};
+pub type int_least64_t = i64;
+pub type uint_least64_t = u64;
+pub type int_fast64_t = i64;
+pub type uint_fast64_t = u64;
+pub type int_least32_t = i32;
+pub type uint_least32_t = u32;
+pub type int_fast32_t = i32;
+pub type uint_fast32_t = u32;
+pub type int_least16_t = i16;
+pub type uint_least16_t = u16;
+pub type int_fast16_t = i16;
+pub type uint_fast16_t = u16;
+pub type int_least8_t = i8;
+pub type uint_least8_t = u8;
+pub type int_fast8_t = i8;
+pub type uint_fast8_t = u8;
+pub type intmax_t = ::core::ffi::c_longlong;
+pub type uintmax_t = ::core::ffi::c_ulonglong;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct shake128incctx {
+    pub ctx: [u64; 26usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of shake128incctx"][::core::mem::size_of::<shake128incctx>() - 208usize];
+    ["Alignment of shake128incctx"][::core::mem::align_of::<shake128incctx>() - 8usize];
+    ["Offset of field: shake128incctx::ctx"][::core::mem::offset_of!(shake128incctx, ctx) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct shake128ctx {
+    pub ctx: [u64; 25usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of shake128ctx"][::core::mem::size_of::<shake128ctx>() - 200usize];
+    ["Alignment of shake128ctx"][::core::mem::align_of::<shake128ctx>() - 8usize];
+    ["Offset of field: shake128ctx::ctx"][::core::mem::offset_of!(shake128ctx, ctx) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct shake256incctx {
+    pub ctx: [u64; 26usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of shake256incctx"][::core::mem::size_of::<shake256incctx>() - 208usize];
+    ["Alignment of shake256incctx"][::core::mem::align_of::<shake256incctx>() - 8usize];
+    ["Offset of field: shake256incctx::ctx"][::core::mem::offset_of!(shake256incctx, ctx) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct shake256ctx {
+    pub ctx: [u64; 25usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of shake256ctx"][::core::mem::size_of::<shake256ctx>() - 200usize];
+    ["Alignment of shake256ctx"][::core::mem::align_of::<shake256ctx>() - 8usize];
+    ["Offset of field: shake256ctx::ctx"][::core::mem::offset_of!(shake256ctx, ctx) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sha3_256incctx {
+    pub ctx: [u64; 26usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of sha3_256incctx"][::core::mem::size_of::<sha3_256incctx>() - 208usize];
+    ["Alignment of sha3_256incctx"][::core::mem::align_of::<sha3_256incctx>() - 8usize];
+    ["Offset of field: sha3_256incctx::ctx"][::core::mem::offset_of!(sha3_256incctx, ctx) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sha3_384incctx {
+    pub ctx: [u64; 26usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of sha3_384incctx"][::core::mem::size_of::<sha3_384incctx>() - 208usize];
+    ["Alignment of sha3_384incctx"][::core::mem::align_of::<sha3_384incctx>() - 8usize];
+    ["Offset of field: sha3_384incctx::ctx"][::core::mem::offset_of!(sha3_384incctx, ctx) - 0usize];
+};
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sha3_512incctx {
+    pub ctx: [u64; 26usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of sha3_512incctx"][::core::mem::size_of::<sha3_512incctx>() - 208usize];
+    ["Alignment of sha3_512incctx"][::core::mem::align_of::<sha3_512incctx>() - 8usize];
+    ["Offset of field: sha3_512incctx::ctx"][::core::mem::offset_of!(sha3_512incctx, ctx) - 0usize];
+};
+unsafe extern "C" {
+    pub fn shake128_absorb(state: *mut shake128ctx, input: *const u8, inlen: usize);
+}
+unsafe extern "C" {
+    pub fn shake128_squeezeblocks(output: *mut u8, nblocks: usize, state: *mut shake128ctx);
+}
+unsafe extern "C" {
+    pub fn shake128_ctx_release(state: *mut shake128ctx);
+}
+unsafe extern "C" {
+    pub fn shake128_ctx_clone(dest: *mut shake128ctx, src: *const shake128ctx);
+}
+unsafe extern "C" {
+    pub fn cshake128_simple_absorb(
+        state: *mut shake128ctx,
+        cstm: u16,
+        input: *const u8,
+        inlen: usize,
+    );
+}
+unsafe extern "C" {
+    pub fn cshake128_simple_squeezeblocks(output: *mut u8, nblocks: usize, state: *mut shake128ctx);
+}
+unsafe extern "C" {
+    pub fn cshake128_simple(
+        output: *mut u8,
+        outlen: usize,
+        cstm: u16,
+        input: *const u8,
+        inlen: usize,
+    );
+}
+unsafe extern "C" {
+    pub fn shake128_inc_init(state: *mut shake128incctx);
+}
+unsafe extern "C" {
+    pub fn shake128_inc_absorb(state: *mut shake128incctx, input: *const u8, inlen: usize);
+}
+unsafe extern "C" {
+    pub fn shake128_inc_finalize(state: *mut shake128incctx);
+}
+unsafe extern "C" {
+    pub fn shake128_inc_squeeze(output: *mut u8, outlen: usize, state: *mut shake128incctx);
+}
+unsafe extern "C" {
+    pub fn shake128_inc_ctx_clone(dest: *mut shake128incctx, src: *const shake128incctx);
+}
+unsafe extern "C" {
+    pub fn shake128_inc_ctx_release(state: *mut shake128incctx);
+}
+unsafe extern "C" {
+    pub fn shake256_absorb(state: *mut shake256ctx, input: *const u8, inlen: usize);
+}
+unsafe extern "C" {
+    pub fn shake256_squeezeblocks(output: *mut u8, nblocks: usize, state: *mut shake256ctx);
+}
+unsafe extern "C" {
+    pub fn shake256_ctx_release(state: *mut shake256ctx);
+}
+unsafe extern "C" {
+    pub fn shake256_ctx_clone(dest: *mut shake256ctx, src: *const shake256ctx);
+}
+unsafe extern "C" {
+    pub fn cshake256_simple_absorb(
+        state: *mut shake256ctx,
+        cstm: u16,
+        input: *const u8,
+        inlen: usize,
+    );
+}
+unsafe extern "C" {
+    pub fn cshake256_simple_squeezeblocks(output: *mut u8, nblocks: usize, state: *mut shake256ctx);
+}
+unsafe extern "C" {
+    pub fn cshake256_simple(
+        output: *mut u8,
+        outlen: usize,
+        cstm: u16,
+        input: *const u8,
+        inlen: usize,
+    );
+}
+unsafe extern "C" {
+    pub fn shake256_inc_init(state: *mut shake256incctx);
+}
+unsafe extern "C" {
+    pub fn shake256_inc_absorb(state: *mut shake256incctx, input: *const u8, inlen: usize);
+}
+unsafe extern "C" {
+    pub fn shake256_inc_finalize(state: *mut shake256incctx);
+}
+unsafe extern "C" {
+    pub fn shake256_inc_squeeze(output: *mut u8, outlen: usize, state: *mut shake256incctx);
+}
+unsafe extern "C" {
+    pub fn shake256_inc_ctx_clone(dest: *mut shake256incctx, src: *const shake256incctx);
+}
+unsafe extern "C" {
+    pub fn shake256_inc_ctx_release(state: *mut shake256incctx);
+}
+unsafe extern "C" {
+    pub fn shake128(output: *mut u8, outlen: usize, input: *const u8, inlen: usize);
+}
+unsafe extern "C" {
+    pub fn shake256(output: *mut u8, outlen: usize, input: *const u8, inlen: usize);
+}
+unsafe extern "C" {
+    pub fn sha3_256_inc_init(state: *mut sha3_256incctx);
+}
+unsafe extern "C" {
+    pub fn sha3_256_inc_absorb(state: *mut sha3_256incctx, input: *const u8, inlen: usize);
+}
+unsafe extern "C" {
+    pub fn sha3_256_inc_finalize(output: *mut u8, state: *mut sha3_256incctx);
+}
+unsafe extern "C" {
+    pub fn sha3_256_inc_ctx_clone(dest: *mut sha3_256incctx, src: *const sha3_256incctx);
+}
+unsafe extern "C" {
+    pub fn sha3_256_inc_ctx_release(state: *mut sha3_256incctx);
+}
+unsafe extern "C" {
+    pub fn sha3_256(output: *mut u8, input: *const u8, inlen: usize);
+}
+unsafe extern "C" {
+    pub fn sha3_384_inc_init(state: *mut sha3_384incctx);
+}
+unsafe extern "C" {
+    pub fn sha3_384_inc_absorb(state: *mut sha3_384incctx, input: *const u8, inlen: usize);
+}
+unsafe extern "C" {
+    pub fn sha3_384_inc_finalize(output: *mut u8, state: *mut sha3_384incctx);
+}
+unsafe extern "C" {
+    pub fn sha3_384_inc_ctx_clone(dest: *mut sha3_384incctx, src: *const sha3_384incctx);
+}
+unsafe extern "C" {
+    pub fn sha3_384_inc_ctx_release(state: *mut sha3_384incctx);
+}
+unsafe extern "C" {
+    pub fn sha3_384(output: *mut u8, input: *const u8, inlen: usize);
+}
+unsafe extern "C" {
+    pub fn sha3_512_inc_init(state: *mut sha3_512incctx);
+}
+unsafe extern "C" {
+    pub fn sha3_512_inc_absorb(state: *mut sha3_512incctx, input: *const u8, inlen: usize);
+}
+unsafe extern "C" {
+    pub fn sha3_512_inc_finalize(output: *mut u8, state: *mut sha3_512incctx);
+}
+unsafe extern "C" {
+    pub fn sha3_512_inc_ctx_clone(dest: *mut sha3_512incctx, src: *const sha3_512incctx);
+}
+unsafe extern "C" {
+    pub fn sha3_512_inc_ctx_release(state: *mut sha3_512incctx);
+}
+unsafe extern "C" {
+    pub fn sha3_512(output: *mut u8, input: *const u8, inlen: usize);
 }

--- a/sys/pqm4/wrapper.h
+++ b/sys/pqm4/wrapper.h
@@ -1,0 +1,2 @@
+#include "pqm4/crypto_kem/ml-kem-1024/m4fspeed/api.h"
+#include "pqm4/mupq/common/fips202.h"


### PR DESCRIPTION
As a prerequisite for optimizing in SHA-3 it will be good to focus on the exact input/output sizes that matter in ML-KEM.

This PR can serve as a basis for that, and also includes a small utility for switching on the hardware RNG on the L4R5ZI.

Note that the functions under test are `#[inline(never)]` here at the moment, so as to get sensible cycle measurements. It shouldn't get merged as is for that reason.

Fixes #53