### PR TITLE
Bump allocator for SHA3

### DIFF
--- a/libcrux/libcrux-sha3/Cargo.toml
+++ b/libcrux/libcrux-sha3/Cargo.toml
@@ -17,10 +17,10 @@ bench = false # so libtest doesn't eat the arguments to criterion
 libcrux-platform = { version = "0.0.2-beta.2", path = "../libcrux-platform" }
 libcrux-intrinsics = { version = "0.0.2-beta.2", path = "../libcrux-intrinsics" }
 
-# # This is only required for verification.
-# # The hax config is set by the hax toolchain.
-# [target.'cfg(hax)'.dependencies]
-# hax-lib = { version = "0.2.0", git = "https://github.com/hacspec/hax/" }
+# This is only required for verification.
+# The hax config is set by the hax toolchain.
+[target.'cfg(hax)'.dependencies]
+hax-lib = { version = "0.2.0", git = "https://github.com/hacspec/hax/" }
 
 [features]
 simd128 = []

--- a/libcrux/libcrux-sha3/Cargo.toml
+++ b/libcrux/libcrux-sha3/Cargo.toml
@@ -17,10 +17,10 @@ bench = false # so libtest doesn't eat the arguments to criterion
 libcrux-platform = { version = "0.0.2-beta.2", path = "../libcrux-platform" }
 libcrux-intrinsics = { version = "0.0.2-beta.2", path = "../libcrux-intrinsics" }
 
-# This is only required for verification.
-# The hax config is set by the hax toolchain.
-[target.'cfg(hax)'.dependencies]
-hax-lib = { version = "0.2.0", git = "https://github.com/hacspec/hax/" }
+# # This is only required for verification.
+# # The hax config is set by the hax toolchain.
+# [target.'cfg(hax)'.dependencies]
+# hax-lib = { version = "0.2.0", git = "https://github.com/hacspec/hax/" }
 
 [features]
 simd128 = []

--- a/libcrux/libcrux-sha3/src/alloc.rs
+++ b/libcrux/libcrux-sha3/src/alloc.rs
@@ -3,45 +3,40 @@
 use core::cell::RefCell;
 use core::default::Default;
 
