### PR TITLE
Introduce `realtime` feature

### DIFF
--- a/libcrux-nucleo-l4r5zi/Cargo.toml
+++ b/libcrux-nucleo-l4r5zi/Cargo.toml
@@ -21,8 +21,8 @@ panic-probe = { version = "0.3", features = ["print-defmt"] }
 cortex-m-semihosting = "0.5.0"
 libcrux-iot-testutil = { path = "../libcrux-iot-testutil" }
 libcrux-testbench = { path = "../libcrux-testbench" }
-embassy-stm32 = { version = "0.2.0", features = [ "stm32l4r5zi", "defmt", "time", "time-driver-any" ] }
-embassy-time = { version = "0.4", features = ["tick-hz-80_000_000", "generic-queue-8"]}
+embassy-stm32 = { version = "0.2.0", features = [ "stm32l4r5zi", "defmt" ] }
+embassy-time = { version = "0.4", features = ["tick-hz-80_000_000", "generic-queue-8"], optional = true}
 libcrux-ml-kem = { path = "../libcrux/libcrux-ml-kem" }
 embedded-alloc = "0.6.0"
 libcrux-pqm4 = { path = "../sys/pqm4" }
@@ -38,6 +38,7 @@ mldsa87 = ["libcrux-testbench/mldsa87"]
 mlkem512 = ["libcrux-testbench/mlkem512"]
 mlkem768 = ["libcrux-testbench/mlkem768"]
 mlkem1024 = ["libcrux-testbench/mlkem1024"]
+realtime = ["dep:embassy-time", "embassy-stm32/time", "embassy-stm32/time-driver-any"] # This allows real time measurements. The clock MUST be run with the `ClockConfig::Fast` configuration, otherwise the device will panic.
 
 # cargo build/run
 [profile.dev]

--- a/libcrux-nucleo-l4r5zi/src/bin/pqm4_rt.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/pqm4_rt.rs
@@ -1,40 +1,42 @@
 #![no_main]
 #![no_std]
 
-use libcrux_nucleo_l4r5zi::{self as board, init::ClockConfig, real_time::Timer}; // global logger + panicking-behavior + memory layout
-
 #[cortex_m_rt::entry]
 fn main() -> ! {
-    // Set up the system clock.
-    let clock_config = ClockConfig::Fast;
-    board::init::setup_clock(clock_config);
+    #[cfg(feature = "realtime")]
+    {
+        use libcrux_nucleo_l4r5zi::{self as board, init::ClockConfig, real_time::Timer}; // global logger + panicking-behavior + memory layout
 
-    let mut sk = [0u8; libcrux_pqm4::KYBER_SECRETKEYBYTES as usize];
-    let mut pk = [0u8; libcrux_pqm4::KYBER_PUBLICKEYBYTES as usize];
+        // Set up the system clock.
+        let clock_config = ClockConfig::Fast;
+        board::init::setup_clock(clock_config);
 
-    let mut ct = [0u8; libcrux_pqm4::KYBER_CIPHERTEXTBYTES as usize];
-    let mut ss_enc = [0u8; libcrux_pqm4::KYBER_SSBYTES as usize];
-    let mut ss_dec = [0u8; libcrux_pqm4::KYBER_SSBYTES as usize];
+        let mut sk = [0u8; libcrux_pqm4::KYBER_SECRETKEYBYTES as usize];
+        let mut pk = [0u8; libcrux_pqm4::KYBER_PUBLICKEYBYTES as usize];
 
-    let start = Timer::start_measurement();
-    core::hint::black_box(unsafe {
-        libcrux_pqm4::crypto_kem_keypair(&raw mut pk[0], &raw mut sk[0]);
-    });
-    Timer::end_measurement("pqm4: Generate Key Pair ML-KEM 1024", start);
+        let mut ct = [0u8; libcrux_pqm4::KYBER_CIPHERTEXTBYTES as usize];
+        let mut ss_enc = [0u8; libcrux_pqm4::KYBER_SSBYTES as usize];
+        let mut ss_dec = [0u8; libcrux_pqm4::KYBER_SSBYTES as usize];
 
-    let start = Timer::start_measurement();
-    core::hint::black_box(unsafe {
-        libcrux_pqm4::crypto_kem_enc(&raw mut ct[0], &raw mut ss_enc[0], &raw const pk[0]);
-    });
-    Timer::end_measurement("pqm4: Encapsulate ML-KEM 1024", start);
+        let start = Timer::start_measurement();
+        core::hint::black_box(unsafe {
+            libcrux_pqm4::crypto_kem_keypair(&raw mut pk[0], &raw mut sk[0]);
+        });
+        Timer::end_measurement("pqm4: Generate Key Pair ML-KEM 1024", start);
 
-    let start = Timer::start_measurement();
-    core::hint::black_box(unsafe {
-        libcrux_pqm4::crypto_kem_dec(&raw mut ss_dec[0], &raw const ct[0], &raw const sk[0]);
-    });
-    Timer::end_measurement("pqm4: Decapsulate ML-KEM 1024", start);
+        let start = Timer::start_measurement();
+        core::hint::black_box(unsafe {
+            libcrux_pqm4::crypto_kem_enc(&raw mut ct[0], &raw mut ss_enc[0], &raw const pk[0]);
+        });
+        Timer::end_measurement("pqm4: Encapsulate ML-KEM 1024", start);
 
-    assert_eq!(ss_enc, ss_dec);
+        let start = Timer::start_measurement();
+        core::hint::black_box(unsafe {
+            libcrux_pqm4::crypto_kem_dec(&raw mut ss_dec[0], &raw const ct[0], &raw const sk[0]);
+        });
+        Timer::end_measurement("pqm4: Decapsulate ML-KEM 1024", start);
 
+        assert_eq!(ss_enc, ss_dec);
+    }
     board::exit()
 }

--- a/libcrux-nucleo-l4r5zi/src/bin/pqm4_rt.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/pqm4_rt.rs
@@ -1,11 +1,11 @@
 #![no_main]
 #![no_std]
-
+use libcrux_nucleo_l4r5zi as board;
 #[cortex_m_rt::entry]
 fn main() -> ! {
     #[cfg(feature = "realtime")]
     {
-        use libcrux_nucleo_l4r5zi::{self as board, init::ClockConfig, real_time::Timer}; // global logger + panicking-behavior + memory layout
+        use libcrux_nucleo_l4r5zi::{init::ClockConfig, real_time::Timer}; // global logger + panicking-behavior + memory layout
 
         // Set up the system clock.
         let clock_config = ClockConfig::Fast;

--- a/libcrux-nucleo-l4r5zi/src/lib.rs
+++ b/libcrux-nucleo-l4r5zi/src/lib.rs
@@ -11,6 +11,7 @@ use panic_probe as _;
 
 pub mod cycle_counter;
 pub mod init;
+#[cfg(feature = "realtime")]
 pub mod real_time;
 
 // same panicking *behavior* as `panic-probe` but doesn't print a panic message


### PR DESCRIPTION
This introduces a feature `realtime` which enables real time measurements. Enabling this feature means the clock **must** be configured using `ClockConfig::Fast`, otherwise the device will panic.
 
Fixes #70 