-pub struct Alloc<const STACK_SIZE: usize, T:Sized + Default + Copy> {
+pub struct Alloc<const STACK_SIZE: usize, T: Sized + Default + Copy> {
     /// The backing buffer.
     #[allow(dead_code)]
     buffer: [T; STACK_SIZE],
     /// Points to the region of available memory within [buffer].
     pointer: RefCell<*mut T>,
-    /// Points to the end of [buffer].
-    end_pointer: *const T,
 }
 
 impl<const STACK_SIZE: usize, T: Sized + Default + Copy> Alloc<STACK_SIZE, T> {
     pub(crate) fn new() -> Self {
-        let mut buffer = [T::default(); STACK_SIZE];
-        let pointer = RefCell::new(buffer.as_mut_ptr());
-        let end_pointer = unsafe { buffer.as_mut_ptr().add(STACK_SIZE) };
+        let buffer = [T::default(); STACK_SIZE];
+        let pointer = RefCell::new(core::ptr::null_mut::<T>());
 
-        Self {
-            buffer,
-            pointer,
-            end_pointer,
-        }
+        let out = Self { buffer, pointer };
+
+        let buffer_ptr = out.buffer.as_ptr();
+
+        *(out.pointer.borrow_mut()) = buffer_ptr as *mut T;
+
+        out
     }
 
     pub(crate) fn alloc(&self, len: usize) -> &mut [T] {
-        println!("Allocation {len}");
-        println!("self.buffer: {:?}", self.buffer.as_ptr());
-        println!("self.pointer: {:?}", *self.pointer.borrow());
         let allocation_start = *self.pointer.borrow();
-        let allocation_end = unsafe { (*self.pointer.borrow()).add(len ) };
+        let allocation_end = unsafe { (*self.pointer.borrow()).add(len) };
 
-        if (allocation_end as *const T) >= self.end_pointer {
+        if (allocation_end as *const T) >= unsafe { self.buffer.as_ptr().add(STACK_SIZE) } {
             panic!("Insufficient memory")
         }
 
-        let out: &mut [T] =
-            unsafe { core::slice::from_raw_parts_mut(allocation_start, len) };
+        let out: &mut [T] = unsafe { core::slice::from_raw_parts_mut(allocation_start, len) };
 
-        *self.pointer.borrow_mut() = unsafe { allocation_start.add(len ) };
-        
+        *self.pointer.borrow_mut() = allocation_end;
+
         out
     }
 
@@ -50,9 +45,8 @@ impl<const STACK_SIZE: usize, T: Sized + Default + Copy> Alloc<STACK_SIZE, T> {
         println!("Freeing {}", allocation.len());
         println!("self.buffer: {:?}", self.buffer.as_ptr());
         println!("self.pointer: {:?}", *self.pointer.borrow());
-        
-        let new_pointer =
-            unsafe { (*self.pointer.borrow()).offset(-(allocation.len() as isize)) };
+
+        let new_pointer = unsafe { (*self.pointer.borrow()).sub(allocation.len()) };
         if (new_pointer as *const T) != allocation.as_ptr() {
             panic!("Invalid free")
         }

--- a/libcrux/libcrux-sha3/src/alloc.rs
+++ b/libcrux/libcrux-sha3/src/alloc.rs
@@ -1,22 +1,70 @@
 #![allow(unsafe_code)]
-struct Alloc<const STACK_SIZE: usize> {
+
+use core::cell::RefCell;
+
+pub struct Alloc<const STACK_SIZE: usize> {
+    /// The backing buffer.
+    #[allow(dead_code)]
     buffer: [u8; STACK_SIZE],
-    pointer: usize,
+    /// Points to the region of available memory within [buffer].
+    pointer: RefCell<*mut u8>,
+    /// Points to the end of [buffer].
+    end_pointer: *const u8,
 }
 
 impl<const STACK_SIZE: usize> Alloc<STACK_SIZE> {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
+        let mut buffer = [0u8; STACK_SIZE];
+        let pointer = RefCell::new(buffer.as_mut_ptr());
+        let end_pointer = unsafe { buffer.as_mut_ptr().add(STACK_SIZE) };
+
         Self {
-            buffer: [0u8; STACK_SIZE],
-            pointer: 0
+            buffer,
+            pointer,
+            end_pointer,
         }
     }
 
-    fn bytes(&self, len: usize) -> &[u8] {
-        let out = unsafe {
-            core::slice::from_raw_parts(self.buffer.as_ptr().add(self.pointer) as *const u8, len)
-        };
+    pub(crate) fn alloc<T: Sized>(&self, len: usize, init: fn(usize) -> T) -> &mut [T] {
+        let t_alignment = core::mem::align_of::<T>();
+        let requested_size = len * core::mem::size_of::<T>();
 
+        let offset = (*self.pointer.borrow()).align_offset(t_alignment);
+
+        let allocation_start = unsafe { (*self.pointer.borrow()).add(offset) };
+        let allocation_end = unsafe { (*self.pointer.borrow()).add(requested_size + offset) };
+
+        if (allocation_end as *const u8) >= self.end_pointer {
+            panic!("Insufficient memory")
+        }
+
+        let out: &mut [u8] =
+            unsafe { core::slice::from_raw_parts_mut(allocation_start, requested_size) };
+
+        let out = unsafe { &mut *(out as *mut [u8] as *mut[T])};
+        let mut out_ptr = out.as_mut_ptr();
+        for i in 0..len {
+            unsafe {
+                out_ptr.write(init(i));
+                out_ptr = out_ptr.offset(1);
+            }
+        }
+        
+        *self.pointer.borrow_mut() = allocation_end;
+        
         out
+    }
+
+    /// This assumes that `allocation` was the most recent allocation.
+    pub(crate) fn free<T: Sized>(&self, allocation: &mut [T]) {
+        let bytes_to_be_freed = allocation.len() * core::mem::size_of::<T>();
+
+        let new_pointer =
+            unsafe { (*self.pointer.borrow()).byte_offset(-(bytes_to_be_freed as isize)) };
+        if (new_pointer as *const u8) < self.buffer.as_ptr() {
+            panic!("Trying to free more than was allocated")
+        }
+
+        *self.pointer.borrow_mut() = new_pointer;
     }
 }

--- a/libcrux/libcrux-sha3/src/alloc.rs
+++ b/libcrux/libcrux-sha3/src/alloc.rs
@@ -1,0 +1,22 @@
+#![allow(unsafe_code)]
+struct Alloc<const STACK_SIZE: usize> {
+    buffer: [u8; STACK_SIZE],
+    pointer: usize,
+}
+
+impl<const STACK_SIZE: usize> Alloc<STACK_SIZE> {
+    fn new() -> Self {
+        Self {
+            buffer: [0u8; STACK_SIZE],
+            pointer: 0
+        }
+    }
+
+    fn bytes(&self, len: usize) -> &[u8] {
+        let out = unsafe {
+            core::slice::from_raw_parts(self.buffer.as_ptr().add(self.pointer) as *const u8, len)
+        };
+
+        out
+    }
+}

--- a/libcrux/libcrux-sha3/src/alloc.rs
+++ b/libcrux/libcrux-sha3/src/alloc.rs
@@ -1,3 +1,17 @@
+//! Very simple bump allocator.
+//!
+//! Safety ⚠️:
+//! - Initializing this is a two-step process. First create an
+//!   allocator with [Alloc::new] and then, after it has been moved to
+//!   a place, set the internal pointer with `set_pointer`:
+//!   ```ignore
+//!   let alloc = Alloc::<STACK_SIZE,T>::new();
+//!   alloc.set_pointer();
+//!   ... // you can now use the allocator, by reference only
+//!   ```
+//! - Memory can only be freed if it is provably the most recently
+//!   allocated memory.
+
 #![allow(unsafe_code)]
 
 use core::cell::RefCell;
@@ -12,20 +26,38 @@ pub struct Alloc<const STACK_SIZE: usize, T: Sized + Default + Copy> {
 }
 
 impl<const STACK_SIZE: usize, T: Sized + Default + Copy> Alloc<STACK_SIZE, T> {
+    /// Creates a new Allocator.
+    ///
+    /// After the allocator has been created and assigned to a place,
+    /// use `self.set_pointer` to initialize the internal
+    /// pointer. After this, the allocator MUST NOT be moved.
     pub(crate) fn new() -> Self {
         let buffer = [T::default(); STACK_SIZE];
-        let pointer = RefCell::new(core::ptr::null_mut::<T>());
+        // We can only set the pointer to the start of `buffer` once
+        // we can assume that `buffer` will not be moved anymore.
+        let pointer = RefCell::new(core::ptr::null_mut::<T>()); 
 
-        let out = Self { buffer, pointer };
-
-        let buffer_ptr = out.buffer.as_ptr();
-
-        *(out.pointer.borrow_mut()) = buffer_ptr as *mut T;
+        let out = Self {
+            buffer,
+            pointer,
+        };
 
         out
     }
 
+    /// Sets the internal pointer to the beginning of `self.buffer`
+    ///
+    /// This MUST be done before calling `alloc` for the first time.
+    /// After calling this `self` MUST NOT be moved, as this lead to
+    /// an invalid state of `self.pointer`.
+    pub(crate) fn set_pointer(&self) {
+        let buffer_ptr = self.buffer.as_ptr();
+        *(self.pointer.borrow_mut()) = buffer_ptr as *mut T;
+    }
+
+    /// Allocate a mutable T-slice of length `len`.
     pub(crate) fn alloc(&self, len: usize) -> &mut [T] {
+        assert!(!(*self.pointer.borrow()).is_null(), "Internal pointer must be set with `self.set_pointer`, after which `self` MUST NOT be moved");
         let allocation_start = *self.pointer.borrow();
         let allocation_end = unsafe { (*self.pointer.borrow()).add(len) };
 
@@ -40,12 +72,11 @@ impl<const STACK_SIZE: usize, T: Sized + Default + Copy> Alloc<STACK_SIZE, T> {
         out
     }
 
-    /// This assumes that `allocation` was the most recent allocation.
+    /// Free the most recent allocation.
+    ///
+    /// This MUST NOT be used if `allocation` cannot be proven to be
+    /// the most recent allocation.
     pub(crate) fn free(&self, allocation: &mut [T]) {
-        println!("Freeing {}", allocation.len());
-        println!("self.buffer: {:?}", self.buffer.as_ptr());
-        println!("self.pointer: {:?}", *self.pointer.borrow());
-
         let new_pointer = unsafe { (*self.pointer.borrow()).sub(allocation.len()) };
         if (new_pointer as *const T) != allocation.as_ptr() {
             panic!("Invalid free")

--- a/libcrux/libcrux-sha3/src/alloc.rs
+++ b/libcrux/libcrux-sha3/src/alloc.rs
@@ -1,20 +1,21 @@
 #![allow(unsafe_code)]
 
 use core::cell::RefCell;
+use core::default::Default;
 
-pub struct Alloc<const STACK_SIZE: usize> {
+pub struct Alloc<const STACK_SIZE: usize, T:Sized + Default + Copy> {
     /// The backing buffer.
     #[allow(dead_code)]
-    buffer: [u8; STACK_SIZE],
+    buffer: [T; STACK_SIZE],
     /// Points to the region of available memory within [buffer].
-    pointer: RefCell<*mut u8>,
+    pointer: RefCell<*mut T>,
     /// Points to the end of [buffer].
-    end_pointer: *const u8,
+    end_pointer: *const T,
 }
 
-impl<const STACK_SIZE: usize> Alloc<STACK_SIZE> {
+impl<const STACK_SIZE: usize, T: Sized + Default + Copy> Alloc<STACK_SIZE, T> {
     pub(crate) fn new() -> Self {
-        let mut buffer = [0u8; STACK_SIZE];
+        let mut buffer = [T::default(); STACK_SIZE];
         let pointer = RefCell::new(buffer.as_mut_ptr());
         let end_pointer = unsafe { buffer.as_mut_ptr().add(STACK_SIZE) };
 
@@ -25,43 +26,28 @@ impl<const STACK_SIZE: usize> Alloc<STACK_SIZE> {
         }
     }
 
-    pub(crate) fn alloc<T: Sized>(&self, len: usize, init: fn(usize) -> T) -> &mut [T] {
-        let t_alignment = core::mem::align_of::<T>();
-        let requested_size = len * core::mem::size_of::<T>();
+    pub(crate) fn alloc(&self, len: usize) -> &mut [T] {
+        println!("Allocation {len}");
+        let allocation_start = *self.pointer.borrow();
+        let allocation_end = unsafe { (*self.pointer.borrow()).add(len ) };
 
-        let offset = (*self.pointer.borrow()).align_offset(t_alignment);
-
-        let allocation_start = unsafe { (*self.pointer.borrow()).add(offset) };
-        let allocation_end = unsafe { (*self.pointer.borrow()).add(requested_size + offset) };
-
-        if (allocation_end as *const u8) >= self.end_pointer {
+        if (allocation_end as *const T) >= self.end_pointer {
             panic!("Insufficient memory")
         }
 
-        let out: &mut [u8] =
-            unsafe { core::slice::from_raw_parts_mut(allocation_start, requested_size) };
+        let out: &mut [T] =
+            unsafe { core::slice::from_raw_parts_mut(allocation_start, len) };
 
-        let out = unsafe { &mut *(out as *mut [u8] as *mut[T])};
-        let mut out_ptr = out.as_mut_ptr();
-        for i in 0..len {
-            unsafe {
-                out_ptr.write(init(i));
-                out_ptr = out_ptr.offset(1);
-            }
-        }
-        
-        *self.pointer.borrow_mut() = allocation_end;
+        *self.pointer.borrow_mut() = unsafe { (*self.pointer.borrow()).add(len ) };
         
         out
     }
 
     /// This assumes that `allocation` was the most recent allocation.
-    pub(crate) fn free<T: Sized>(&self, allocation: &mut [T]) {
-        let bytes_to_be_freed = allocation.len() * core::mem::size_of::<T>();
-
+    pub(crate) fn free(&self, allocation: &mut [T]) {
         let new_pointer =
-            unsafe { (*self.pointer.borrow()).byte_offset(-(bytes_to_be_freed as isize)) };
-        if (new_pointer as *const u8) < self.buffer.as_ptr() {
+            unsafe { (*self.pointer.borrow()).offset(-(allocation.len() as isize)) };
+        if (new_pointer as *const T) < self.buffer.as_ptr() {
             panic!("Trying to free more than was allocated")
         }
 

--- a/libcrux/libcrux-sha3/src/alloc.rs
+++ b/libcrux/libcrux-sha3/src/alloc.rs
@@ -28,6 +28,8 @@ impl<const STACK_SIZE: usize, T: Sized + Default + Copy> Alloc<STACK_SIZE, T> {
 
     pub(crate) fn alloc(&self, len: usize) -> &mut [T] {
         println!("Allocation {len}");
+        println!("self.buffer: {:?}", self.buffer.as_ptr());
+        println!("self.pointer: {:?}", *self.pointer.borrow());
         let allocation_start = *self.pointer.borrow();
         let allocation_end = unsafe { (*self.pointer.borrow()).add(len ) };
 
@@ -38,17 +40,21 @@ impl<const STACK_SIZE: usize, T: Sized + Default + Copy> Alloc<STACK_SIZE, T> {
         let out: &mut [T] =
             unsafe { core::slice::from_raw_parts_mut(allocation_start, len) };
 
-        *self.pointer.borrow_mut() = unsafe { (*self.pointer.borrow()).add(len ) };
+        *self.pointer.borrow_mut() = unsafe { allocation_start.add(len ) };
         
         out
     }
 
     /// This assumes that `allocation` was the most recent allocation.
     pub(crate) fn free(&self, allocation: &mut [T]) {
+        println!("Freeing {}", allocation.len());
+        println!("self.buffer: {:?}", self.buffer.as_ptr());
+        println!("self.pointer: {:?}", *self.pointer.borrow());
+        
         let new_pointer =
             unsafe { (*self.pointer.borrow()).offset(-(allocation.len() as isize)) };
-        if (new_pointer as *const T) < self.buffer.as_ptr() {
-            panic!("Trying to free more than was allocated")
+        if (new_pointer as *const T) != allocation.as_ptr() {
+            panic!("Invalid free")
         }
 
         *self.pointer.borrow_mut() = new_pointer;

--- a/libcrux/libcrux-sha3/src/generic_keccak.rs
+++ b/libcrux/libcrux-sha3/src/generic_keccak.rs
@@ -583,6 +583,8 @@ pub(crate) fn keccak<const N: usize, T: KeccakStateItem<N>, const RATE: usize, c
     out: [&mut [u8]; N],
 ) {
     let alloc = Alloc::<500, T>::new();
+    alloc.set_pointer(); // We have to set the pointer here because
+                         // the assignment above also moves `alloc`.
     let mut s = KeccakState::<N, T>::new(&alloc);
 
     for i in 0..data[0].len() / RATE {

--- a/libcrux/libcrux-sha3/src/generic_keccak.rs
+++ b/libcrux/libcrux-sha3/src/generic_keccak.rs
@@ -1,15 +1,22 @@
 //! The generic SHA3 implementation that uses portable or platform specific
 //! sub-routines.
 
-use crate::traits::*;
+use crate::{alloc::Alloc, traits::*};
 
 #[cfg_attr(hax, hax_lib::opaque)]
-#[derive(Clone, Copy)]
-pub(crate) struct KeccakState<const N: usize, T: KeccakStateItem<N>> {
-    st: [T; 25],
+pub(crate) struct KeccakState<'a, const N: usize, T: KeccakStateItem<N>> {
+    st: &'a mut [T],
 }
 
-impl<const N: usize, T: KeccakStateItem<N>> KeccakState<N, T> {
+impl<'a, const N: usize, T: KeccakStateItem<N>> KeccakState<'a, N, T> {
+    /// Create a new Shake128 x4 state.
+    #[inline(always)]
+    pub(crate) fn new<const STACK_SIZE: usize>(alloc: &'a Alloc<STACK_SIZE>) -> Self {
+        Self {
+            st: alloc.alloc(25, |_| T::zero()),
+        }
+    }
+
     fn get(&self, i: usize, j: usize) -> T {
         get_ij(&self.st, i, j)
     }
@@ -18,25 +25,16 @@ impl<const N: usize, T: KeccakStateItem<N>> KeccakState<N, T> {
     }
 }
 
-impl<const N: usize, T: KeccakStateItem<N>> KeccakState<N, T> {
-    /// Create a new Shake128 x4 state.
-    #[inline(always)]
-    pub(crate) fn new() -> Self {
-        Self {
-            st: [T::zero(); 25],
-        }
-    }
-}
-
 /// The internal keccak state that can also buffer inputs to absorb.
 /// This is used in the general xof APIs.
 #[cfg_attr(hax, hax_lib::opaque)]
 pub(crate) struct KeccakXofState<
+    'a,
     const PARALLEL_LANES: usize,
     const RATE: usize,
     STATE: KeccakStateItem<PARALLEL_LANES>,
 > {
-    inner: KeccakState<PARALLEL_LANES, STATE>,
+    inner: KeccakState<'a, PARALLEL_LANES, STATE>,
 
     // Buffer inputs on absorb.
     buf: [[u8; RATE]; PARALLEL_LANES],
@@ -48,8 +46,12 @@ pub(crate) struct KeccakXofState<
     sponge: bool,
 }
 
-impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakStateItem<PARALLEL_LANES>>
-    KeccakXofState<PARALLEL_LANES, RATE, STATE>
+impl<
+        'a,
+        const PARALLEL_LANES: usize,
+        const RATE: usize,
+        STATE: KeccakStateItem<PARALLEL_LANES>,
+    > KeccakXofState<'a, PARALLEL_LANES, RATE, STATE>
 {
     /// An all zero block
     pub(crate) const fn zero_block() -> [u8; RATE] {
@@ -57,9 +59,9 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakStateItem<PARA
     }
 
     /// Generate a new keccak xof state.
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new<const STACK_SIZE: usize>(alloc: &'a Alloc<STACK_SIZE>) -> Self {
         Self {
-            inner: KeccakState::new(),
+            inner: KeccakState::new(alloc),
             buf: [Self::zero_block(); PARALLEL_LANES],
             buf_len: 0,
             sponge: false,
@@ -76,8 +78,8 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakStateItem<PARA
     ///
     /// This works best with relatively small `inputs`.
     #[inline(always)]
-    pub(crate) fn absorb(&mut self, inputs: &[&[u8]; PARALLEL_LANES]) {
-        let input_remainder_len = self.absorb_full(inputs);
+    pub(crate) fn absorb<const STACK_SIZE: usize>(&mut self, alloc: &Alloc<STACK_SIZE>, inputs: &[&[u8]; PARALLEL_LANES]) {
+        let input_remainder_len = self.absorb_full(alloc, inputs);
 
         // ... buffer the rest if there's not enough input (left).
         if input_remainder_len > 0 {
@@ -95,7 +97,11 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakStateItem<PARA
         }
     }
 
-    fn absorb_full(&mut self, inputs: &[&[u8]; PARALLEL_LANES]) -> usize {
+    fn absorb_full<const STACK_SIZE: usize>(
+        &mut self,
+        alloc: &Alloc<STACK_SIZE>,
+        inputs: &[&[u8]; PARALLEL_LANES],
+    ) -> usize {
         debug_assert!(PARALLEL_LANES > 0);
         debug_assert!(self.buf_len < RATE);
         #[cfg(debug_assertions)]
@@ -115,7 +121,7 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakStateItem<PARA
                 borrowed[i] = &self.buf[i];
             }
             STATE::load_block::<RATE>(&mut self.inner.st, &borrowed, 0);
-            keccakf1600(&mut self.inner);
+            keccakf1600(alloc, &mut self.inner);
 
             // "empty" the local buffer
             self.buf_len = 0;
@@ -130,7 +136,7 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakStateItem<PARA
         for i in 0..num_blocks {
             // We only get in here if `input_len / RATE > 0`.
             STATE::load_block::<RATE>(&mut self.inner.st, &inputs, input_consumed + i * RATE);
-            keccakf1600(&mut self.inner);
+            keccakf1600(alloc, &mut self.inner);
         }
 
         remainder
@@ -166,8 +172,12 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakStateItem<PARA
     /// The `inputs` block may be empty. Everything in the `inputs` block beyond
     /// `RATE` bytes is ignored.
     #[inline(always)]
-    pub(crate) fn absorb_final<const DELIMITER: u8>(&mut self, inputs: &[&[u8]; PARALLEL_LANES]) {
-        let input_remainder_len = self.absorb_full(inputs);
+    pub(crate) fn absorb_final<const STACK_SIZE: usize, const DELIMITER: u8>(
+        &mut self,
+        alloc: &Alloc<STACK_SIZE>,
+        inputs: &[&[u8]; PARALLEL_LANES],
+    ) {
+        let input_remainder_len = self.absorb_full(alloc, inputs);
 
         // Consume the remaining bytes.
         // This may be in the local buffer or in the input.
@@ -186,17 +196,17 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakStateItem<PARA
         }
 
         STATE::load_block_full::<RATE>(&mut self.inner.st, &blocks, 0);
-        keccakf1600(&mut self.inner);
+        keccakf1600(alloc, &mut self.inner);
     }
 
     /// Squeeze `N` x `LEN` bytes.
     #[inline(always)]
-    pub(crate) fn squeeze(&mut self, out: [&mut [u8]; PARALLEL_LANES]) {
+    pub(crate) fn squeeze<const STACK_SIZE: usize>(&mut self, alloc: &Alloc<STACK_SIZE>, out: [&mut [u8]; PARALLEL_LANES]) {
         if self.sponge {
             // If we called `squeeze` before, call f1600 first.
             // We do it this way around so that we don't call f1600 at the end
             // when we don't need it.
-            keccakf1600(&mut self.inner);
+            keccakf1600(alloc, &mut self.inner);
         }
 
         // How many blocks do we need to squeeze out?
@@ -215,14 +225,14 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakStateItem<PARA
         for _ in 1..blocks {
             // Here we know that we always have full blocks to write out.
             let (out0, tmp) = STATE::split_at_mut_n(out_rest, RATE);
-            keccakf1600(&mut self.inner);
+            keccakf1600(alloc, &mut self.inner);
             STATE::store::<RATE>(&self.inner.st, out0);
             out_rest = tmp;
         }
 
         if last < out_len {
             // Squeeze out the last partial block
-            keccakf1600(&mut self.inner);
+            keccakf1600(alloc, &mut self.inner);
             STATE::store::<RATE>(&self.inner.st, out_rest);
         }
 
@@ -320,8 +330,13 @@ const _PI: [usize; 24] = [
 ];
 
 #[inline(always)]
-pub(crate) fn pi<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T>) {
-    let old = s.clone();
+pub(crate) fn pi<const N: usize, T: KeccakStateItem<N>>(
+    s: &mut KeccakState<N, T>,
+    scratch: &mut [T],
+) {
+    scratch.copy_from_slice(s.st);
+    let old = KeccakState { st: scratch };
+
     s.set(1, 0, old.get(0, 3));
     s.set(2, 0, old.get(0, 1));
     s.set(3, 0, old.get(0, 4));
@@ -349,8 +364,12 @@ pub(crate) fn pi<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T
 }
 
 #[inline(always)]
-pub(crate) fn chi<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T>) {
-    let old = s.clone();
+pub(crate) fn chi<const N: usize, T: KeccakStateItem<N>>(
+    s: &mut KeccakState<N, T>,
+    scratch: &mut [T],
+) {
+    scratch.copy_from_slice(s.st);
+    let old = KeccakState { st: scratch };
 
     #[allow(clippy::needless_range_loop)]
     for i in 0..5 {
@@ -401,32 +420,45 @@ pub(crate) fn iota<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N,
 }
 
 #[inline(always)]
-pub(crate) fn keccakf1600<const N: usize, T: KeccakStateItem<N>>(s: &mut KeccakState<N, T>) {
+pub(crate) fn keccakf1600<const STACK_SIZE: usize, const N: usize, T: KeccakStateItem<N>>(
+    alloc: &Alloc<STACK_SIZE>,
+    s: &mut KeccakState<N, T>,
+) {
+    let scratch = alloc.alloc(25, |_| T::zero());
     for i in 0..24 {
         theta_rho(s);
-        pi(s);
-        chi(s);
+        pi(s, scratch);
+        chi(s, scratch);
         iota(s, i);
     }
+    alloc.free(scratch);
 }
 
 #[inline(always)]
-pub(crate) fn absorb_block<const N: usize, T: KeccakStateItem<N>, const RATE: usize>(
+pub(crate) fn absorb_block<
+    const STACK_SIZE: usize,
+    const N: usize,
+    T: KeccakStateItem<N>,
+    const RATE: usize,
+>(
+    alloc: &Alloc<STACK_SIZE>,
     s: &mut KeccakState<N, T>,
     blocks: &[&[u8]; N],
     start: usize,
 ) {
     T::load_block::<RATE>(&mut s.st, blocks, start);
-    keccakf1600(s)
+    keccakf1600(alloc, s)
 }
 
 #[inline(always)]
 pub(crate) fn absorb_final<
+    const STACK_SIZE: usize,
     const N: usize,
     T: KeccakStateItem<N>,
     const RATE: usize,
     const DELIM: u8,
 >(
+    alloc: &Alloc<STACK_SIZE>,
     s: &mut KeccakState<N, T>,
     last: &[&[u8]; N],
     start: usize,
@@ -434,7 +466,7 @@ pub(crate) fn absorb_final<
 ) {
     debug_assert!(N > 0 && len < RATE); // && last[0].len() < RATE
 
-    let mut blocks = [[0u8; 200]; N];
+    let mut blocks = [[0u8; 200]; N]; // XXX: Allocate this
     for i in 0..N {
         if len > 0 {
             blocks[i][0..len].copy_from_slice(&last[i][start..start + len]);
@@ -443,7 +475,7 @@ pub(crate) fn absorb_final<
         blocks[i][RATE - 1] |= 0x80;
     }
     T::load_block_full::<RATE>(&mut s.st, &blocks, 0);
-    keccakf1600(s)
+    keccakf1600(alloc, s)
 }
 
 #[inline(always)]
@@ -455,60 +487,78 @@ pub(crate) fn squeeze_first_block<const N: usize, T: KeccakStateItem<N>, const R
 }
 
 #[inline(always)]
-pub(crate) fn squeeze_next_block<const N: usize, T: KeccakStateItem<N>, const RATE: usize>(
+pub(crate) fn squeeze_next_block<
+    const STACK_SIZE: usize,
+    const N: usize,
+    T: KeccakStateItem<N>,
+    const RATE: usize,
+>(
+    alloc: &Alloc<STACK_SIZE>,
     s: &mut KeccakState<N, T>,
+
     out: &mut [&mut [u8]; N],
 ) {
-    keccakf1600(s);
+    keccakf1600(alloc, s);
     T::store_block::<RATE>(&s.st, out)
 }
 
 #[inline(always)]
 pub(crate) fn squeeze_first_three_blocks<
+    const STACK_SIZE: usize,
     const N: usize,
     T: KeccakStateItem<N>,
     const RATE: usize,
 >(
+    alloc: &Alloc<STACK_SIZE>,
     s: &mut KeccakState<N, T>,
     out: [&mut [u8]; N],
 ) {
     let (mut o0, o1) = T::split_at_mut_n(out, RATE);
     squeeze_first_block::<N, T, RATE>(s, &mut o0);
     let (mut o1, mut o2) = T::split_at_mut_n(o1, RATE);
-    squeeze_next_block::<N, T, RATE>(s, &mut o1);
-    squeeze_next_block::<N, T, RATE>(s, &mut o2);
+    squeeze_next_block::<STACK_SIZE, N, T, RATE>(alloc, s, &mut o1);
+    squeeze_next_block::<STACK_SIZE, N, T, RATE>(alloc, s, &mut o2);
 }
 
 #[inline(always)]
 pub(crate) fn squeeze_first_five_blocks<
+    const STACK_SIZE: usize,
     const N: usize,
     T: KeccakStateItem<N>,
     const RATE: usize,
 >(
+    alloc: &Alloc<STACK_SIZE>,
     s: &mut KeccakState<N, T>,
+
     out: [&mut [u8]; N],
 ) {
     let (mut o0, o1) = T::split_at_mut_n(out, RATE);
     squeeze_first_block::<N, T, RATE>(s, &mut o0);
     let (mut o1, o2) = T::split_at_mut_n(o1, RATE);
 
-    squeeze_next_block::<N, T, RATE>(s, &mut o1);
+    squeeze_next_block::<STACK_SIZE, N, T, RATE>(alloc, s, &mut o1);
     let (mut o2, o3) = T::split_at_mut_n(o2, RATE);
 
-    squeeze_next_block::<N, T, RATE>(s, &mut o2);
+    squeeze_next_block::<STACK_SIZE, N, T, RATE>(alloc, s, &mut o2);
     let (mut o3, mut o4) = T::split_at_mut_n(o3, RATE);
 
-    squeeze_next_block::<N, T, RATE>(s, &mut o3);
-    squeeze_next_block::<N, T, RATE>(s, &mut o4);
+    squeeze_next_block::<STACK_SIZE, N, T, RATE>(alloc, s, &mut o3);
+    squeeze_next_block::<STACK_SIZE, N, T, RATE>(alloc, s, &mut o4);
 }
 
 #[inline(always)]
-pub(crate) fn squeeze_last<const N: usize, T: KeccakStateItem<N>, const RATE: usize>(
+pub(crate) fn squeeze_last<
+    const STACK_SIZE: usize,
+    const N: usize,
+    T: KeccakStateItem<N>,
+    const RATE: usize,
+>(
+    alloc: &Alloc<STACK_SIZE>,
     mut s: KeccakState<N, T>,
     out: [&mut [u8]; N],
 ) {
-    keccakf1600(&mut s);
-    let mut b = [[0u8; 200]; N];
+    keccakf1600(alloc, &mut s);
+    let mut b = [[0u8; 200]; N]; // XXX: Allocate this
     T::store_block_full::<RATE>(&s.st, &mut b);
     for i in 0..N {
         out[i].copy_from_slice(&b[i][0..out[i].len()]);
@@ -520,7 +570,7 @@ pub(crate) fn squeeze_first_and_last<const N: usize, T: KeccakStateItem<N>, cons
     s: &KeccakState<N, T>,
     out: [&mut [u8]; N],
 ) {
-    let mut b = [[0u8; 200]; N];
+    let mut b = [[0u8; 200]; N]; // XXX: Allocate this
     T::store_block_full::<RATE>(&s.st, &mut b);
     for i in 0..N {
         out[i].copy_from_slice(&b[i][0..out[i].len()]);
@@ -532,14 +582,16 @@ pub(crate) fn keccak<const N: usize, T: KeccakStateItem<N>, const RATE: usize, c
     data: &[&[u8]; N],
     out: [&mut [u8]; N],
 ) {
-    let mut s = KeccakState::<N, T>::new();
+    let alloc = Alloc::<500>::new();
+    let mut s = KeccakState::<N, T>::new(&alloc);
+
     for i in 0..data[0].len() / RATE {
         // T::slice_n(data, i * RATE, RATE)
-        absorb_block::<N, T, RATE>(&mut s, &data, i * RATE);
+        absorb_block::<500, N, T, RATE>(&alloc, &mut s, &data, i * RATE);
     }
     let rem = data[0].len() % RATE;
     // T::slice_n(data, data[0].len() - rem, rem)
-    absorb_final::<N, T, RATE, DELIM>(&mut s, data, data[0].len() - rem, rem);
+    absorb_final::<500, N, T, RATE, DELIM>(&alloc, &mut s, data, data[0].len() - rem, rem);
 
     let outlen = out[0].len();
     let blocks = outlen / RATE;
@@ -552,11 +604,11 @@ pub(crate) fn keccak<const N: usize, T: KeccakStateItem<N>, const RATE: usize, c
         squeeze_first_block::<N, T, RATE>(&s, &mut o0);
         for _i in 1..blocks {
             let (mut o, orest) = T::split_at_mut_n(o1, RATE);
-            squeeze_next_block::<N, T, RATE>(&mut s, &mut o);
+            squeeze_next_block::<500, N, T, RATE>(&alloc, &mut s,  &mut o);
             o1 = orest;
         }
         if last < outlen {
-            squeeze_last::<N, T, RATE>(s, o1)
+            squeeze_last::<500, N, T, RATE>(&alloc, s,  o1)
         }
     }
 }

--- a/libcrux/libcrux-sha3/src/lib.rs
+++ b/libcrux/libcrux-sha3/src/lib.rs
@@ -285,40 +285,40 @@ pub mod portable {
         /// An XOF
         pub trait Xof<'a, const RATE: usize>: private::Sealed {
             /// Create new absorb state
-            fn new<const STACK_SIZE: usize>(alloc: &'a Alloc<STACK_SIZE>) -> Self;
+            fn new<const STACK_SIZE: usize>(alloc: &'a Alloc<STACK_SIZE, u64>) -> Self;
 
             /// Absorb input
-            fn absorb<const STACK_SIZE: usize>(&mut self, alloc: &Alloc<STACK_SIZE>, input: &[u8]);
+            fn absorb<const STACK_SIZE: usize>(&mut self, alloc: &Alloc<STACK_SIZE, u64>, input: &[u8]);
 
             /// Absorb final input (may be empty)
             fn absorb_final<const STACK_SIZE: usize>(
                 &mut self,
-                alloc: &Alloc<STACK_SIZE>,
+                alloc: &Alloc<STACK_SIZE, u64>,
                 input: &[u8],
             );
 
             /// Squeeze output bytes
             fn squeeze<const STACK_SIZE: usize>(
                 &mut self,
-                alloc: &Alloc<STACK_SIZE>,
+                alloc: &Alloc<STACK_SIZE, u64>,
                 out: &mut [u8],
             );
         }
 
         impl<'a> Xof<'a, 168> for Shake128Xof<'a> {
-            fn new<const STACK_SIZE: usize>(alloc: &'a Alloc<STACK_SIZE>) -> Self {
+            fn new<const STACK_SIZE: usize>(alloc: &'a Alloc<STACK_SIZE, u64>) -> Self {
                 Self {
                     state: KeccakXofState::<1, 168, u64>::new(alloc),
                 }
             }
 
-            fn absorb<const STACK_SIZE: usize>(&mut self, alloc: &Alloc<STACK_SIZE>, input: &[u8]) {
+            fn absorb<const STACK_SIZE: usize>(&mut self, alloc: &Alloc<STACK_SIZE, u64>, input: &[u8]) {
                 self.state.absorb(alloc, &[input]);
             }
 
             fn absorb_final<const STACK_SIZE: usize>(
                 &mut self,
-                alloc: &Alloc<STACK_SIZE>,
+                alloc: &Alloc<STACK_SIZE, u64>,
                 input: &[u8],
             ) {
                 self.state
@@ -328,7 +328,7 @@ pub mod portable {
             /// Shake128 squeeze
             fn squeeze<const STACK_SIZE: usize>(
                 &mut self,
-                alloc: &Alloc<STACK_SIZE>,
+                alloc: &Alloc<STACK_SIZE, u64>,
                 out: &mut [u8],
             ) {
                 self.state.squeeze(alloc, [out]);
@@ -338,21 +338,21 @@ pub mod portable {
         /// Shake256 XOF in absorb state
         impl<'a> Xof<'a, 136> for Shake256Xof<'a> {
             /// Shake256 new state
-            fn new<const STACK_SIZE: usize>(alloc: &'a Alloc<STACK_SIZE>) -> Self {
+            fn new<const STACK_SIZE: usize>(alloc: &'a Alloc<STACK_SIZE, u64>) -> Self {
                 Self {
                     state: KeccakXofState::<1, 136, u64>::new(alloc),
                 }
             }
 
             /// Shake256 absorb
-            fn absorb<const STACK_SIZE: usize>(&mut self, alloc: &Alloc<STACK_SIZE>, input: &[u8]) {
+            fn absorb<const STACK_SIZE: usize>(&mut self, alloc: &Alloc<STACK_SIZE, u64>, input: &[u8]) {
                 self.state.absorb(alloc, &[input]);
             }
 
             /// Shake256 absorb final
             fn absorb_final<const STACK_SIZE: usize>(
                 &mut self,
-                alloc: &Alloc<STACK_SIZE>,
+                alloc: &Alloc<STACK_SIZE, u64>,
                 input: &[u8],
             ) {
                 self.state
@@ -362,7 +362,7 @@ pub mod portable {
             /// Shake256 squeeze
             fn squeeze<const STACK_SIZE: usize>(
                 &mut self,
-                alloc: &Alloc<STACK_SIZE>,
+                alloc: &Alloc<STACK_SIZE, u64>,
                 out: &mut [u8],
             ) {
                 self.state.squeeze(alloc, [out]);
@@ -371,7 +371,7 @@ pub mod portable {
 
         /// Create a new SHAKE-128 state object.
         #[inline(never)]
-        pub fn shake128_init<const STACK_SIZE: usize>(alloc: &Alloc<STACK_SIZE>) -> KeccakState {
+        pub fn shake128_init<const STACK_SIZE: usize>(alloc: &Alloc<STACK_SIZE, u64>) -> KeccakState {
             KeccakState {
                 state: GenericState::<1, u64>::new(&alloc),
             }
@@ -380,7 +380,7 @@ pub mod portable {
         /// Absorb
         #[inline(never)]
         pub fn shake128_absorb_final<const STACK_SIZE: usize>(
-            alloc: &Alloc<STACK_SIZE>,
+            alloc: &Alloc<STACK_SIZE, u64>,
             s: &mut KeccakState,
             data0: &[u8],
         ) {
@@ -396,7 +396,7 @@ pub mod portable {
         /// Squeeze three blocks
         #[inline(always)]
         pub fn shake128_squeeze_first_three_blocks<const STACK_SIZE: usize>(
-            alloc: &Alloc<STACK_SIZE>,
+            alloc: &Alloc<STACK_SIZE, u64>,
             s: &mut KeccakState,
             out0: &mut [u8],
         ) {
@@ -406,7 +406,7 @@ pub mod portable {
         /// Squeeze five blocks
         #[inline(always)]
         pub fn shake128_squeeze_first_five_blocks<const STACK_SIZE: usize>(
-            alloc: &Alloc<STACK_SIZE>,
+            alloc: &Alloc<STACK_SIZE, u64>,
             s: &mut KeccakState,
             out0: &mut [u8],
         ) {
@@ -416,7 +416,7 @@ pub mod portable {
         /// Squeeze another block
         #[inline(never)]
         pub fn shake128_squeeze_next_block<const STACK_SIZE: usize>(
-            alloc: &Alloc<STACK_SIZE>,
+            alloc: &Alloc<STACK_SIZE, u64>,
             s: &mut KeccakState,
             out0: &mut [u8],
         ) {
@@ -425,7 +425,7 @@ pub mod portable {
 
         /// Create a new SHAKE-256 state object.
         #[inline(always)]
-        pub fn shake256_init<const STACK_SIZE: usize>(alloc: &Alloc<STACK_SIZE>) -> KeccakState {
+        pub fn shake256_init<const STACK_SIZE: usize>(alloc: &Alloc<STACK_SIZE, u64>) -> KeccakState {
             KeccakState {
                 state: GenericState::<1, u64>::new(&alloc),
             }
@@ -434,7 +434,7 @@ pub mod portable {
         /// Absorb some data for SHAKE-256 for the last time
         #[inline(always)]
         pub fn shake256_absorb_final<const STACK_SIZE: usize>(
-            alloc: &Alloc<STACK_SIZE>,
+            alloc: &Alloc<STACK_SIZE, u64>,
             s: &mut KeccakState,
             data: &[u8],
         ) {
@@ -456,7 +456,7 @@ pub mod portable {
         /// Squeeze the next SHAKE-256 block
         #[inline(always)]
         pub fn shake256_squeeze_next_block<const STACK_SIZE: usize>(
-            alloc: &Alloc<STACK_SIZE>,
+            alloc: &Alloc<STACK_SIZE, u64>,
             s: &mut KeccakState,
             out: &mut [u8],
         ) {

--- a/libcrux/libcrux-sha3/src/lib.rs
+++ b/libcrux/libcrux-sha3/src/lib.rs
@@ -2,16 +2,16 @@
 //!
 //! A SHA3 implementation with optional simd optimisations.
 
-#![no_std]
+// #![no_std]
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
 
-pub mod simd;
+// pub mod simd;
 
+mod alloc;
 mod generic_keccak;
 mod portable_keccak;
 mod traits;
-mod alloc;
 
 /// A SHA3 224 Digest
 pub type Sha3_224Digest = [u8; 28];
@@ -209,9 +209,8 @@ pub mod portable {
     use generic_keccak::KeccakState as GenericState;
 
     /// The Keccak state for the incremental API.
-    #[derive(Clone, Copy)]
-    pub struct KeccakState {
-        state: GenericState<1, u64>,
+    pub struct KeccakState<'a> {
+        state: GenericState<'a, 1, u64>,
     }
 
     #[inline(always)]
@@ -266,126 +265,186 @@ pub mod portable {
         mod private {
             pub trait Sealed {}
 
-            impl Sealed for super::Shake128Xof {}
-            impl Sealed for super::Shake256Xof {}
+            impl Sealed for super::Shake128Xof<'_> {}
+            impl Sealed for super::Shake256Xof<'_> {}
         }
+        use crate::alloc::Alloc;
+
         use super::*;
 
         /// SHAKE128 Xof state
-        pub struct Shake128Xof {
-            state: KeccakXofState<1, 168, u64>,
+        pub struct Shake128Xof<'a> {
+            state: KeccakXofState<'a, 1, 168, u64>,
         }
 
         /// SHAKE256 Xof state
-        pub struct Shake256Xof {
-            state: KeccakXofState<1, 136, u64>,
+        pub struct Shake256Xof<'a> {
+            state: KeccakXofState<'a, 1, 136, u64>,
         }
 
         /// An XOF
-        pub trait Xof<const RATE: usize>: private::Sealed {
+        pub trait Xof<'a, const RATE: usize>: private::Sealed {
             /// Create new absorb state
-            fn new() -> Self;
+            fn new<const STACK_SIZE: usize>(alloc: &'a Alloc<STACK_SIZE>) -> Self;
 
             /// Absorb input
-            fn absorb(&mut self, input: &[u8]);
+            fn absorb<const STACK_SIZE: usize>(&mut self, alloc: &Alloc<STACK_SIZE>, input: &[u8]);
 
             /// Absorb final input (may be empty)
-            fn absorb_final(&mut self, input: &[u8]);
+            fn absorb_final<const STACK_SIZE: usize>(
+                &mut self,
+                alloc: &Alloc<STACK_SIZE>,
+                input: &[u8],
+            );
 
             /// Squeeze output bytes
-            fn squeeze(&mut self, out: &mut [u8]);
+            fn squeeze<const STACK_SIZE: usize>(
+                &mut self,
+                alloc: &Alloc<STACK_SIZE>,
+                out: &mut [u8],
+            );
         }
 
-        impl Xof<168> for Shake128Xof {
-            fn new() -> Self {
+        impl<'a> Xof<'a, 168> for Shake128Xof<'a> {
+            fn new<const STACK_SIZE: usize>(alloc: &'a Alloc<STACK_SIZE>) -> Self {
                 Self {
-                    state: KeccakXofState::<1, 168, u64>::new(),
+                    state: KeccakXofState::<1, 168, u64>::new(alloc),
                 }
             }
 
-            fn absorb(&mut self, input: &[u8]) {
-                self.state.absorb(&[input]);
+            fn absorb<const STACK_SIZE: usize>(&mut self, alloc: &Alloc<STACK_SIZE>, input: &[u8]) {
+                self.state.absorb(alloc, &[input]);
             }
 
-            fn absorb_final(&mut self, input: &[u8]) {
-                self.state.absorb_final::<0x1fu8>(&[input]);
+            fn absorb_final<const STACK_SIZE: usize>(
+                &mut self,
+                alloc: &Alloc<STACK_SIZE>,
+                input: &[u8],
+            ) {
+                self.state
+                    .absorb_final::<STACK_SIZE, 0x1fu8>(alloc, &[input]);
             }
 
             /// Shake128 squeeze
-            fn squeeze(&mut self, out: &mut [u8]) {
-                self.state.squeeze([out]);
+            fn squeeze<const STACK_SIZE: usize>(
+                &mut self,
+                alloc: &Alloc<STACK_SIZE>,
+                out: &mut [u8],
+            ) {
+                self.state.squeeze(alloc, [out]);
             }
         }
 
         /// Shake256 XOF in absorb state
-        impl Xof<136> for Shake256Xof {
+        impl<'a> Xof<'a, 136> for Shake256Xof<'a> {
             /// Shake256 new state
-            fn new() -> Self {
+            fn new<const STACK_SIZE: usize>(alloc: &'a Alloc<STACK_SIZE>) -> Self {
                 Self {
-                    state: KeccakXofState::<1, 136, u64>::new(),
+                    state: KeccakXofState::<1, 136, u64>::new(alloc),
                 }
             }
 
             /// Shake256 absorb
-            fn absorb(&mut self, input: &[u8]) {
-                self.state.absorb(&[input]);
+            fn absorb<const STACK_SIZE: usize>(&mut self, alloc: &Alloc<STACK_SIZE>, input: &[u8]) {
+                self.state.absorb(alloc, &[input]);
             }
 
             /// Shake256 absorb final
-            fn absorb_final(&mut self, input: &[u8]) {
-                self.state.absorb_final::<0x1fu8>(&[input]);
+            fn absorb_final<const STACK_SIZE: usize>(
+                &mut self,
+                alloc: &Alloc<STACK_SIZE>,
+                input: &[u8],
+            ) {
+                self.state
+                    .absorb_final::<STACK_SIZE, 0x1fu8>(alloc, &[input]);
             }
 
             /// Shake256 squeeze
-            fn squeeze(&mut self, out: &mut [u8]) {
-                self.state.squeeze([out]);
+            fn squeeze<const STACK_SIZE: usize>(
+                &mut self,
+                alloc: &Alloc<STACK_SIZE>,
+                out: &mut [u8],
+            ) {
+                self.state.squeeze(alloc, [out]);
             }
         }
 
         /// Create a new SHAKE-128 state object.
         #[inline(never)]
-        pub fn shake128_init() -> KeccakState {
+        pub fn shake128_init<const STACK_SIZE: usize>(alloc: &Alloc<STACK_SIZE>) -> KeccakState {
             KeccakState {
-                state: GenericState::<1, u64>::new(),
+                state: GenericState::<1, u64>::new(&alloc),
             }
         }
 
         /// Absorb
         #[inline(never)]
-        pub fn shake128_absorb_final(s: &mut KeccakState, data0: &[u8]) {
-            absorb_final::<1, u64, 168, 0x1fu8>(&mut s.state, &[data0], 0, data0.len());
+        pub fn shake128_absorb_final<const STACK_SIZE: usize>(
+            alloc: &Alloc<STACK_SIZE>,
+            s: &mut KeccakState,
+            data0: &[u8],
+        ) {
+            absorb_final::<STACK_SIZE, 1, u64, 168, 0x1fu8>(
+                alloc,
+                &mut s.state,
+                &[data0],
+                0,
+                data0.len(),
+            );
         }
 
         /// Squeeze three blocks
         #[inline(always)]
-        pub fn shake128_squeeze_first_three_blocks(s: &mut KeccakState, out0: &mut [u8]) {
-            squeeze_first_three_blocks::<1, u64, 168>(&mut s.state, [out0])
+        pub fn shake128_squeeze_first_three_blocks<const STACK_SIZE: usize>(
+            alloc: &Alloc<STACK_SIZE>,
+            s: &mut KeccakState,
+            out0: &mut [u8],
+        ) {
+            squeeze_first_three_blocks::<STACK_SIZE, 1, u64, 168>(alloc, &mut s.state, [out0])
         }
 
         /// Squeeze five blocks
         #[inline(always)]
-        pub fn shake128_squeeze_first_five_blocks(s: &mut KeccakState, out0: &mut [u8]) {
-            squeeze_first_five_blocks::<1, u64, 168>(&mut s.state, [out0])
+        pub fn shake128_squeeze_first_five_blocks<const STACK_SIZE: usize>(
+            alloc: &Alloc<STACK_SIZE>,
+            s: &mut KeccakState,
+            out0: &mut [u8],
+        ) {
+            squeeze_first_five_blocks::<STACK_SIZE, 1, u64, 168>(alloc, &mut s.state, [out0])
         }
 
         /// Squeeze another block
         #[inline(never)]
-        pub fn shake128_squeeze_next_block(s: &mut KeccakState, out0: &mut [u8]) {
-            squeeze_next_block::<1, u64, 168>(&mut s.state, &mut [out0])
+        pub fn shake128_squeeze_next_block<const STACK_SIZE: usize>(
+            alloc: &Alloc<STACK_SIZE>,
+            s: &mut KeccakState,
+            out0: &mut [u8],
+        ) {
+            squeeze_next_block::<STACK_SIZE, 1, u64, 168>(alloc, &mut s.state, &mut [out0])
         }
 
         /// Create a new SHAKE-256 state object.
         #[inline(always)]
-        pub fn shake256_init() -> KeccakState {
+        pub fn shake256_init<const STACK_SIZE: usize>(alloc: &Alloc<STACK_SIZE>) -> KeccakState {
             KeccakState {
-                state: GenericState::<1, u64>::new(),
+                state: GenericState::<1, u64>::new(&alloc),
             }
         }
 
         /// Absorb some data for SHAKE-256 for the last time
         #[inline(always)]
-        pub fn shake256_absorb_final(s: &mut KeccakState, data: &[u8]) {
-            absorb_final::<1, u64, 136, 0x1fu8>(&mut s.state, &[data], 0, data.len());
+        pub fn shake256_absorb_final<const STACK_SIZE: usize>(
+            alloc: &Alloc<STACK_SIZE>,
+            s: &mut KeccakState,
+            data: &[u8],
+        ) {
+            absorb_final::<STACK_SIZE, 1, u64, 136, 0x1fu8>(
+                alloc,
+                &mut s.state,
+                &[data],
+                0,
+                data.len(),
+            );
         }
 
         /// Squeeze the first SHAKE-256 block
@@ -396,770 +455,774 @@ pub mod portable {
 
         /// Squeeze the next SHAKE-256 block
         #[inline(always)]
-        pub fn shake256_squeeze_next_block(s: &mut KeccakState, out: &mut [u8]) {
-            squeeze_next_block::<1, u64, 136>(&mut s.state, &mut [out])
-        }
-    }
-}
-
-/// A neon optimised implementation.
-///
-/// When this is compiled for non-neon architectures, the functions panic.
-/// The caller must make sure to check for hardware feature before calling these
-/// functions and compile them in.
-///
-/// Feature `simd128` enables the implementations in this module.
-#[cfg(feature = "simd128")]
-pub mod neon {
-    use crate::generic_keccak::keccak;
-
-    #[cfg(feature = "simd128")]
-    #[inline(always)]
-    fn keccakx2<const RATE: usize, const DELIM: u8>(data: &[&[u8]; 2], out: [&mut [u8]; 2]) {
-        keccak::<2, crate::simd::arm64::uint64x2_t, RATE, DELIM>(data, out)
-    }
-
-    /// A portable SHA3 224 implementation.
-    #[allow(unused_variables)]
-    #[inline(always)]
-    pub fn sha224(digest: &mut [u8], data: &[u8]) {
-        let mut dummy = [0u8; 28];
-        keccakx2::<144, 0x06u8>(&[data, data], [digest, &mut dummy]);
-    }
-
-    /// A portable SHA3 256 implementation.
-    #[allow(unused_variables)]
-    #[inline(always)]
-    pub fn sha256(digest: &mut [u8], data: &[u8]) {
-        let mut dummy = [0u8; 32];
-        keccakx2::<136, 0x06u8>(&[data, data], [digest, &mut dummy]);
-    }
-
-    /// A portable SHA3 384 implementation.
-    #[allow(unused_variables)]
-    #[inline(always)]
-    pub fn sha384(digest: &mut [u8], data: &[u8]) {
-        let mut dummy = [0u8; 48];
-        keccakx2::<104, 0x06u8>(&[data, data], [digest, &mut dummy]);
-    }
-
-    /// A portable SHA3 512 implementation.
-    #[allow(unused_variables)]
-    #[inline(always)]
-    pub fn sha512(digest: &mut [u8], data: &[u8]) {
-        let mut dummy = [0u8; 64];
-        keccakx2::<72, 0x06u8>(&[data, data], [digest, &mut dummy]);
-    }
-
-    /// A portable SHAKE128 implementation.
-    #[allow(unused_variables)]
-    #[inline(always)]
-    pub fn shake128<const LEN: usize>(digest: &mut [u8; LEN], data: &[u8]) {
-        let mut dummy = [0u8; LEN];
-        keccakx2::<168, 0x1fu8>(&[data, data], [digest, &mut dummy]);
-    }
-
-    /// A portable SHAKE256 implementation.
-    #[allow(unused_variables)]
-    #[inline(always)]
-    pub fn shake256<const LEN: usize>(digest: &mut [u8; LEN], data: &[u8]) {
-        let mut dummy = [0u8; LEN];
-        keccakx2::<136, 0x1fu8>(&[data, data], [digest, &mut dummy]);
-    }
-
-    /// Performing 2 operations in parallel
-    pub mod x2 {
-        use super::*;
-
-        /// Run SHAKE256 on both inputs in parallel.
-        ///
-        /// Writes the two results into `out0` and `out1`
-        #[allow(unused_variables)]
-        #[inline(always)]
-        pub fn shake256(input0: &[u8], input1: &[u8], out0: &mut [u8], out1: &mut [u8]) {
-            // TODO: make argument ordering consistent
-            keccakx2::<136, 0x1fu8>(&[input0, input1], [out0, out1]);
-        }
-
-        /// Run up to 4 SHAKE256 operations in parallel.
-        ///
-        /// **PANICS** when `N` is not 2, 3, or 4.
-        #[allow(non_snake_case)]
-        #[inline(always)]
-        fn _shake256xN<const LEN: usize, const N: usize>(input: &[[u8; 33]; N]) -> [[u8; LEN]; N] {
-            debug_assert!(N == 2 || N == 3 || N == 4);
-
-            let mut out = [[0u8; LEN]; N];
-            match N {
-                2 => {
-                    let (out0, out1) = out.split_at_mut(1);
-                    shake256(&input[0], &input[1], &mut out0[0], &mut out1[0]);
-                }
-                3 => {
-                    let mut extra = [0u8; LEN];
-                    let (out0, out12) = out.split_at_mut(1);
-                    let (out1, out2) = out12.split_at_mut(1);
-                    shake256(&input[0], &input[1], &mut out0[0], &mut out1[0]);
-                    shake256(&input[2], &input[2], &mut out2[0], &mut extra);
-                }
-                4 => {
-                    let (out0, out123) = out.split_at_mut(1);
-                    let (out1, out23) = out123.split_at_mut(1);
-                    let (out2, out3) = out23.split_at_mut(1);
-                    shake256(&input[0], &input[1], &mut out0[0], &mut out1[0]);
-                    shake256(&input[2], &input[3], &mut out2[0], &mut out3[0]);
-                }
-                _ => unreachable!("Only 2, 3, or 4 are supported for N"),
-            }
-            out
-        }
-
-        /// An incremental API to perform 2 operations in parallel
-        pub mod incremental {
-            use crate::generic_keccak::{
-                absorb_final, squeeze_first_block, squeeze_first_five_blocks,
-                squeeze_first_three_blocks, squeeze_next_block, KeccakState as GenericState,
-            };
-
-            /// The Keccak state for the incremental API.
-            pub struct KeccakState {
-                state: GenericState<2, crate::simd::arm64::uint64x2_t>,
-            }
-
-            type KeccakState2Internal = GenericState<2, crate::simd::arm64::uint64x2_t>;
-
-            /// Initialise the `KeccakState2`.
-            #[inline(always)]
-            pub fn init() -> KeccakState {
-                // XXX: These functions could alternatively implement the same with
-                //      the portable implementation
-                // {
-                //     let s0 = KeccakState::new();
-                //     let s1 = KeccakState::new();
-                //     [s0, s1]
-                // }
-                KeccakState {
-                    state: KeccakState2Internal::new(),
-                }
-            }
-
-            /// Shake128 absorb `data0` and `data1` in the [`KeccakState`] `s`.
-            #[inline(always)]
-            pub fn shake128_absorb_final(s: &mut KeccakState, data0: &[u8], data1: &[u8]) {
-                // XXX: These functions could alternatively implement the same with
-                //      the portable implementation
-                // {
-                //     let [mut s0, mut s1] = s;
-                //     shake128_absorb_final(&mut s0, data0);
-                //     shake128_absorb_final(&mut s1, data1);
-                // }
-                absorb_final::<2, crate::simd::arm64::uint64x2_t, 168, 0x1fu8>(
-                    &mut s.state,
-                    &[data0, data1],
-                    0,
-                    data0.len(),
-                );
-            }
-
-            /// Shake256 absorb `data0` and `data1` in the [`KeccakState`] `s`.
-            #[inline(always)]
-            pub fn shake256_absorb_final(s: &mut KeccakState, data0: &[u8], data1: &[u8]) {
-                // XXX: These functions could alternatively implement the same with
-                //      the portable implementation
-                // {
-                //     let [mut s0, mut s1] = s;
-                //     shake128_absorb_final(&mut s0, data0);
-                //     shake128_absorb_final(&mut s1, data1);
-                // }
-                absorb_final::<2, crate::simd::arm64::uint64x2_t, 136, 0x1fu8>(
-                    &mut s.state,
-                    &[data0, data1],
-                    0,
-                    data0.len(),
-                );
-            }
-
-            /// Initialise the state and perform up to 4 absorbs at the same time,
-            /// using two [`KeccakState2`].
-            ///
-            /// **PANICS** when `N` is not 2, 3, or 4.
-            #[allow(non_snake_case)]
-            #[inline(always)]
-            fn _shake128_absorb_finalxN<const N: usize>(input: [[u8; 34]; N]) -> [KeccakState; 2] {
-                debug_assert!(N == 2 || N == 3 || N == 4);
-                let mut state = [init(), init()];
-
-                match N {
-                    2 => {
-                        shake128_absorb_final(&mut state[0], &input[0], &input[1]);
-                    }
-                    3 => {
-                        shake128_absorb_final(&mut state[0], &input[0], &input[1]);
-                        shake128_absorb_final(&mut state[1], &input[2], &input[2]);
-                    }
-                    4 => {
-                        shake128_absorb_final(&mut state[0], &input[0], &input[1]);
-                        shake128_absorb_final(&mut state[1], &input[2], &input[3]);
-                    }
-                    _ => unreachable!("This function can only called be called with N = 2, 3, 4"),
-                }
-
-                state
-            }
-
-            /// Squeeze 2 times the first three blocks in parallel in the
-            /// [`KeccakState`] and return the output in `out0` and `out1`.
-            #[inline(always)]
-            pub fn shake128_squeeze_first_three_blocks(
-                s: &mut KeccakState,
-                out0: &mut [u8],
-                out1: &mut [u8],
-            ) {
-                // XXX: These functions could alternatively implement the same with
-                //      the portable implementation
-                // {
-                //     let [mut s0, mut s1] = s;
-                //     shake128_squeeze_first_three_blocks(&mut s0, out0);
-                //     shake128_squeeze_first_three_blocks(&mut s1, out1);
-                // }
-                squeeze_first_three_blocks::<2, crate::simd::arm64::uint64x2_t, 168>(
-                    &mut s.state,
-                    [out0, out1],
-                )
-            }
-
-            /// Squeeze five blocks
-            #[inline(always)]
-            pub fn shake128_squeeze_first_five_blocks(
-                s: &mut KeccakState,
-                out0: &mut [u8],
-                out1: &mut [u8],
-            ) {
-                squeeze_first_five_blocks::<2, crate::simd::arm64::uint64x2_t, 168>(
-                    &mut s.state,
-                    [out0, out1],
-                )
-            }
-
-            /// Squeeze block
-            #[inline(always)]
-            pub fn shake256_squeeze_first_block(
-                s: &mut KeccakState,
-                out0: &mut [u8],
-                out1: &mut [u8],
-            ) {
-                squeeze_first_block::<2, crate::simd::arm64::uint64x2_t, 136>(
-                    &mut s.state,
-                    &mut [out0, out1],
-                );
-            }
-
-            /// Squeeze next block
-            #[inline(always)]
-            pub fn shake256_squeeze_next_block(
-                s: &mut KeccakState,
-                out0: &mut [u8],
-                out1: &mut [u8],
-            ) {
-                squeeze_next_block::<2, crate::simd::arm64::uint64x2_t, 136>(
-                    &mut s.state,
-                    &mut [out0, out1],
-                );
-            }
-
-            /// Squeeze up to 3 x 4 (N) blocks in parallel, using two [`KeccakState2`].
-            /// Each block is of size `LEN`.
-            ///
-            /// **PANICS** when `N` is not 2, 3, or 4.
-            #[allow(non_snake_case)]
-            #[inline(always)]
-            fn _shake128_squeeze3xN<const LEN: usize, const N: usize>(
-                state: &mut [KeccakState; 2],
-            ) -> [[u8; LEN]; N] {
-                debug_assert!(N == 2 || N == 3 || N == 4);
-
-                let mut out = [[0u8; LEN]; N];
-                match N {
-                    2 => {
-                        let (out0, out1) = out.split_at_mut(1);
-                        shake128_squeeze_first_three_blocks(
-                            &mut state[0],
-                            &mut out0[0],
-                            &mut out1[0],
-                        );
-                    }
-                    3 => {
-                        let mut extra = [0u8; LEN];
-                        let (out0, out12) = out.split_at_mut(1);
-                        let (out1, out2) = out12.split_at_mut(1);
-                        shake128_squeeze_first_three_blocks(
-                            &mut state[0],
-                            &mut out0[0],
-                            &mut out1[0],
-                        );
-                        shake128_squeeze_first_three_blocks(
-                            &mut state[1],
-                            &mut out2[0],
-                            &mut extra,
-                        );
-                    }
-                    4 => {
-                        let (out0, out123) = out.split_at_mut(1);
-                        let (out1, out23) = out123.split_at_mut(1);
-                        let (out2, out3) = out23.split_at_mut(1);
-                        shake128_squeeze_first_three_blocks(
-                            &mut state[0],
-                            &mut out0[0],
-                            &mut out1[0],
-                        );
-                        shake128_squeeze_first_three_blocks(
-                            &mut state[1],
-                            &mut out2[0],
-                            &mut out3[0],
-                        );
-                    }
-                    _ => unreachable!("This function can only called be called with N = 2, 3, 4"),
-                }
-                out
-            }
-
-            /// Squeeze 2 times the next block in parallel in the
-            /// [`KeccakState`] and return the output in `out0` and `out1`.
-            #[inline(always)]
-            pub fn shake128_squeeze_next_block(
-                s: &mut KeccakState,
-                out0: &mut [u8],
-                out1: &mut [u8],
-            ) {
-                // XXX: These functions could alternatively implement the same with
-                //      the portable implementation
-                // {
-                //     let [mut s0, mut s1] = s;
-                //     shake128_squeeze_next_block(&mut s0, out0);
-                //     shake128_squeeze_next_block(&mut s1, out1);
-                // }
-                squeeze_next_block::<2, crate::simd::arm64::uint64x2_t, 168>(
-                    &mut s.state,
-                    &mut [out0, out1],
-                )
-            }
-
-            /// Squeeze up to 4 (N) blocks in parallel, using two [`KeccakState2`].
-            /// Each block is of size `LEN`.
-            ///
-            /// **PANICS** when `N` is not 2, 3, or 4.
-            #[allow(non_snake_case)]
-            #[inline(always)]
-            fn _shake128_squeezexN<const LEN: usize, const N: usize>(
-                state: &mut [KeccakState; 2],
-            ) -> [[u8; LEN]; N] {
-                debug_assert!(N == 2 || N == 3 || N == 4);
-
-                let mut out = [[0u8; LEN]; N];
-                match N {
-                    2 => {
-                        let mut out0 = [0u8; LEN];
-                        let mut out1 = [0u8; LEN];
-                        shake128_squeeze_next_block(&mut state[0], &mut out0, &mut out1);
-                        out[0] = out0;
-                        out[1] = out1;
-                    }
-                    3 => {
-                        let mut out0 = [0u8; LEN];
-                        let mut out1 = [0u8; LEN];
-                        let mut out2 = [0u8; LEN];
-                        let mut out3 = [0u8; LEN];
-                        shake128_squeeze_next_block(&mut state[0], &mut out0, &mut out1);
-                        shake128_squeeze_next_block(&mut state[1], &mut out2, &mut out3);
-                        out[0] = out0;
-                        out[1] = out1;
-                        out[2] = out2;
-                    }
-                    4 => {
-                        let mut out0 = [0u8; LEN];
-                        let mut out1 = [0u8; LEN];
-                        let mut out2 = [0u8; LEN];
-                        let mut out3 = [0u8; LEN];
-                        shake128_squeeze_next_block(&mut state[0], &mut out0, &mut out1);
-                        shake128_squeeze_next_block(&mut state[1], &mut out2, &mut out3);
-                        out[0] = out0;
-                        out[1] = out1;
-                        out[2] = out2;
-                        out[3] = out3;
-                    }
-                    _ => unreachable!("This function is only called with N = 2, 3, 4"),
-                }
-                out
-            }
-        }
-    }
-}
-
-/// An AVX2 optimised implementation.
-///
-/// When this is compiled for non-neon architectures, the functions panic.
-/// The caller must make sure to check for hardware feature before calling these
-/// functions and compile them in.
-///
-/// Feature `simd256` enables the implementations in this module.
-#[cfg(feature = "simd256")]
-pub mod avx2 {
-    /// Performing 4 operations in parallel
-    pub mod x4 {
-        use crate::generic_keccak::keccak;
-        use libcrux_intrinsics::avx2::*;
-
-        /// Perform 4 SHAKE256 operations in parallel
-        #[allow(clippy::too_many_arguments)]
-        #[inline(always)]
-        pub fn shake256(
-            input0: &[u8],
-            input1: &[u8],
-            input2: &[u8],
-            input3: &[u8],
-            out0: &mut [u8],
-            out1: &mut [u8],
-            out2: &mut [u8],
-            out3: &mut [u8],
+        pub fn shake256_squeeze_next_block<const STACK_SIZE: usize>(
+            alloc: &Alloc<STACK_SIZE>,
+            s: &mut KeccakState,
+            out: &mut [u8],
         ) {
-            // XXX: These functions could alternatively implement the same with
-            //      the portable implementation
-            // #[cfg(feature = "simd128")]
-            // {
-            //     keccakx2::<136, 0x1fu8>([input0, input1], [out0, out1]);
-            //     keccakx2::<136, 0x1fu8>([input2, input3], [out2, out3]);
-            // }
-            // {
-            //     keccakx1::<136, 0x1fu8>([input0], [out0]);
-            //     keccakx1::<136, 0x1fu8>([input1], [out1]);
-            //     keccakx1::<136, 0x1fu8>([input2], [out2]);
-            //     keccakx1::<136, 0x1fu8>([input3], [out3]);
-            // }
-            keccak::<4, Vec256, 136, 0x1fu8>(
-                &[input0, input1, input2, input3],
-                [out0, out1, out2, out3],
-            );
-        }
-
-        /// Run up to 4 SHAKE256 operations in parallel.
-        ///
-        /// **PANICS** when `N` is not 2, 3, or 4.
-        #[allow(non_snake_case)]
-        #[inline(always)]
-        fn _shake256xN<const LEN: usize, const N: usize>(input: &[[u8; 33]; N]) -> [[u8; LEN]; N] {
-            debug_assert!(N == 2 || N == 3 || N == 4);
-            let mut out = [[0u8; LEN]; N];
-
-            match N {
-                2 => {
-                    let mut dummy_out0 = [0u8; LEN];
-                    let mut dummy_out1 = [0u8; LEN];
-                    let (out0, out1) = out.split_at_mut(1);
-                    shake256(
-                        &input[0],
-                        &input[1],
-                        &input[0],
-                        &input[0],
-                        &mut out0[0],
-                        &mut out1[0],
-                        &mut dummy_out0,
-                        &mut dummy_out1,
-                    );
-                }
-                3 => {
-                    let mut dummy_out0 = [0u8; LEN];
-                    let (out0, out12) = out.split_at_mut(1);
-                    let (out1, out2) = out12.split_at_mut(1);
-                    shake256(
-                        &input[0],
-                        &input[1],
-                        &input[2],
-                        &input[0],
-                        &mut out0[0],
-                        &mut out1[0],
-                        &mut out2[0],
-                        &mut dummy_out0,
-                    );
-                }
-                4 => {
-                    let (out0, out123) = out.split_at_mut(1);
-                    let (out1, out23) = out123.split_at_mut(1);
-                    let (out2, out3) = out23.split_at_mut(1);
-                    shake256(
-                        &input[0],
-                        &input[1],
-                        &input[2],
-                        &input[3],
-                        &mut out0[0],
-                        &mut out1[0],
-                        &mut out2[0],
-                        &mut out3[0],
-                    );
-                }
-                _ => unreachable!("This function must only be called with N = 2, 3, 4"),
-            }
-            out
-        }
-
-        /// An incremental API to perform 4 operations in parallel
-        pub mod incremental {
-            use crate::generic_keccak::{
-                absorb_final, squeeze_first_three_blocks, squeeze_next_block,
-                KeccakState as GenericState,
-            };
-            use crate::generic_keccak::{squeeze_first_block, squeeze_first_five_blocks};
-            use libcrux_intrinsics::avx2::*;
-
-            /// The Keccak state for the incremental API.
-            #[cfg(feature = "simd256")]
-            pub struct KeccakState {
-                state: GenericState<4, Vec256>,
-            }
-
-            /// Initialise the [`KeccakState`].
-            #[inline(always)]
-            pub fn init() -> KeccakState {
-                KeccakState {
-                    state: GenericState::new(),
-                }
-            }
-
-            /// Absorb
-            #[inline(always)]
-            pub fn shake128_absorb_final(
-                s: &mut KeccakState,
-                data0: &[u8],
-                data1: &[u8],
-                data2: &[u8],
-                data3: &[u8],
-            ) {
-                absorb_final::<4, Vec256, 168, 0x1fu8>(
-                    &mut s.state,
-                    &[data0, data1, data2, data3],
-                    0,
-                    data0.len(),
-                );
-            }
-
-            /// Absorb
-            #[inline(always)]
-            pub fn shake256_absorb_final(
-                s: &mut KeccakState,
-                data0: &[u8],
-                data1: &[u8],
-                data2: &[u8],
-                data3: &[u8],
-            ) {
-                absorb_final::<4, Vec256, 136, 0x1fu8>(
-                    &mut s.state,
-                    &[data0, data1, data2, data3],
-                    0,
-                    data0.len(),
-                );
-            }
-
-            /// Squeeze block
-            #[inline(always)]
-            pub fn shake256_squeeze_first_block(
-                s: &mut KeccakState,
-                out0: &mut [u8],
-                out1: &mut [u8],
-                out2: &mut [u8],
-                out3: &mut [u8],
-            ) {
-                squeeze_first_block::<4, Vec256, 136>(&mut s.state, &mut [out0, out1, out2, out3]);
-            }
-
-            /// Squeeze next block
-            #[inline(always)]
-            pub fn shake256_squeeze_next_block(
-                s: &mut KeccakState,
-                out0: &mut [u8],
-                out1: &mut [u8],
-                out2: &mut [u8],
-                out3: &mut [u8],
-            ) {
-                squeeze_next_block::<4, Vec256, 136>(&mut s.state, &mut [out0, out1, out2, out3]);
-            }
-
-            /// Initialise the state and perform up to 4 absorbs at the same time,
-            /// using two [`KeccakState`].
-            ///
-            /// **PANICS** when `N` is not 2, 3, or 4.
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            fn _shake128_absorb_finalxN<const N: usize>(input: [[u8; 34]; N]) -> KeccakState {
-                debug_assert!(N == 2 || N == 3 || N == 4);
-                let mut state = init();
-
-                match N {
-                    2 => {
-                        shake128_absorb_final(
-                            &mut state, &input[0], &input[1], &input[0], &input[0],
-                        );
-                    }
-                    3 => {
-                        shake128_absorb_final(
-                            &mut state, &input[0], &input[1], &input[2], &input[0],
-                        );
-                    }
-                    4 => {
-                        shake128_absorb_final(
-                            &mut state, &input[0], &input[1], &input[2], &input[3],
-                        );
-                    }
-                    _ => unreachable!("This function must only be called with N = 2, 3, 4"),
-                }
-
-                state
-            }
-
-            /// Squeeze three blocks
-            #[inline(always)]
-            pub fn shake128_squeeze_first_three_blocks(
-                s: &mut KeccakState,
-                out0: &mut [u8],
-                out1: &mut [u8],
-                out2: &mut [u8],
-                out3: &mut [u8],
-            ) {
-                squeeze_first_three_blocks::<4, Vec256, 168>(
-                    &mut s.state,
-                    [out0, out1, out2, out3],
-                );
-            }
-
-            /// Squeeze five blocks
-            #[inline(always)]
-            pub fn shake128_squeeze_first_five_blocks(
-                s: &mut KeccakState,
-                out0: &mut [u8],
-                out1: &mut [u8],
-                out2: &mut [u8],
-                out3: &mut [u8],
-            ) {
-                squeeze_first_five_blocks::<4, Vec256, 168>(&mut s.state, [out0, out1, out2, out3]);
-            }
-
-            /// Squeeze up to 3 x 4 (N) blocks in parallel, using two [`KeccakState`].
-            /// Each block is of size `LEN`.
-            ///
-            /// **PANICS** when `N` is not 2, 3, or 4.
-            #[inline(always)]
-            #[allow(non_snake_case)]
-            fn _shake128_squeeze3xN<const LEN: usize, const N: usize>(
-                state: &mut KeccakState,
-            ) -> [[u8; LEN]; N] {
-                debug_assert!(N == 2 || N == 3 || N == 4);
-
-                let mut out = [[0u8; LEN]; N];
-                match N {
-                    2 => {
-                        let mut dummy_out0 = [0u8; LEN];
-                        let mut dummy_out1 = [0u8; LEN];
-                        let (out0, out1) = out.split_at_mut(1);
-                        shake128_squeeze_first_three_blocks(
-                            state,
-                            &mut out0[0],
-                            &mut out1[0],
-                            &mut dummy_out0,
-                            &mut dummy_out1,
-                        );
-                    }
-                    3 => {
-                        let mut dummy_out0 = [0u8; LEN];
-                        let (out0, out12) = out.split_at_mut(1);
-                        let (out1, out2) = out12.split_at_mut(1);
-                        shake128_squeeze_first_three_blocks(
-                            state,
-                            &mut out0[0],
-                            &mut out1[0],
-                            &mut out2[0],
-                            &mut dummy_out0,
-                        );
-                    }
-                    4 => {
-                        let (out0, out123) = out.split_at_mut(1);
-                        let (out1, out23) = out123.split_at_mut(1);
-                        let (out2, out3) = out23.split_at_mut(1);
-                        shake128_squeeze_first_three_blocks(
-                            state,
-                            &mut out0[0],
-                            &mut out1[0],
-                            &mut out2[0],
-                            &mut out3[0],
-                        );
-                    }
-                    _ => unreachable!("This function must only be called with N = 2, 3, 4"),
-                }
-                out
-            }
-
-            /// Squeeze another block
-            #[inline(always)]
-            pub fn shake128_squeeze_next_block(
-                s: &mut KeccakState,
-                out0: &mut [u8],
-                out1: &mut [u8],
-                out2: &mut [u8],
-                out3: &mut [u8],
-            ) {
-                squeeze_next_block::<4, Vec256, 168>(&mut s.state, &mut [out0, out1, out2, out3]);
-            }
-
-            /// Squeeze up to 4 (N) blocks in parallel, using two [`KeccakState`].
-            /// Each block is of size `LEN`.
-            ///
-            /// **PANICS** when `N` is not 2, 3, or 4.
-            #[allow(non_snake_case)]
-            #[inline(always)]
-            fn _shake128_squeezexN<const LEN: usize, const N: usize>(
-                state: &mut KeccakState,
-            ) -> [[u8; LEN]; N] {
-                debug_assert!(N == 2 || N == 3 || N == 4);
-
-                let mut out = [[0u8; LEN]; N];
-                match N {
-                    2 => {
-                        let mut dummy_out0 = [0u8; LEN];
-                        let mut dummy_out1 = [0u8; LEN];
-                        let (out0, out1) = out.split_at_mut(1);
-                        shake128_squeeze_next_block(
-                            state,
-                            &mut out0[0],
-                            &mut out1[0],
-                            &mut dummy_out0,
-                            &mut dummy_out1,
-                        );
-                    }
-                    3 => {
-                        let mut dummy_out0 = [0u8; LEN];
-                        let (out0, out12) = out.split_at_mut(1);
-                        let (out1, out2) = out12.split_at_mut(1);
-                        shake128_squeeze_next_block(
-                            state,
-                            &mut out0[0],
-                            &mut out1[0],
-                            &mut out2[0],
-                            &mut dummy_out0,
-                        );
-                    }
-                    4 => {
-                        let (out0, out123) = out.split_at_mut(1);
-                        let (out1, out23) = out123.split_at_mut(1);
-                        let (out2, out3) = out23.split_at_mut(1);
-                        shake128_squeeze_next_block(
-                            state,
-                            &mut out0[0],
-                            &mut out1[0],
-                            &mut out2[0],
-                            &mut out3[0],
-                        );
-                    }
-                    _ => unreachable!("This function is only called with 2, 3, 4"),
-                }
-                out
-            }
+            squeeze_next_block::<STACK_SIZE, 1, u64, 136>(alloc, &mut s.state, &mut [out])
         }
     }
 }
+
+// /// A neon optimised implementation.
+// ///
+// /// When this is compiled for non-neon architectures, the functions panic.
+// /// The caller must make sure to check for hardware feature before calling these
+// /// functions and compile them in.
+// ///
+// /// Feature `simd128` enables the implementations in this module.
+// #[cfg(feature = "simd128")]
+// pub mod neon {
+//     use crate::generic_keccak::keccak;
+
+//     #[cfg(feature = "simd128")]
+//     #[inline(always)]
+//     fn keccakx2<const RATE: usize, const DELIM: u8>(data: &[&[u8]; 2], out: [&mut [u8]; 2]) {
+//         keccak::<2, crate::simd::arm64::uint64x2_t, RATE, DELIM>(data, out)
+//     }
+
+//     /// A portable SHA3 224 implementation.
+//     #[allow(unused_variables)]
+//     #[inline(always)]
+//     pub fn sha224(digest: &mut [u8], data: &[u8]) {
+//         let mut dummy = [0u8; 28];
+//         keccakx2::<144, 0x06u8>(&[data, data], [digest, &mut dummy]);
+//     }
+
+//     /// A portable SHA3 256 implementation.
+//     #[allow(unused_variables)]
+//     #[inline(always)]
+//     pub fn sha256(digest: &mut [u8], data: &[u8]) {
+//         let mut dummy = [0u8; 32];
+//         keccakx2::<136, 0x06u8>(&[data, data], [digest, &mut dummy]);
+//     }
+
+//     /// A portable SHA3 384 implementation.
+//     #[allow(unused_variables)]
+//     #[inline(always)]
+//     pub fn sha384(digest: &mut [u8], data: &[u8]) {
+//         let mut dummy = [0u8; 48];
+//         keccakx2::<104, 0x06u8>(&[data, data], [digest, &mut dummy]);
+//     }
+
+//     /// A portable SHA3 512 implementation.
+//     #[allow(unused_variables)]
+//     #[inline(always)]
+//     pub fn sha512(digest: &mut [u8], data: &[u8]) {
+//         let mut dummy = [0u8; 64];
+//         keccakx2::<72, 0x06u8>(&[data, data], [digest, &mut dummy]);
+//     }
+
+//     /// A portable SHAKE128 implementation.
+//     #[allow(unused_variables)]
+//     #[inline(always)]
+//     pub fn shake128<const LEN: usize>(digest: &mut [u8; LEN], data: &[u8]) {
+//         let mut dummy = [0u8; LEN];
+//         keccakx2::<168, 0x1fu8>(&[data, data], [digest, &mut dummy]);
+//     }
+
+//     /// A portable SHAKE256 implementation.
+//     #[allow(unused_variables)]
+//     #[inline(always)]
+//     pub fn shake256<const LEN: usize>(digest: &mut [u8; LEN], data: &[u8]) {
+//         let mut dummy = [0u8; LEN];
+//         keccakx2::<136, 0x1fu8>(&[data, data], [digest, &mut dummy]);
+//     }
+
+//     /// Performing 2 operations in parallel
+//     pub mod x2 {
+//         use super::*;
+
+//         /// Run SHAKE256 on both inputs in parallel.
+//         ///
+//         /// Writes the two results into `out0` and `out1`
+//         #[allow(unused_variables)]
+//         #[inline(always)]
+//         pub fn shake256(input0: &[u8], input1: &[u8], out0: &mut [u8], out1: &mut [u8]) {
+//             // TODO: make argument ordering consistent
+//             keccakx2::<136, 0x1fu8>(&[input0, input1], [out0, out1]);
+//         }
+
+//         /// Run up to 4 SHAKE256 operations in parallel.
+//         ///
+//         /// **PANICS** when `N` is not 2, 3, or 4.
+//         #[allow(non_snake_case)]
+//         #[inline(always)]
+//         fn _shake256xN<const LEN: usize, const N: usize>(input: &[[u8; 33]; N]) -> [[u8; LEN]; N] {
+//             debug_assert!(N == 2 || N == 3 || N == 4);
+
+//             let mut out = [[0u8; LEN]; N];
+//             match N {
+//                 2 => {
+//                     let (out0, out1) = out.split_at_mut(1);
+//                     shake256(&input[0], &input[1], &mut out0[0], &mut out1[0]);
+//                 }
+//                 3 => {
+//                     let mut extra = [0u8; LEN];
+//                     let (out0, out12) = out.split_at_mut(1);
+//                     let (out1, out2) = out12.split_at_mut(1);
+//                     shake256(&input[0], &input[1], &mut out0[0], &mut out1[0]);
+//                     shake256(&input[2], &input[2], &mut out2[0], &mut extra);
+//                 }
+//                 4 => {
+//                     let (out0, out123) = out.split_at_mut(1);
+//                     let (out1, out23) = out123.split_at_mut(1);
+//                     let (out2, out3) = out23.split_at_mut(1);
+//                     shake256(&input[0], &input[1], &mut out0[0], &mut out1[0]);
+//                     shake256(&input[2], &input[3], &mut out2[0], &mut out3[0]);
+//                 }
+//                 _ => unreachable!("Only 2, 3, or 4 are supported for N"),
+//             }
+//             out
+//         }
+
+//         /// An incremental API to perform 2 operations in parallel
+//         pub mod incremental {
+//             use crate::generic_keccak::{
+//                 absorb_final, squeeze_first_block, squeeze_first_five_blocks,
+//                 squeeze_first_three_blocks, squeeze_next_block, KeccakState as GenericState,
+//             };
+
+//             /// The Keccak state for the incremental API.
+//             pub struct KeccakState {
+//                 state: GenericState<2, crate::simd::arm64::uint64x2_t>,
+//             }
+
+//             type KeccakState2Internal = GenericState<2, crate::simd::arm64::uint64x2_t>;
+
+//             /// Initialise the `KeccakState2`.
+//             #[inline(always)]
+//             pub fn init() -> KeccakState {
+//                 // XXX: These functions could alternatively implement the same with
+//                 //      the portable implementation
+//                 // {
+//                 //     let s0 = KeccakState::new();
+//                 //     let s1 = KeccakState::new();
+//                 //     [s0, s1]
+//                 // }
+//                 KeccakState {
+//                     state: KeccakState2Internal::new(),
+//                 }
+//             }
+
+//             /// Shake128 absorb `data0` and `data1` in the [`KeccakState`] `s`.
+//             #[inline(always)]
+//             pub fn shake128_absorb_final(s: &mut KeccakState, data0: &[u8], data1: &[u8]) {
+//                 // XXX: These functions could alternatively implement the same with
+//                 //      the portable implementation
+//                 // {
+//                 //     let [mut s0, mut s1] = s;
+//                 //     shake128_absorb_final(&mut s0, data0);
+//                 //     shake128_absorb_final(&mut s1, data1);
+//                 // }
+//                 absorb_final::<2, crate::simd::arm64::uint64x2_t, 168, 0x1fu8>(
+//                     &mut s.state,
+//                     &[data0, data1],
+//                     0,
+//                     data0.len(),
+//                 );
+//             }
+
+//             /// Shake256 absorb `data0` and `data1` in the [`KeccakState`] `s`.
+//             #[inline(always)]
+//             pub fn shake256_absorb_final(s: &mut KeccakState, data0: &[u8], data1: &[u8]) {
+//                 // XXX: These functions could alternatively implement the same with
+//                 //      the portable implementation
+//                 // {
+//                 //     let [mut s0, mut s1] = s;
+//                 //     shake128_absorb_final(&mut s0, data0);
+//                 //     shake128_absorb_final(&mut s1, data1);
+//                 // }
+//                 absorb_final::<2, crate::simd::arm64::uint64x2_t, 136, 0x1fu8>(
+//                     &mut s.state,
+//                     &[data0, data1],
+//                     0,
+//                     data0.len(),
+//                 );
+//             }
+
+//             /// Initialise the state and perform up to 4 absorbs at the same time,
+//             /// using two [`KeccakState2`].
+//             ///
+//             /// **PANICS** when `N` is not 2, 3, or 4.
+//             #[allow(non_snake_case)]
+//             #[inline(always)]
+//             fn _shake128_absorb_finalxN<const N: usize>(input: [[u8; 34]; N]) -> [KeccakState; 2] {
+//                 debug_assert!(N == 2 || N == 3 || N == 4);
+//                 let mut state = [init(), init()];
+
+//                 match N {
+//                     2 => {
+//                         shake128_absorb_final(&mut state[0], &input[0], &input[1]);
+//                     }
+//                     3 => {
+//                         shake128_absorb_final(&mut state[0], &input[0], &input[1]);
+//                         shake128_absorb_final(&mut state[1], &input[2], &input[2]);
+//                     }
+//                     4 => {
+//                         shake128_absorb_final(&mut state[0], &input[0], &input[1]);
+//                         shake128_absorb_final(&mut state[1], &input[2], &input[3]);
+//                     }
+//                     _ => unreachable!("This function can only called be called with N = 2, 3, 4"),
+//                 }
+
+//                 state
+//             }
+
+//             /// Squeeze 2 times the first three blocks in parallel in the
+//             /// [`KeccakState`] and return the output in `out0` and `out1`.
+//             #[inline(always)]
+//             pub fn shake128_squeeze_first_three_blocks(
+//                 s: &mut KeccakState,
+//                 out0: &mut [u8],
+//                 out1: &mut [u8],
+//             ) {
+//                 // XXX: These functions could alternatively implement the same with
+//                 //      the portable implementation
+//                 // {
+//                 //     let [mut s0, mut s1] = s;
+//                 //     shake128_squeeze_first_three_blocks(&mut s0, out0);
+//                 //     shake128_squeeze_first_three_blocks(&mut s1, out1);
+//                 // }
+//                 squeeze_first_three_blocks::<2, crate::simd::arm64::uint64x2_t, 168>(
+//                     &mut s.state,
+//                     [out0, out1],
+//                 )
+//             }
+
+//             /// Squeeze five blocks
+//             #[inline(always)]
+//             pub fn shake128_squeeze_first_five_blocks(
+//                 s: &mut KeccakState,
+//                 out0: &mut [u8],
+//                 out1: &mut [u8],
+//             ) {
+//                 squeeze_first_five_blocks::<2, crate::simd::arm64::uint64x2_t, 168>(
+//                     &mut s.state,
+//                     [out0, out1],
+//                 )
+//             }
+
+//             /// Squeeze block
+//             #[inline(always)]
+//             pub fn shake256_squeeze_first_block(
+//                 s: &mut KeccakState,
+//                 out0: &mut [u8],
+//                 out1: &mut [u8],
+//             ) {
+//                 squeeze_first_block::<2, crate::simd::arm64::uint64x2_t, 136>(
+//                     &mut s.state,
+//                     &mut [out0, out1],
+//                 );
+//             }
+
+//             /// Squeeze next block
+//             #[inline(always)]
+//             pub fn shake256_squeeze_next_block(
+//                 s: &mut KeccakState,
+//                 out0: &mut [u8],
+//                 out1: &mut [u8],
+//             ) {
+//                 squeeze_next_block::<2, crate::simd::arm64::uint64x2_t, 136>(
+//                     &mut s.state,
+//                     &mut [out0, out1],
+//                 );
+//             }
+
+//             /// Squeeze up to 3 x 4 (N) blocks in parallel, using two [`KeccakState2`].
+//             /// Each block is of size `LEN`.
+//             ///
+//             /// **PANICS** when `N` is not 2, 3, or 4.
+//             #[allow(non_snake_case)]
+//             #[inline(always)]
+//             fn _shake128_squeeze3xN<const LEN: usize, const N: usize>(
+//                 state: &mut [KeccakState; 2],
+//             ) -> [[u8; LEN]; N] {
+//                 debug_assert!(N == 2 || N == 3 || N == 4);
+
+//                 let mut out = [[0u8; LEN]; N];
+//                 match N {
+//                     2 => {
+//                         let (out0, out1) = out.split_at_mut(1);
+//                         shake128_squeeze_first_three_blocks(
+//                             &mut state[0],
+//                             &mut out0[0],
+//                             &mut out1[0],
+//                         );
+//                     }
+//                     3 => {
+//                         let mut extra = [0u8; LEN];
+//                         let (out0, out12) = out.split_at_mut(1);
+//                         let (out1, out2) = out12.split_at_mut(1);
+//                         shake128_squeeze_first_three_blocks(
+//                             &mut state[0],
+//                             &mut out0[0],
+//                             &mut out1[0],
+//                         );
+//                         shake128_squeeze_first_three_blocks(
+//                             &mut state[1],
+//                             &mut out2[0],
+//                             &mut extra,
+//                         );
+//                     }
+//                     4 => {
+//                         let (out0, out123) = out.split_at_mut(1);
+//                         let (out1, out23) = out123.split_at_mut(1);
+//                         let (out2, out3) = out23.split_at_mut(1);
+//                         shake128_squeeze_first_three_blocks(
+//                             &mut state[0],
+//                             &mut out0[0],
+//                             &mut out1[0],
+//                         );
+//                         shake128_squeeze_first_three_blocks(
+//                             &mut state[1],
+//                             &mut out2[0],
+//                             &mut out3[0],
+//                         );
+//                     }
+//                     _ => unreachable!("This function can only called be called with N = 2, 3, 4"),
+//                 }
+//                 out
+//             }
+
+//             /// Squeeze 2 times the next block in parallel in the
+//             /// [`KeccakState`] and return the output in `out0` and `out1`.
+//             #[inline(always)]
+//             pub fn shake128_squeeze_next_block(
+//                 s: &mut KeccakState,
+//                 out0: &mut [u8],
+//                 out1: &mut [u8],
+//             ) {
+//                 // XXX: These functions could alternatively implement the same with
+//                 //      the portable implementation
+//                 // {
+//                 //     let [mut s0, mut s1] = s;
+//                 //     shake128_squeeze_next_block(&mut s0, out0);
+//                 //     shake128_squeeze_next_block(&mut s1, out1);
+//                 // }
+//                 squeeze_next_block::<2, crate::simd::arm64::uint64x2_t, 168>(
+//                     &mut s.state,
+//                     &mut [out0, out1],
+//                 )
+//             }
+
+//             /// Squeeze up to 4 (N) blocks in parallel, using two [`KeccakState2`].
+//             /// Each block is of size `LEN`.
+//             ///
+//             /// **PANICS** when `N` is not 2, 3, or 4.
+//             #[allow(non_snake_case)]
+//             #[inline(always)]
+//             fn _shake128_squeezexN<const LEN: usize, const N: usize>(
+//                 state: &mut [KeccakState; 2],
+//             ) -> [[u8; LEN]; N] {
+//                 debug_assert!(N == 2 || N == 3 || N == 4);
+
+//                 let mut out = [[0u8; LEN]; N];
+//                 match N {
+//                     2 => {
+//                         let mut out0 = [0u8; LEN];
+//                         let mut out1 = [0u8; LEN];
+//                         shake128_squeeze_next_block(&mut state[0], &mut out0, &mut out1);
+//                         out[0] = out0;
+//                         out[1] = out1;
+//                     }
+//                     3 => {
+//                         let mut out0 = [0u8; LEN];
+//                         let mut out1 = [0u8; LEN];
+//                         let mut out2 = [0u8; LEN];
+//                         let mut out3 = [0u8; LEN];
+//                         shake128_squeeze_next_block(&mut state[0], &mut out0, &mut out1);
+//                         shake128_squeeze_next_block(&mut state[1], &mut out2, &mut out3);
+//                         out[0] = out0;
+//                         out[1] = out1;
+//                         out[2] = out2;
+//                     }
+//                     4 => {
+//                         let mut out0 = [0u8; LEN];
+//                         let mut out1 = [0u8; LEN];
+//                         let mut out2 = [0u8; LEN];
+//                         let mut out3 = [0u8; LEN];
+//                         shake128_squeeze_next_block(&mut state[0], &mut out0, &mut out1);
+//                         shake128_squeeze_next_block(&mut state[1], &mut out2, &mut out3);
+//                         out[0] = out0;
+//                         out[1] = out1;
+//                         out[2] = out2;
+//                         out[3] = out3;
+//                     }
+//                     _ => unreachable!("This function is only called with N = 2, 3, 4"),
+//                 }
+//                 out
+//             }
+//         }
+//     }
+// }
+
+// /// An AVX2 optimised implementation.
+// ///
+// /// When this is compiled for non-neon architectures, the functions panic.
+// /// The caller must make sure to check for hardware feature before calling these
+// /// functions and compile them in.
+// ///
+// /// Feature `simd256` enables the implementations in this module.
+// #[cfg(feature = "simd256")]
+// pub mod avx2 {
+//     /// Performing 4 operations in parallel
+//     pub mod x4 {
+//         use crate::generic_keccak::keccak;
+//         use libcrux_intrinsics::avx2::*;
+
+//         /// Perform 4 SHAKE256 operations in parallel
+//         #[allow(clippy::too_many_arguments)]
+//         #[inline(always)]
+//         pub fn shake256(
+//             input0: &[u8],
+//             input1: &[u8],
+//             input2: &[u8],
+//             input3: &[u8],
+//             out0: &mut [u8],
+//             out1: &mut [u8],
+//             out2: &mut [u8],
+//             out3: &mut [u8],
+//         ) {
+//             // XXX: These functions could alternatively implement the same with
+//             //      the portable implementation
+//             // #[cfg(feature = "simd128")]
+//             // {
+//             //     keccakx2::<136, 0x1fu8>([input0, input1], [out0, out1]);
+//             //     keccakx2::<136, 0x1fu8>([input2, input3], [out2, out3]);
+//             // }
+//             // {
+//             //     keccakx1::<136, 0x1fu8>([input0], [out0]);
+//             //     keccakx1::<136, 0x1fu8>([input1], [out1]);
+//             //     keccakx1::<136, 0x1fu8>([input2], [out2]);
+//             //     keccakx1::<136, 0x1fu8>([input3], [out3]);
+//             // }
+//             keccak::<4, Vec256, 136, 0x1fu8>(
+//                 &[input0, input1, input2, input3],
+//                 [out0, out1, out2, out3],
+//             );
+//         }
+
+//         /// Run up to 4 SHAKE256 operations in parallel.
+//         ///
+//         /// **PANICS** when `N` is not 2, 3, or 4.
+//         #[allow(non_snake_case)]
+//         #[inline(always)]
+//         fn _shake256xN<const LEN: usize, const N: usize>(input: &[[u8; 33]; N]) -> [[u8; LEN]; N] {
+//             debug_assert!(N == 2 || N == 3 || N == 4);
+//             let mut out = [[0u8; LEN]; N];
+
+//             match N {
+//                 2 => {
+//                     let mut dummy_out0 = [0u8; LEN];
+//                     let mut dummy_out1 = [0u8; LEN];
+//                     let (out0, out1) = out.split_at_mut(1);
+//                     shake256(
+//                         &input[0],
+//                         &input[1],
+//                         &input[0],
+//                         &input[0],
+//                         &mut out0[0],
+//                         &mut out1[0],
+//                         &mut dummy_out0,
+//                         &mut dummy_out1,
+//                     );
+//                 }
+//                 3 => {
+//                     let mut dummy_out0 = [0u8; LEN];
+//                     let (out0, out12) = out.split_at_mut(1);
+//                     let (out1, out2) = out12.split_at_mut(1);
+//                     shake256(
+//                         &input[0],
+//                         &input[1],
+//                         &input[2],
+//                         &input[0],
+//                         &mut out0[0],
+//                         &mut out1[0],
+//                         &mut out2[0],
+//                         &mut dummy_out0,
+//                     );
+//                 }
+//                 4 => {
+//                     let (out0, out123) = out.split_at_mut(1);
+//                     let (out1, out23) = out123.split_at_mut(1);
+//                     let (out2, out3) = out23.split_at_mut(1);
+//                     shake256(
+//                         &input[0],
+//                         &input[1],
+//                         &input[2],
+//                         &input[3],
+//                         &mut out0[0],
+//                         &mut out1[0],
+//                         &mut out2[0],
+//                         &mut out3[0],
+//                     );
+//                 }
+//                 _ => unreachable!("This function must only be called with N = 2, 3, 4"),
+//             }
+//             out
+//         }
+
+//         /// An incremental API to perform 4 operations in parallel
+//         pub mod incremental {
+//             use crate::generic_keccak::{
+//                 absorb_final, squeeze_first_three_blocks, squeeze_next_block,
+//                 KeccakState as GenericState,
+//             };
+//             use crate::generic_keccak::{squeeze_first_block, squeeze_first_five_blocks};
+//             use libcrux_intrinsics::avx2::*;
+
+//             /// The Keccak state for the incremental API.
+//             #[cfg(feature = "simd256")]
+//             pub struct KeccakState {
+//                 state: GenericState<4, Vec256>,
+//             }
+
+//             /// Initialise the [`KeccakState`].
+//             #[inline(always)]
+//             pub fn init() -> KeccakState {
+//                 KeccakState {
+//                     state: GenericState::new(),
+//                 }
+//             }
+
+//             /// Absorb
+//             #[inline(always)]
+//             pub fn shake128_absorb_final(
+//                 s: &mut KeccakState,
+//                 data0: &[u8],
+//                 data1: &[u8],
+//                 data2: &[u8],
+//                 data3: &[u8],
+//             ) {
+//                 absorb_final::<4, Vec256, 168, 0x1fu8>(
+//                     &mut s.state,
+//                     &[data0, data1, data2, data3],
+//                     0,
+//                     data0.len(),
+//                 );
+//             }
+
+//             /// Absorb
+//             #[inline(always)]
+//             pub fn shake256_absorb_final(
+//                 s: &mut KeccakState,
+//                 data0: &[u8],
+//                 data1: &[u8],
+//                 data2: &[u8],
+//                 data3: &[u8],
+//             ) {
+//                 absorb_final::<4, Vec256, 136, 0x1fu8>(
+//                     &mut s.state,
+//                     &[data0, data1, data2, data3],
+//                     0,
+//                     data0.len(),
+//                 );
+//             }
+
+//             /// Squeeze block
+//             #[inline(always)]
+//             pub fn shake256_squeeze_first_block(
+//                 s: &mut KeccakState,
+//                 out0: &mut [u8],
+//                 out1: &mut [u8],
+//                 out2: &mut [u8],
+//                 out3: &mut [u8],
+//             ) {
+//                 squeeze_first_block::<4, Vec256, 136>(&mut s.state, &mut [out0, out1, out2, out3]);
+//             }
+
+//             /// Squeeze next block
+//             #[inline(always)]
+//             pub fn shake256_squeeze_next_block(
+//                 s: &mut KeccakState,
+//                 out0: &mut [u8],
+//                 out1: &mut [u8],
+//                 out2: &mut [u8],
+//                 out3: &mut [u8],
+//             ) {
+//                 squeeze_next_block::<4, Vec256, 136>(&mut s.state, &mut [out0, out1, out2, out3]);
+//             }
+
+//             /// Initialise the state and perform up to 4 absorbs at the same time,
+//             /// using two [`KeccakState`].
+//             ///
+//             /// **PANICS** when `N` is not 2, 3, or 4.
+//             #[inline(always)]
+//             #[allow(non_snake_case)]
+//             fn _shake128_absorb_finalxN<const N: usize>(input: [[u8; 34]; N]) -> KeccakState {
+//                 debug_assert!(N == 2 || N == 3 || N == 4);
+//                 let mut state = init();
+
+//                 match N {
+//                     2 => {
+//                         shake128_absorb_final(
+//                             &mut state, &input[0], &input[1], &input[0], &input[0],
+//                         );
+//                     }
+//                     3 => {
+//                         shake128_absorb_final(
+//                             &mut state, &input[0], &input[1], &input[2], &input[0],
+//                         );
+//                     }
+//                     4 => {
+//                         shake128_absorb_final(
+//                             &mut state, &input[0], &input[1], &input[2], &input[3],
+//                         );
+//                     }
+//                     _ => unreachable!("This function must only be called with N = 2, 3, 4"),
+//                 }
+
+//                 state
+//             }
+
+//             /// Squeeze three blocks
+//             #[inline(always)]
+//             pub fn shake128_squeeze_first_three_blocks(
+//                 s: &mut KeccakState,
+//                 out0: &mut [u8],
+//                 out1: &mut [u8],
+//                 out2: &mut [u8],
+//                 out3: &mut [u8],
+//             ) {
+//                 squeeze_first_three_blocks::<4, Vec256, 168>(
+//                     &mut s.state,
+//                     [out0, out1, out2, out3],
+//                 );
+//             }
+
+//             /// Squeeze five blocks
+//             #[inline(always)]
+//             pub fn shake128_squeeze_first_five_blocks(
+//                 s: &mut KeccakState,
+//                 out0: &mut [u8],
+//                 out1: &mut [u8],
+//                 out2: &mut [u8],
+//                 out3: &mut [u8],
+//             ) {
+//                 squeeze_first_five_blocks::<4, Vec256, 168>(&mut s.state, [out0, out1, out2, out3]);
+//             }
+
+//             /// Squeeze up to 3 x 4 (N) blocks in parallel, using two [`KeccakState`].
+//             /// Each block is of size `LEN`.
+//             ///
+//             /// **PANICS** when `N` is not 2, 3, or 4.
+//             #[inline(always)]
+//             #[allow(non_snake_case)]
+//             fn _shake128_squeeze3xN<const LEN: usize, const N: usize>(
+//                 state: &mut KeccakState,
+//             ) -> [[u8; LEN]; N] {
+//                 debug_assert!(N == 2 || N == 3 || N == 4);
+
+//                 let mut out = [[0u8; LEN]; N];
+//                 match N {
+//                     2 => {
+//                         let mut dummy_out0 = [0u8; LEN];
+//                         let mut dummy_out1 = [0u8; LEN];
+//                         let (out0, out1) = out.split_at_mut(1);
+//                         shake128_squeeze_first_three_blocks(
+//                             state,
+//                             &mut out0[0],
+//                             &mut out1[0],
+//                             &mut dummy_out0,
+//                             &mut dummy_out1,
+//                         );
+//                     }
+//                     3 => {
+//                         let mut dummy_out0 = [0u8; LEN];
+//                         let (out0, out12) = out.split_at_mut(1);
+//                         let (out1, out2) = out12.split_at_mut(1);
+//                         shake128_squeeze_first_three_blocks(
+//                             state,
+//                             &mut out0[0],
+//                             &mut out1[0],
+//                             &mut out2[0],
+//                             &mut dummy_out0,
+//                         );
+//                     }
+//                     4 => {
+//                         let (out0, out123) = out.split_at_mut(1);
+//                         let (out1, out23) = out123.split_at_mut(1);
+//                         let (out2, out3) = out23.split_at_mut(1);
+//                         shake128_squeeze_first_three_blocks(
+//                             state,
+//                             &mut out0[0],
+//                             &mut out1[0],
+//                             &mut out2[0],
+//                             &mut out3[0],
+//                         );
+//                     }
+//                     _ => unreachable!("This function must only be called with N = 2, 3, 4"),
+//                 }
+//                 out
+//             }
+
+//             /// Squeeze another block
+//             #[inline(always)]
+//             pub fn shake128_squeeze_next_block(
+//                 s: &mut KeccakState,
+//                 out0: &mut [u8],
+//                 out1: &mut [u8],
+//                 out2: &mut [u8],
+//                 out3: &mut [u8],
+//             ) {
+//                 squeeze_next_block::<4, Vec256, 168>(&mut s.state, &mut [out0, out1, out2, out3]);
+//             }
+
+//             /// Squeeze up to 4 (N) blocks in parallel, using two [`KeccakState`].
+//             /// Each block is of size `LEN`.
+//             ///
+//             /// **PANICS** when `N` is not 2, 3, or 4.
+//             #[allow(non_snake_case)]
+//             #[inline(always)]
+//             fn _shake128_squeezexN<const LEN: usize, const N: usize>(
+//                 state: &mut KeccakState,
+//             ) -> [[u8; LEN]; N] {
+//                 debug_assert!(N == 2 || N == 3 || N == 4);
+
+//                 let mut out = [[0u8; LEN]; N];
+//                 match N {
+//                     2 => {
+//                         let mut dummy_out0 = [0u8; LEN];
+//                         let mut dummy_out1 = [0u8; LEN];
+//                         let (out0, out1) = out.split_at_mut(1);
+//                         shake128_squeeze_next_block(
+//                             state,
+//                             &mut out0[0],
+//                             &mut out1[0],
+//                             &mut dummy_out0,
+//                             &mut dummy_out1,
+//                         );
+//                     }
+//                     3 => {
+//                         let mut dummy_out0 = [0u8; LEN];
+//                         let (out0, out12) = out.split_at_mut(1);
+//                         let (out1, out2) = out12.split_at_mut(1);
+//                         shake128_squeeze_next_block(
+//                             state,
+//                             &mut out0[0],
+//                             &mut out1[0],
+//                             &mut out2[0],
+//                             &mut dummy_out0,
+//                         );
+//                     }
+//                     4 => {
+//                         let (out0, out123) = out.split_at_mut(1);
+//                         let (out1, out23) = out123.split_at_mut(1);
+//                         let (out2, out3) = out23.split_at_mut(1);
+//                         shake128_squeeze_next_block(
+//                             state,
+//                             &mut out0[0],
+//                             &mut out1[0],
+//                             &mut out2[0],
+//                             &mut out3[0],
+//                         );
+//                     }
+//                     _ => unreachable!("This function is only called with 2, 3, 4"),
+//                 }
+//                 out
+//             }
+//         }
+//     }
+// }

--- a/libcrux/libcrux-sha3/src/lib.rs
+++ b/libcrux/libcrux-sha3/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! A SHA3 implementation with optional simd optimisations.
 
-// #![no_std]
+#![no_std]
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
 

--- a/libcrux/libcrux-sha3/src/lib.rs
+++ b/libcrux/libcrux-sha3/src/lib.rs
@@ -3,7 +3,7 @@
 //! A SHA3 implementation with optional simd optimisations.
 
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![deny(missing_docs)]
 
 pub mod simd;
@@ -11,6 +11,7 @@ pub mod simd;
 mod generic_keccak;
 mod portable_keccak;
 mod traits;
+mod alloc;
 
 /// A SHA3 224 Digest
 pub type Sha3_224Digest = [u8; 28];

--- a/libcrux/libcrux-sha3/src/portable_keccak.rs
+++ b/libcrux/libcrux-sha3/src/portable_keccak.rs
@@ -34,26 +34,19 @@ fn _veorq_n_u64(a: u64, c: u64) -> u64 {
 }
 
 #[inline(always)]
-pub(crate) fn load_block<const RATE: usize>(state: &mut [u64; 25], blocks: &[u8], start: usize) {
+pub(crate) fn load_block<const RATE: usize>(state: &mut [u64], blocks: &[u8], start: usize) {
     debug_assert!(RATE <= blocks.len() && RATE % 8 == 0);
-    let mut state_flat = [0u64; 25];
     for i in 0..RATE / 8 {
         let offset = start + 8 * i;
-        state_flat[i] = u64::from_le_bytes(blocks[offset..offset + 8].try_into().unwrap());
-    }
-    for i in 0..RATE / 8 {
-        set_ij(
-            state,
-            i / 5,
-            i % 5,
-            get_ij(state, i / 5, i % 5) ^ state_flat[i],
-        );
+        let intermediate = u64::from_le_bytes(blocks[offset..offset + 8].try_into().unwrap());
+        let intermediate = get_ij(state, i / 5, i % 5) ^ intermediate;
+        set_ij(state, i / 5, i % 5, intermediate);
     }
 }
 
 #[inline(always)]
 pub(crate) fn load_block_full<const RATE: usize>(
-    state: &mut [u64; 25],
+    state: &mut [u64],
     blocks: &[u8; 200],
     start: usize,
 ) {
@@ -61,14 +54,14 @@ pub(crate) fn load_block_full<const RATE: usize>(
 }
 
 #[inline(always)]
-pub(crate) fn store_block<const RATE: usize>(s: &[u64; 25], out: &mut [u8]) {
+pub(crate) fn store_block<const RATE: usize>(s: &[u64], out: &mut [u8]) {
     for i in 0..RATE / 8 {
         out[8 * i..8 * i + 8].copy_from_slice(&get_ij(s, i / 5, i % 5).to_le_bytes());
     }
 }
 
 #[inline(always)]
-pub(crate) fn store_block_full<const RATE: usize>(s: &[u64; 25], out: &mut [u8; 200]) {
+pub(crate) fn store_block_full<const RATE: usize>(s: &[u64], out: &mut [u8; 200]) {
     store_block::<RATE>(s, out);
 }
 
@@ -107,23 +100,23 @@ impl KeccakItem<1> for u64 {
         a ^ b
     }
     #[inline(always)]
-    fn load_block<const RATE: usize>(state: &mut [Self; 25], blocks: &[&[u8]; 1], start: usize) {
+    fn load_block<const RATE: usize>(state: &mut [Self], blocks: &[&[u8]; 1], start: usize) {
         load_block::<RATE>(state, blocks[0], start)
     }
     #[inline(always)]
-    fn store_block<const RATE: usize>(state: &[Self; 25], out: &mut [&mut [u8]; 1]) {
+    fn store_block<const RATE: usize>(state: &[Self], out: &mut [&mut [u8]; 1]) {
         store_block::<RATE>(state, out[0])
     }
     #[inline(always)]
     fn load_block_full<const RATE: usize>(
-        state: &mut [Self; 25],
+        state: &mut [Self],
         blocks: &[[u8; 200]; 1],
         start: usize,
     ) {
         load_block_full::<RATE>(state, &blocks[0], start)
     }
     #[inline(always)]
-    fn store_block_full<const RATE: usize>(state: &[Self; 25], out: &mut [[u8; 200]; 1]) {
+    fn store_block_full<const RATE: usize>(state: &[Self], out: &mut [[u8; 200]; 1]) {
         store_block_full::<RATE>(state, &mut out[0]);
     }
 
@@ -135,7 +128,7 @@ impl KeccakItem<1> for u64 {
 
     /// `out` has the exact size we want here. It must be less than or equal to `RATE`.
     #[inline(always)]
-    fn store<const RATE: usize>(state: &[Self; 25], out: [&mut [u8]; 1]) {
+    fn store<const RATE: usize>(state: &[Self], out: [&mut [u8]; 1]) {
         debug_assert!(out.len() <= RATE / 8, "{} > {}", out.len(), RATE);
 
         let num_full_blocks = out[0].len() / 8;

--- a/libcrux/libcrux-sha3/src/traits.rs
+++ b/libcrux/libcrux-sha3/src/traits.rs
@@ -1,6 +1,7 @@
 /// A Keccak Item
 /// This holds the internal state and depends on the architecture.
-pub trait KeccakStateItem<const N: usize>: internal::KeccakItem<N> {}
+
+pub trait KeccakStateItem<const N: usize>: internal::KeccakItem<N> + Default {}
 
 // Implement the public trait for all items.
 impl<const N: usize, T: internal::KeccakItem<N>> KeccakStateItem<N> for T {}
@@ -24,7 +25,7 @@ pub(crate) fn set_ij<const N: usize, T: KeccakStateItem<N>>(
 
 pub(crate) mod internal {
     /// A trait for multiplexing implementations.
-    pub trait KeccakItem<const N: usize>: Clone + Copy {
+    pub trait KeccakItem<const N: usize>: Clone + Copy + Default {
         fn zero() -> Self;
         fn xor5(a: Self, b: Self, c: Self, d: Self, e: Self) -> Self;
         fn rotate_left1_and_xor(a: Self, b: Self) -> Self;

--- a/libcrux/libcrux-sha3/src/traits.rs
+++ b/libcrux/libcrux-sha3/src/traits.rs
@@ -6,7 +6,7 @@ pub trait KeccakStateItem<const N: usize>: internal::KeccakItem<N> {}
 impl<const N: usize, T: internal::KeccakItem<N>> KeccakStateItem<N> for T {}
 
 pub(crate) fn get_ij<const N: usize, T: KeccakStateItem<N>>(
-    arr: &[T; 25],
+    arr: &[T],
     i: usize,
     j: usize,
 ) -> T {
@@ -14,7 +14,7 @@ pub(crate) fn get_ij<const N: usize, T: KeccakStateItem<N>>(
 }
 
 pub(crate) fn set_ij<const N: usize, T: KeccakStateItem<N>>(
-    arr: &mut [T; 25],
+    arr: &mut[T],
     i: usize,
     j: usize,
     v: T,
@@ -32,15 +32,15 @@ pub(crate) mod internal {
         fn and_not_xor(a: Self, b: Self, c: Self) -> Self;
         fn xor_constant(a: Self, c: u64) -> Self;
         fn xor(a: Self, b: Self) -> Self;
-        fn load_block<const RATE: usize>(state: &mut [Self; 25], blocks: &[&[u8]; N], start: usize);
-        fn store_block<const RATE: usize>(state: &[Self; 25], blocks: &mut [&mut [u8]; N]);
+        fn load_block<const RATE: usize>(state: &mut [Self], blocks: &[&[u8]; N], start: usize);
+        fn store_block<const RATE: usize>(state: &[Self], blocks: &mut [&mut [u8]; N]);
         fn load_block_full<const RATE: usize>(
-            state: &mut [Self; 25],
+            state: &mut [Self],
             blocks: &[[u8; 200]; N],
             start: usize,
         );
-        fn store_block_full<const RATE: usize>(a: &[Self; 25], out: &mut [[u8; 200]; N]);
+        fn store_block_full<const RATE: usize>(a: &[Self], out: &mut [[u8; 200]; N]);
         fn split_at_mut_n(a: [&mut [u8]; N], mid: usize) -> ([&mut [u8]; N], [&mut [u8]; N]);
-        fn store<const RATE: usize>(state: &[Self; 25], out: [&mut [u8]; N]);
+        fn store<const RATE: usize>(state: &[Self], out: [&mut [u8]; N]);
     }
 }


### PR DESCRIPTION
This PR introduces a custom bump allocator for SHA-3.

The idea is very simple in that it has as a backing buffer a `[T]` of size `STACK_SIZE` where it must be able to initialize `T` using `Default`. Then, when we can really be sure that the buffer or the `Alloc` struct that contains it _will not be moved anymore_, we can initialize a `pointer` which points at the boundary of allocated and free memory within the buffer (i.e. initially it will point at the start of `buffer`).
Allocation then means pushing that pointer forward by the amount requested (provided the request can be served without overrunning the buffer) and handing out a `&mut [T]` to the allocated memory.
Deallocation only works if the memory to be freed is what was most recently allocated. In our context I hope that we can usually establish this.

Potential TODO:
- This thing will only give out a single type of slice, so if we want to allocate e.g. the temporary buffer `b` in `squeeze_last` or `absorb_final` we would have to pass around a second allocator for `&mut [u8; 200]` slices. 
- Instead we could try making the backing buffer a `[u8]` array and using `transmute` to make whatever slice we need. But figuring out the safety on that seems more involved.

Fixes #54 