### PR TITLE
[ML-KEM] NTT Base multiplication: Cache intermediates & better accumulation

### DIFF
--- a/libcrux-nucleo-l4r5zi/src/bin/mlkem_cycles.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/mlkem_cycles.rs
@@ -28,6 +28,7 @@ fn main() -> ! {
     }
 
     let randomness_gen = [1u8; libcrux_ml_kem::KEY_GENERATION_SEED_SIZE];
+
     let pair = core::hint::black_box(mlkem::generate_key_pair(randomness_gen));
     let randomness_encaps = [2u8; libcrux_ml_kem::ENCAPS_SEED_SIZE];
     let (ciphertext, _shared_secret_initiator) =

--- a/libcrux/libcrux-ml-kem/src/ind_cca.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca.rs
@@ -299,7 +299,6 @@ pub(crate) fn encapsulate<
     let mut r_as_ntt: [PolynomialRingElement<Vector>; K] =
         core::array::from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
     let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
-    let mut scratch = PolynomialRingElement::<Vector>::ZERO();
     let mut accumulator = [0i32; 256];
     let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
 
@@ -328,7 +327,6 @@ pub(crate) fn encapsulate<
         &mut ciphertext,
         &mut r_as_ntt,
         &mut error_2,
-        &mut scratch,
         &mut cache,
         &mut accumulator,
     );
@@ -403,7 +401,6 @@ pub(crate) fn decapsulate<
             (length ${private_key}.f_value))"#
     );
     let mut decrypted = [0u8; 32];
-    let mut scratch = PolynomialRingElement::<Vector>::ZERO();
     let mut accumulator = [0i32; 256];
 
     crate::ind_cpa::decrypt::<
@@ -488,7 +485,6 @@ pub(crate) fn decapsulate<
         &mut expected_ciphertext,
         &mut r_as_ntt,
         &mut error_2,
-        &mut scratch,
         &mut cache,
         &mut accumulator,
     );
@@ -1086,7 +1082,6 @@ pub(crate) mod unpacked {
         let mut r_as_ntt: [PolynomialRingElement<Vector>; K] =
             from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
         let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
-        let mut scratch = PolynomialRingElement::<Vector>::ZERO();
 
         let mut accumulator = [0i32; 256];
         let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
@@ -1115,7 +1110,6 @@ pub(crate) mod unpacked {
             &mut ciphertext,
             &mut r_as_ntt,
             &mut error_2,
-            &mut scratch,
             &mut cache,
             &mut accumulator,
         );
@@ -1203,8 +1197,6 @@ pub(crate) mod unpacked {
         assert (v (Spec.MLKEM.v_C2_SIZE $K) == 32 * v (Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K))"#
         );
         let mut decrypted = [0u8; SHARED_SECRET_SIZE];
-
-        let mut scratch = PolynomialRingElement::<Vector>::ZERO();
         let mut accumulator = [0i32; 256];
 
         ind_cpa::decrypt_unpacked::<
@@ -1278,7 +1270,6 @@ pub(crate) mod unpacked {
             &mut expected_ciphertext,
             &mut r_as_ntt,
             &mut error_2,
-            &mut scratch,
             &mut cache,
             &mut accumulator,
         );

--- a/libcrux/libcrux-ml-kem/src/ind_cca.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca.rs
@@ -421,7 +421,7 @@ pub(crate) fn decapsulate<
         ind_cpa_secret_key,
         &ciphertext.value,
         &mut decrypted,
-        &mut scratch,
+        &mut scratch.coefficients[0],
         &mut accumulator,
     );
 
@@ -1229,7 +1229,7 @@ pub(crate) mod unpacked {
             &key_pair.private_key.ind_cpa_private_key,
             &ciphertext.value,
             &mut decrypted,
-            &mut scratch,
+            &mut scratch.coefficients[0],
             &mut accumulator,
         );
 

--- a/libcrux/libcrux-ml-kem/src/ind_cca.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca.rs
@@ -408,6 +408,7 @@ pub(crate) fn decapsulate<
     );
     let mut decrypted = [0u8; 32];
     let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+    let mut accumulator = [0i32; 256];
 
     crate::ind_cpa::decrypt::<
         K,
@@ -421,6 +422,7 @@ pub(crate) fn decapsulate<
         &ciphertext.value,
         &mut decrypted,
         &mut scratch,
+        &mut accumulator,
     );
 
     let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] = into_padded_array(&decrypted);
@@ -463,7 +465,7 @@ pub(crate) fn decapsulate<
     let mut r_as_ntt: [PolynomialRingElement<Vector>; K] =
         core::array::from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
     let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
-    let mut accumulator = [0i32; 256];
+
     let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
 
     crate::ind_cpa::encrypt::<
@@ -1214,6 +1216,8 @@ pub(crate) mod unpacked {
         let mut decrypted = [0u8; SHARED_SECRET_SIZE];
 
         let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+        let mut accumulator = [0i32; 256];
+
         ind_cpa::decrypt_unpacked::<
             K,
             CIPHERTEXT_SIZE,
@@ -1226,6 +1230,7 @@ pub(crate) mod unpacked {
             &ciphertext.value,
             &mut decrypted,
             &mut scratch,
+            &mut accumulator,
         );
 
         let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] = into_padded_array(&decrypted);
@@ -1257,7 +1262,7 @@ pub(crate) mod unpacked {
         let mut r_as_ntt: [PolynomialRingElement<Vector>; K] =
             from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
         let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
-        let mut accumulator = [0i32; 256];
+
         let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
 
         ind_cpa::encrypt_unpacked::<

--- a/libcrux/libcrux-ml-kem/src/ind_cca.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca.rs
@@ -206,6 +206,9 @@ pub(crate) fn generate_keypair<
     let mut ind_cpa_private_key = [0u8; CPA_PRIVATE_KEY_SIZE];
     let mut public_key = [0u8; PUBLIC_KEY_SIZE];
     let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+    let mut accumulator = [0i32; 256];
+    let mut s_cache = [PolynomialRingElement::<Vector>::ZERO(); K];
+
     crate::ind_cpa::generate_keypair::<
         K,
         K_SQUARED,
@@ -222,6 +225,8 @@ pub(crate) fn generate_keypair<
         &mut ind_cpa_private_key,
         &mut public_key,
         &mut scratch,
+        &mut s_cache,
+        &mut accumulator,
     );
 
     let mut secret_key_serialized = [0u8; PRIVATE_KEY_SIZE];
@@ -299,6 +304,9 @@ pub(crate) fn encapsulate<
         core::array::from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
     let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
     let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+    let mut accumulator = [0i32; 256];
+    let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
+
     crate::ind_cpa::encrypt::<
         K,
         K_SQUARED,
@@ -325,6 +333,8 @@ pub(crate) fn encapsulate<
         &mut r_as_ntt,
         &mut error_2,
         &mut scratch,
+        &mut cache,
+        &mut accumulator,
     );
 
     let ciphertext = MlKemCiphertext::from(ciphertext);
@@ -453,6 +463,9 @@ pub(crate) fn decapsulate<
     let mut r_as_ntt: [PolynomialRingElement<Vector>; K] =
         core::array::from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
     let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
+    let mut accumulator = [0i32; 256];
+    let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
+
     crate::ind_cpa::encrypt::<
         K,
         K_SQUARED,
@@ -479,6 +492,8 @@ pub(crate) fn decapsulate<
         &mut r_as_ntt,
         &mut error_2,
         &mut scratch,
+        &mut cache,
+        &mut accumulator,
     );
 
     let mut implicit_rejection_shared_secret_kdf = [0u8; SHARED_SECRET_SIZE];
@@ -970,6 +985,9 @@ pub(crate) mod unpacked {
         let ind_cpa_keypair_randomness = &randomness[0..CPA_PKE_KEY_GENERATION_SEED_SIZE];
         let implicit_rejection_value = &randomness[CPA_PKE_KEY_GENERATION_SEED_SIZE..];
         let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+
+        let mut accumulator = [0i32; 256];
+        let mut s_cache = [PolynomialRingElement::<Vector>::ZERO(); K];
         generate_keypair_unpacked::<
             K,
             K_SQUARED,
@@ -984,6 +1002,8 @@ pub(crate) mod unpacked {
             &mut out.private_key.ind_cpa_private_key,
             &mut out.public_key.ind_cpa_public_key,
             &mut scratch,
+            &mut s_cache,
+            &mut accumulator,
         );
 
         #[allow(non_snake_case)]
@@ -1076,6 +1096,9 @@ pub(crate) mod unpacked {
             from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
         let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
         let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+
+        let mut accumulator = [0i32; 256];
+        let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
         ind_cpa::encrypt_unpacked::<
             K,
             K_SQUARED,
@@ -1102,6 +1125,8 @@ pub(crate) mod unpacked {
             &mut r_as_ntt,
             &mut error_2,
             &mut scratch,
+            &mut cache,
+            &mut accumulator,
         );
         let mut shared_secret_array = [0u8; SHARED_SECRET_SIZE];
         shared_secret_array.copy_from_slice(shared_secret);
@@ -1232,6 +1257,9 @@ pub(crate) mod unpacked {
         let mut r_as_ntt: [PolynomialRingElement<Vector>; K] =
             from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
         let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
+        let mut accumulator = [0i32; 256];
+        let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
+
         ind_cpa::encrypt_unpacked::<
             K,
             K_SQUARED,
@@ -1258,6 +1286,8 @@ pub(crate) mod unpacked {
             &mut r_as_ntt,
             &mut error_2,
             &mut scratch,
+            &mut cache,
+            &mut accumulator,
         );
 
         let selector =

--- a/libcrux/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cpa.rs
@@ -814,6 +814,7 @@ pub(crate) fn encrypt_unpacked<
         error_2,
         scratch,
         cache,
+        accumulator,
     );
 
     encrypt_c2::<K, V_COMPRESSION_FACTOR, C2_LEN, Vector>(
@@ -851,6 +852,7 @@ pub(crate) fn encrypt_c1<
     error_2: &mut PolynomialRingElement<Vector>,
     scratch: &mut PolynomialRingElement<Vector>,
     cache: &mut [PolynomialRingElement<Vector>],
+    accumulator: &mut [i32; 256],
 ) {
     // for i from 0 to k−1 do
     //     r[i] := CBD{η1}(PRF(r, N))
@@ -900,7 +902,15 @@ pub(crate) fn encrypt_c1<
     // u := NTT^{-1}(AˆT ◦ rˆ) + e_1
     let mut u = from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
 
-    compute_vector_u::<K, Vector>(matrix, &r_as_ntt, cache, &error_1, &mut u, scratch);
+    compute_vector_u::<K, Vector>(
+        matrix,
+        &r_as_ntt,
+        cache,
+        &error_1,
+        &mut u,
+        scratch,
+        accumulator,
+    );
 
     // c_1 := Encode_{du}(Compress_q(u,d_u))
     compress_then_serialize_u::<K, C1_LEN, U_COMPRESSION_FACTOR, BLOCK_LEN, Vector>(

--- a/libcrux/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cpa.rs
@@ -779,11 +779,9 @@ pub(crate) fn encrypt_unpacked<
     ciphertext: &mut [u8],
     r_as_ntt: &mut [PolynomialRingElement<Vector>],
     error_2: &mut PolynomialRingElement<Vector>,
-    scratch: &mut PolynomialRingElement<Vector>,
     cache: &mut [PolynomialRingElement<Vector>],
     accumulator: &mut [i32; 256],
 ) {
-    // let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
     encrypt_c1::<
         K,
         K_SQUARED,
@@ -814,7 +812,6 @@ pub(crate) fn encrypt_unpacked<
         &error_2,
         message,
         &mut ciphertext[C1_LEN..],
-        scratch,
         &cache,
         accumulator,
     );
@@ -869,7 +866,7 @@ pub(crate) fn encrypt_c1<
     // end for
     let mut error_1: [PolynomialRingElement<Vector>; K] =
         from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
-    let mut sampling_buffer = [0i16; 256];
+    let mut sampling_buffer = [0i16; 256]; // XXX: Could reuse accumulator here.
     let domain_separator =
         sample_ring_element_cbd::<K, ETA2_RANDOMNESS_SIZE, ETA2, PRF_OUTPUT_SIZE2, Vector, Hasher>(
             prf_input,
@@ -912,7 +909,6 @@ pub(crate) fn encrypt_c2<
     error_2: &PolynomialRingElement<Vector>,
     message: [u8; SHARED_SECRET_SIZE],
     ciphertext: &mut [u8],
-    scratch: &mut PolynomialRingElement<Vector>,
     cache: &[PolynomialRingElement<Vector>],
     accumulator: &mut [i32; 256],
 ) {
@@ -926,7 +922,6 @@ pub(crate) fn encrypt_c2<
         error_2,
         &message_as_ring_element,
         &mut v,
-        scratch,
         cache,
         accumulator,
     );
@@ -984,7 +979,6 @@ pub(crate) fn encrypt<
     ciphertext: &mut [u8],
     r_as_ntt: &mut [PolynomialRingElement<Vector>],
     error_2: &mut PolynomialRingElement<Vector>,
-    scratch: &mut PolynomialRingElement<Vector>,
     cache: &mut [PolynomialRingElement<Vector>],
     accumulator: &mut [i32; 256],
 ) {
@@ -1022,7 +1016,6 @@ pub(crate) fn encrypt<
         ciphertext,
         r_as_ntt,
         error_2,
-        scratch,
         cache,
         accumulator,
     )

--- a/libcrux/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cpa.rs
@@ -891,15 +891,7 @@ pub(crate) fn encrypt_c1<
     // u := NTT^{-1}(AˆT ◦ rˆ) + e_1
     let mut u = from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
 
-    compute_vector_u::<K, Vector>(
-        matrix,
-        &r_as_ntt,
-        cache,
-        &error_1,
-        &mut u,
-        scratch,
-        accumulator,
-    );
+    compute_vector_u::<K, Vector>(matrix, &r_as_ntt, cache, &error_1, &mut u, accumulator);
 
     // c_1 := Encode_{du}(Compress_q(u,d_u))
     compress_then_serialize_u::<K, C1_LEN, U_COMPRESSION_FACTOR, BLOCK_LEN, Vector>(
@@ -1104,7 +1096,6 @@ fn deserialize_then_decompress_u<
 >(
     ciphertext: &[u8; CIPHERTEXT_SIZE],
     u_as_ntt: &mut [PolynomialRingElement<Vector>],
-    scratch: &mut Vector,
 ) {
     hax_lib::fstar!(
         "assert (v (($COEFFICIENTS_IN_RING_ELEMENT *! $U_COMPRESSION_FACTOR ) /!
@@ -1223,7 +1214,6 @@ pub(crate) fn decrypt_unpacked<
     deserialize_then_decompress_u::<K, CIPHERTEXT_SIZE, U_COMPRESSION_FACTOR, Vector>(
         ciphertext,
         &mut u_as_ntt,
-        scratch,
     );
 
     // v := Decompress_q(Decode_{d_v}(c + d_u·k·n / 8), d_v)
@@ -1240,7 +1230,6 @@ pub(crate) fn decrypt_unpacked<
         &secret_key.secret_as_ntt,
         &u_as_ntt,
         &mut message,
-        scratch,
         accumulator,
     );
     compress_then_serialize_message(&message, decrypted, scratch);

--- a/libcrux/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cpa.rs
@@ -1227,6 +1227,7 @@ pub(crate) fn decrypt_unpacked<
     ciphertext: &[u8; CIPHERTEXT_SIZE],
     decrypted: &mut [u8],
     scratch: &mut PolynomialRingElement<Vector>,
+    accumulator: &mut [i32; 256],
 ) {
     // u := Decompress_q(Decode_{d_u}(c), d_u)
     let mut u_as_ntt = from_fn(|_| PolynomialRingElement::<Vector>::ZERO());
@@ -1251,6 +1252,7 @@ pub(crate) fn decrypt_unpacked<
         &u_as_ntt,
         &mut message,
         scratch,
+        accumulator,
     );
     compress_then_serialize_message(&message, decrypted, &mut scratch.coefficients[0]);
 }
@@ -1278,6 +1280,7 @@ pub(crate) fn decrypt<
     ciphertext: &[u8; CIPHERTEXT_SIZE],
     decrypted: &mut [u8],
     scratch: &mut PolynomialRingElement<Vector>,
+    accumulator: &mut [i32; 256],
 ) {
     hax_lib::fstar!(r#"reveal_opaque (`%Spec.MLKEM.ind_cpa_decrypt) Spec.MLKEM.ind_cpa_decrypt"#);
     // sˆ := Decode_12(sk)
@@ -1292,5 +1295,11 @@ pub(crate) fn decrypt<
         U_COMPRESSION_FACTOR,
         V_COMPRESSION_FACTOR,
         Vector,
-    >(&secret_key_unpacked, ciphertext, decrypted, scratch);
+    >(
+        &secret_key_unpacked,
+        ciphertext,
+        decrypted,
+        scratch,
+        accumulator,
+    );
 }

--- a/libcrux/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cpa.rs
@@ -363,7 +363,6 @@ fn sample_vector_cbd_then_ntt<
     re_as_ntt: &mut [PolynomialRingElement<Vector>],
     prf_input: [u8; 33],
     mut domain_separator: u8,
-    scratch: &mut Vector,
 ) -> u8 {
     let mut prf_inputs = [prf_input; K];
     let _domain_separator_init = domain_separator;
@@ -386,7 +385,7 @@ fn sample_vector_cbd_then_ntt<
         let mut sample_buffer = [0i16; 256];
         sample_from_binomial_distribution::<ETA, Vector>(randomness, &mut sample_buffer);
         PolynomialRingElement::from_i16_array(&sample_buffer, &mut re_as_ntt[i]);
-        ntt_binomially_sampled_ring_element(&mut re_as_ntt[i], scratch);
+        ntt_binomially_sampled_ring_element(&mut re_as_ntt[i]);
     }
     hax_lib::fstar!(
         "sample_vector_cbd_then_ntt_helper_2
@@ -496,12 +495,7 @@ pub(crate) fn generate_keypair_unpacked<
         PRF_OUTPUT_SIZE1,
         Vector,
         Hasher,
-    >(
-        &mut private_key.secret_as_ntt,
-        prf_input,
-        0,
-        &mut scratch.coefficients[0],
-    );
+    >(&mut private_key.secret_as_ntt, prf_input, 0);
     let mut error_as_ntt = from_fn(|_| PolynomialRingElement::<Vector>::ZERO());
     let _ = sample_vector_cbd_then_ntt::<
         K,
@@ -510,12 +504,7 @@ pub(crate) fn generate_keypair_unpacked<
         PRF_OUTPUT_SIZE1,
         Vector,
         Hasher,
-    >(
-        &mut error_as_ntt,
-        prf_input,
-        domain_separator,
-        &mut scratch.coefficients[0],
-    );
+    >(&mut error_as_ntt, prf_input, domain_separator);
 
     // tˆ := Aˆ ◦ sˆ + eˆ
     compute_As_plus_e(
@@ -867,7 +856,7 @@ pub(crate) fn encrypt_c1<
         PRF_OUTPUT_SIZE1,
         Vector,
         Hasher,
-    >(r_as_ntt, prf_input, 0, &mut scratch.coefficients[0]);
+    >(r_as_ntt, prf_input, 0);
     hax_lib::fstar!(
         "Lib.Sequence.eq_intro #u8 #32 $randomness (Seq.slice $prf_input 0 32);
         assert (v $domain_separator == v $K)"
@@ -1133,7 +1122,7 @@ fn deserialize_then_decompress_u<
                   (Seq.slice $ciphertext (j * v (Spec.MLKEM.v_C1_BLOCK_SIZE $K))
                     (j * v (Spec.MLKEM.v_C1_BLOCK_SIZE $K) + v (Spec.MLKEM.v_C1_BLOCK_SIZE $K))))"#) });
             deserialize_then_decompress_ring_element_u::<U_COMPRESSION_FACTOR, Vector>(u_bytes, &mut u_as_ntt[i]);
-            ntt_vector_u::<U_COMPRESSION_FACTOR, Vector>(&mut u_as_ntt[i], scratch);
+            ntt_vector_u::<U_COMPRESSION_FACTOR, Vector>(&mut u_as_ntt[i]);
         }
     }
     hax_lib::fstar!(
@@ -1226,7 +1215,7 @@ pub(crate) fn decrypt_unpacked<
     secret_key: &IndCpaPrivateKeyUnpacked<K, Vector>,
     ciphertext: &[u8; CIPHERTEXT_SIZE],
     decrypted: &mut [u8],
-    scratch: &mut PolynomialRingElement<Vector>,
+    scratch: &mut Vector,
     accumulator: &mut [i32; 256],
 ) {
     // u := Decompress_q(Decode_{d_u}(c), d_u)
@@ -1234,7 +1223,7 @@ pub(crate) fn decrypt_unpacked<
     deserialize_then_decompress_u::<K, CIPHERTEXT_SIZE, U_COMPRESSION_FACTOR, Vector>(
         ciphertext,
         &mut u_as_ntt,
-        &mut scratch.coefficients[0],
+        scratch,
     );
 
     // v := Decompress_q(Decode_{d_v}(c + d_u·k·n / 8), d_v)
@@ -1254,7 +1243,7 @@ pub(crate) fn decrypt_unpacked<
         scratch,
         accumulator,
     );
-    compress_then_serialize_message(&message, decrypted, &mut scratch.coefficients[0]);
+    compress_then_serialize_message(&message, decrypted, scratch);
 }
 
 #[allow(non_snake_case)]
@@ -1279,7 +1268,7 @@ pub(crate) fn decrypt<
     secret_key: &[u8],
     ciphertext: &[u8; CIPHERTEXT_SIZE],
     decrypted: &mut [u8],
-    scratch: &mut PolynomialRingElement<Vector>,
+    scratch: &mut Vector,
     accumulator: &mut [i32; 256],
 ) {
     hax_lib::fstar!(r#"reveal_opaque (`%Spec.MLKEM.ind_cpa_decrypt) Spec.MLKEM.ind_cpa_decrypt"#);

--- a/libcrux/libcrux-ml-kem/src/matrix.rs
+++ b/libcrux/libcrux-ml-kem/src/matrix.rs
@@ -90,12 +90,14 @@ pub(crate) fn compute_message<const K: usize, Vector: Operations>(
     u_as_ntt: &[PolynomialRingElement<Vector>; K],
     result: &mut PolynomialRingElement<Vector>,
     scratch: &mut PolynomialRingElement<Vector>,
+    accumulator: &mut [i32; 256],
 ) {
+    *accumulator = [0i32; 256];
     for i in 0..K {
-        secret_as_ntt[i].ntt_multiply(&u_as_ntt[i], scratch);
-        result.add_to_ring_element::<K>(scratch);
+        secret_as_ntt[i].accumulating_ntt_multiply(&u_as_ntt[i], accumulator);
     }
 
+    PolynomialRingElement::reducing_from_i32_array(accumulator, result);
     invert_ntt_montgomery::<K, Vector>(result, &mut scratch.coefficients[0]);
     v.subtract_reduce(result);
 }

--- a/libcrux/libcrux-ml-kem/src/matrix.rs
+++ b/libcrux/libcrux-ml-kem/src/matrix.rs
@@ -129,7 +129,7 @@ pub(crate) fn compute_ring_element_v<const K: usize, Vector: Operations>(
 ) {
     let mut accumulator = [0i32; 256];
     for i in 0..K {
-        t_as_ntt[i].ntt_multiply_cached(&r_as_ntt[i], &mut accumulator, &cache[i]);
+        t_as_ntt[i].accumulating_ntt_multiply_use_cache(&r_as_ntt[i], &mut accumulator, &cache[i]);
         // result.add_to_ring_element::<K>(&scratch);
     }
     let mut accumulator_reduced = [0i16; 256];
@@ -170,7 +170,7 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations>(
 
     let mut accumulator = [0i32; 256];
     for j in 0..K {
-        entry::<K, Vector>(a_as_ntt, 0, j).ntt_multiply_caching(
+        entry::<K, Vector>(a_as_ntt, 0, j).accumulating_ntt_multiply_fill_cache(
             &r_as_ntt[j],
             &mut accumulator,
             &mut cache[j],
@@ -189,7 +189,7 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations>(
     for i in 1..K {
         accumulator = [0i32; 256];
         for j in 0..K {
-            entry::<K, Vector>(a_as_ntt, i, j).ntt_multiply_cached(
+            entry::<K, Vector>(a_as_ntt, i, j).accumulating_ntt_multiply_use_cache(
                 &r_as_ntt[j],
                 &mut accumulator,
                 &cache[j],
@@ -235,7 +235,7 @@ pub(crate) fn compute_As_plus_e<const K: usize, Vector: Operations>(
     let mut s_cache = [PolynomialRingElement::<Vector>::ZERO(); K];
     let mut accumulator = [0i32; 256];
     for j in 0..K {
-        entry::<K, Vector>(matrix_A, 0, j).ntt_multiply_caching(
+        entry::<K, Vector>(matrix_A, 0, j).accumulating_ntt_multiply_fill_cache(
             &s_as_ntt[j],
             &mut accumulator,
             &mut s_cache[j],
@@ -258,7 +258,7 @@ pub(crate) fn compute_As_plus_e<const K: usize, Vector: Operations>(
         t_as_ntt[i] = PolynomialRingElement::<Vector>::ZERO();
         accumulator = [0i32; 256];
         for j in 0..K {
-            entry::<K, Vector>(matrix_A, i, j).ntt_multiply_cached(
+            entry::<K, Vector>(matrix_A, i, j).accumulating_ntt_multiply_use_cache(
                 &s_as_ntt[j],
                 &mut accumulator,
                 &s_cache[j],

--- a/libcrux/libcrux-ml-kem/src/matrix.rs
+++ b/libcrux/libcrux-ml-kem/src/matrix.rs
@@ -120,8 +120,7 @@ pub(crate) fn compute_ring_element_v<const K: usize, Vector: Operations>(
     r_as_ntt: &[PolynomialRingElement<Vector>],
     error_2: &PolynomialRingElement<Vector>,
     message: &PolynomialRingElement<Vector>,
-    result: &mut PolynomialRingElement<Vector>,
-    scratch: &mut PolynomialRingElement<Vector>,
+    v: &mut PolynomialRingElement<Vector>,
     cache: &[PolynomialRingElement<Vector>],
     accumulator: &mut [i32; 256],
 ) {
@@ -129,10 +128,11 @@ pub(crate) fn compute_ring_element_v<const K: usize, Vector: Operations>(
     for i in 0..K {
         t_as_ntt[i].accumulating_ntt_multiply_use_cache(&r_as_ntt[i], accumulator, &cache[i]);
     }
-    PolynomialRingElement::reducing_from_i32_array(accumulator, result);
+    // XXX: Could possibly reuse part of the cache here.
+    PolynomialRingElement::reducing_from_i32_array(accumulator, v);
 
-    invert_ntt_montgomery::<K, Vector>(result);
-    error_2.add_message_error_reduce(message, result, &mut scratch.coefficients[0]);
+    invert_ntt_montgomery::<K, Vector>(v);
+    error_2.add_message_error_reduce(message, v);
 }
 
 /// Compute u := InvertNTT(Aᵀ ◦ r̂) + e₁

--- a/libcrux/libcrux-ml-kem/src/matrix.rs
+++ b/libcrux/libcrux-ml-kem/src/matrix.rs
@@ -89,7 +89,6 @@ pub(crate) fn compute_message<const K: usize, Vector: Operations>(
     secret_as_ntt: &[PolynomialRingElement<Vector>; K],
     u_as_ntt: &[PolynomialRingElement<Vector>; K],
     result: &mut PolynomialRingElement<Vector>,
-    scratch: &mut Vector,
     accumulator: &mut [i32; 256],
 ) {
     *accumulator = [0i32; 256];
@@ -98,7 +97,7 @@ pub(crate) fn compute_message<const K: usize, Vector: Operations>(
     }
 
     PolynomialRingElement::reducing_from_i32_array(accumulator, result);
-    invert_ntt_montgomery::<K, Vector>(result, scratch);
+    invert_ntt_montgomery::<K, Vector>(result);
     v.subtract_reduce(result);
 }
 
@@ -132,7 +131,7 @@ pub(crate) fn compute_ring_element_v<const K: usize, Vector: Operations>(
     }
     PolynomialRingElement::reducing_from_i32_array(accumulator, result);
 
-    invert_ntt_montgomery::<K, Vector>(result, &mut scratch.coefficients[0]);
+    invert_ntt_montgomery::<K, Vector>(result);
     error_2.add_message_error_reduce(message, result, &mut scratch.coefficients[0]);
 }
 
@@ -156,7 +155,6 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations>(
     cache: &mut [PolynomialRingElement<Vector>],
     error_1: &[PolynomialRingElement<Vector>],
     result: &mut [PolynomialRingElement<Vector>],
-    scratch: &mut PolynomialRingElement<Vector>,
     accumulator: &mut [i32; 256],
 ) {
     debug_assert!(a_as_ntt.len() == K * K);
@@ -173,7 +171,7 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations>(
         // result[0].add_to_ring_element::<K>(scratch);
     }
     PolynomialRingElement::reducing_from_i32_array(accumulator, &mut result[0]);
-    invert_ntt_montgomery::<K, Vector>(&mut result[0], &mut scratch.coefficients[0]);
+    invert_ntt_montgomery::<K, Vector>(&mut result[0]);
     result[0].add_error_reduce(&error_1[0]);
 
     for i in 1..K {
@@ -188,7 +186,7 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations>(
         }
         PolynomialRingElement::reducing_from_i32_array(accumulator, &mut result[i]);
 
-        invert_ntt_montgomery::<K, Vector>(&mut result[i], &mut scratch.coefficients[0]);
+        invert_ntt_montgomery::<K, Vector>(&mut result[i]);
         result[i].add_error_reduce(&error_1[i]);
     }
 }

--- a/libcrux/libcrux-ml-kem/src/matrix.rs
+++ b/libcrux/libcrux-ml-kem/src/matrix.rs
@@ -89,7 +89,7 @@ pub(crate) fn compute_message<const K: usize, Vector: Operations>(
     secret_as_ntt: &[PolynomialRingElement<Vector>; K],
     u_as_ntt: &[PolynomialRingElement<Vector>; K],
     result: &mut PolynomialRingElement<Vector>,
-    scratch: &mut PolynomialRingElement<Vector>,
+    scratch: &mut Vector,
     accumulator: &mut [i32; 256],
 ) {
     *accumulator = [0i32; 256];
@@ -98,7 +98,7 @@ pub(crate) fn compute_message<const K: usize, Vector: Operations>(
     }
 
     PolynomialRingElement::reducing_from_i32_array(accumulator, result);
-    invert_ntt_montgomery::<K, Vector>(result, &mut scratch.coefficients[0]);
+    invert_ntt_montgomery::<K, Vector>(result, scratch);
     v.subtract_reduce(result);
 }
 

--- a/libcrux/libcrux-ml-kem/src/matrix.rs
+++ b/libcrux/libcrux-ml-kem/src/matrix.rs
@@ -124,6 +124,7 @@ pub(crate) fn compute_ring_element_v<const K: usize, Vector: Operations>(
     cache: &[PolynomialRingElement<Vector>],
     accumulator: &mut [i32; 256],
 ) {
+    *accumulator = [0i32; 256];
     for i in 0..K {
         t_as_ntt[i].accumulating_ntt_multiply_use_cache(&r_as_ntt[i], accumulator, &cache[i]);
     }
@@ -154,32 +155,36 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations>(
     error_1: &[PolynomialRingElement<Vector>],
     result: &mut [PolynomialRingElement<Vector>],
     scratch: &mut PolynomialRingElement<Vector>,
+    accumulator: &mut [i32; 256],
 ) {
     debug_assert!(a_as_ntt.len() == K * K);
     debug_assert!(r_as_ntt.len() == K);
     debug_assert!(error_1.len() == K);
 
+    *accumulator = [0i32; 256];
     for j in 0..K {
-        entry::<K, Vector>(a_as_ntt, 0, j).ntt_multiply_fill_cache(
+        entry::<K, Vector>(a_as_ntt, 0, j).accumulating_ntt_multiply_fill_cache(
             &r_as_ntt[j],
-            scratch,
+            accumulator,
             &mut cache[j],
         );
-        result[0].add_to_ring_element::<K>(scratch);
+        // result[0].add_to_ring_element::<K>(scratch);
     }
-
+    PolynomialRingElement::reducing_from_i32_array(accumulator, &mut result[0]);
     invert_ntt_montgomery::<K, Vector>(&mut result[0], &mut scratch.coefficients[0]);
     result[0].add_error_reduce(&error_1[0]);
 
     for i in 1..K {
+        *accumulator = [0i32; 256];
         for j in 0..K {
-            entry::<K, Vector>(a_as_ntt, i, j).ntt_multiply_use_cache(
+            entry::<K, Vector>(a_as_ntt, i, j).accumulating_ntt_multiply_use_cache(
                 &r_as_ntt[j],
-                scratch,
+                accumulator,
                 &cache[j],
             );
-            result[i].add_to_ring_element::<K>(scratch);
+            // result[i].add_to_ring_element::<K>(scratch);
         }
+        PolynomialRingElement::reducing_from_i32_array(accumulator, &mut result[i]);
 
         invert_ntt_montgomery::<K, Vector>(&mut result[i], &mut scratch.coefficients[0]);
         result[i].add_error_reduce(&error_1[i]);

--- a/libcrux/libcrux-ml-kem/src/ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/ntt.rs
@@ -197,7 +197,7 @@ pub(crate) fn ntt_at_layer_3<Vector: Operations>(
         (v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array $a) i) +
         v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array t) i))))"#))]
 fn ntt_layer_int_vec_step<Vector: Operations>(a: &mut Vector, b: &mut Vector, zeta_r: i16) {
-    Vector::montgomery_butterfly(a, b, zeta_r);
+    Vector::montgomery_ct_butterfly(a, b, zeta_r);
 }
 
 #[inline(always)]
@@ -273,7 +273,7 @@ pub(crate) fn ntt_at_layer_7<Vector: Operations>(re: &mut PolynomialRingElement<
             )
         });
         hax_lib::fstar!(r#"reveal_opaque (`%ntt_layer_7_pre) (ntt_layer_7_pre #$:Vector)"#);
-        Vector::butterfly(&mut a[j], &mut b[j], -1600);
+        Vector::ct_butterfly(&mut a[j], &mut b[j], -1600);
     }
 }
 

--- a/libcrux/libcrux-ml-kem/src/polynomial.rs
+++ b/libcrux/libcrux-ml-kem/src/polynomial.rs
@@ -302,6 +302,46 @@ fn ntt_multiply<Vector: Operations>(
     }
 }
 
+#[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
+fn ntt_multiply_caching<Vector: Operations>(
+    myself: &PolynomialRingElement<Vector>,
+    rhs: &PolynomialRingElement<Vector>,
+    out: &mut PolynomialRingElement<Vector>,
+    cache: &mut PolynomialRingElement<Vector>,
+) {
+    for i in 0..VECTORS_IN_RING_ELEMENT {
+        Vector::ntt_multiply_caching(
+            &myself.coefficients[i],
+            &rhs.coefficients[i],
+            &mut out.coefficients[i],
+            &mut cache.coefficients[i],
+            zeta(64 + 4 * i),
+            zeta(64 + 4 * i + 1),
+            zeta(64 + 4 * i + 2),
+            zeta(64 + 4 * i + 3),
+        );
+    }
+}
+
+#[inline(always)]
+#[hax_lib::fstar::verification_status(lax)]
+fn ntt_multiply_cached<Vector: Operations>(
+    myself: &PolynomialRingElement<Vector>,
+    rhs: &PolynomialRingElement<Vector>,
+    out: &mut PolynomialRingElement<Vector>,
+    cache: &PolynomialRingElement<Vector>,
+) {
+    for i in 0..VECTORS_IN_RING_ELEMENT {
+        Vector::ntt_multiply_cached(
+            &myself.coefficients[i],
+            &rhs.coefficients[i],
+            &mut out.coefficients[i],
+            &cache.coefficients[i],
+        );
+    }
+}
+
 // FIXME: We pulled out all the items because of https://github.com/hacspec/hax/issues/1183
 // Revisit when that issue is fixed.
 #[hax_lib::attributes]
@@ -388,6 +428,16 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
     #[inline(always)]
     pub(crate) fn ntt_multiply(&self, rhs: &Self, out: &mut Self) {
         ntt_multiply(self, rhs, out)
+    }
+
+    #[inline(always)]
+    pub(crate) fn ntt_multiply_caching(&self, rhs: &Self, out: &mut Self, cache: &mut Self) {
+        ntt_multiply_caching(self, rhs, out, cache)
+    }
+
+    #[inline(always)]
+    pub(crate) fn ntt_multiply_cached(&self, rhs: &Self, out: &mut Self, cache: &Self) {
+        ntt_multiply_cached(self, rhs, out, cache)
     }
 }
 

--- a/libcrux/libcrux-ml-kem/src/polynomial.rs
+++ b/libcrux/libcrux-ml-kem/src/polynomial.rs
@@ -307,14 +307,14 @@ fn ntt_multiply<Vector: Operations>(
 fn ntt_multiply_caching<Vector: Operations>(
     myself: &PolynomialRingElement<Vector>,
     rhs: &PolynomialRingElement<Vector>,
-    out: &mut PolynomialRingElement<Vector>,
+    accumulator: &mut [i32; 256],
     cache: &mut PolynomialRingElement<Vector>,
 ) {
     for i in 0..VECTORS_IN_RING_ELEMENT {
         Vector::ntt_multiply_caching(
             &myself.coefficients[i],
             &rhs.coefficients[i],
-            &mut out.coefficients[i],
+            &mut accumulator[i * 16..(i + 1) * 16],
             &mut cache.coefficients[i],
             zeta(64 + 4 * i),
             zeta(64 + 4 * i + 1),
@@ -329,14 +329,14 @@ fn ntt_multiply_caching<Vector: Operations>(
 fn ntt_multiply_cached<Vector: Operations>(
     myself: &PolynomialRingElement<Vector>,
     rhs: &PolynomialRingElement<Vector>,
-    out: &mut PolynomialRingElement<Vector>,
+    accumulator: &mut [i32; 256],
     cache: &PolynomialRingElement<Vector>,
 ) {
     for i in 0..VECTORS_IN_RING_ELEMENT {
         Vector::ntt_multiply_cached(
             &myself.coefficients[i],
             &rhs.coefficients[i],
-            &mut out.coefficients[i],
+            &mut accumulator[i * 16..(i + 1) * 16],
             &cache.coefficients[i],
         );
     }
@@ -431,13 +431,23 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
     }
 
     #[inline(always)]
-    pub(crate) fn ntt_multiply_caching(&self, rhs: &Self, out: &mut Self, cache: &mut Self) {
-        ntt_multiply_caching(self, rhs, out, cache)
+    pub(crate) fn ntt_multiply_caching(
+        &self,
+        rhs: &Self,
+        accumulator: &mut [i32; 256],
+        cache: &mut Self,
+    ) {
+        ntt_multiply_caching(self, rhs, accumulator, cache)
     }
 
     #[inline(always)]
-    pub(crate) fn ntt_multiply_cached(&self, rhs: &Self, out: &mut Self, cache: &Self) {
-        ntt_multiply_cached(self, rhs, out, cache)
+    pub(crate) fn ntt_multiply_cached(
+        &self,
+        rhs: &Self,
+        accumulator: &mut [i32; 256],
+        cache: &Self,
+    ) {
+        ntt_multiply_cached(self, rhs, accumulator, cache)
     }
 }
 

--- a/libcrux/libcrux-ml-kem/src/polynomial.rs
+++ b/libcrux/libcrux-ml-kem/src/polynomial.rs
@@ -304,14 +304,14 @@ fn ntt_multiply<Vector: Operations>(
 
 #[inline(always)]
 #[hax_lib::fstar::verification_status(lax)]
-fn ntt_multiply_caching<Vector: Operations>(
+fn accumulating_ntt_multiply_fill_cache<Vector: Operations>(
     myself: &PolynomialRingElement<Vector>,
     rhs: &PolynomialRingElement<Vector>,
     accumulator: &mut [i32; 256],
     cache: &mut PolynomialRingElement<Vector>,
 ) {
     for i in 0..VECTORS_IN_RING_ELEMENT {
-        Vector::ntt_multiply_caching(
+        Vector::accumulating_ntt_multiply_fill_cache(
             &myself.coefficients[i],
             &rhs.coefficients[i],
             &mut accumulator[i * 16..(i + 1) * 16],
@@ -326,14 +326,14 @@ fn ntt_multiply_caching<Vector: Operations>(
 
 #[inline(always)]
 #[hax_lib::fstar::verification_status(lax)]
-fn ntt_multiply_cached<Vector: Operations>(
+fn accumulating_ntt_multiply_use_cache<Vector: Operations>(
     myself: &PolynomialRingElement<Vector>,
     rhs: &PolynomialRingElement<Vector>,
     accumulator: &mut [i32; 256],
     cache: &PolynomialRingElement<Vector>,
 ) {
     for i in 0..VECTORS_IN_RING_ELEMENT {
-        Vector::ntt_multiply_cached(
+        Vector::accumulating_ntt_multiply_use_cache(
             &myself.coefficients[i],
             &rhs.coefficients[i],
             &mut accumulator[i * 16..(i + 1) * 16],
@@ -431,23 +431,23 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
     }
 
     #[inline(always)]
-    pub(crate) fn ntt_multiply_caching(
+    pub(crate) fn accumulating_ntt_multiply_fill_cache(
         &self,
         rhs: &Self,
         accumulator: &mut [i32; 256],
         cache: &mut Self,
     ) {
-        ntt_multiply_caching(self, rhs, accumulator, cache)
+        accumulating_ntt_multiply_fill_cache(self, rhs, accumulator, cache)
     }
 
     #[inline(always)]
-    pub(crate) fn ntt_multiply_cached(
+    pub(crate) fn accumulating_ntt_multiply_use_cache(
         &self,
         rhs: &Self,
         accumulator: &mut [i32; 256],
         cache: &Self,
     ) {
-        ntt_multiply_cached(self, rhs, accumulator, cache)
+        accumulating_ntt_multiply_use_cache(self, rhs, accumulator, cache)
     }
 }
 

--- a/libcrux/libcrux-ml-kem/src/polynomial.rs
+++ b/libcrux/libcrux-ml-kem/src/polynomial.rs
@@ -179,14 +179,13 @@ fn subtract_reduce<Vector: Operations>(
 #[inline(always)]
 #[hax_lib::fstar::verification_status(lax)]
 fn add_message_error_reduce<Vector: Operations>(
-    myself: &PolynomialRingElement<Vector>,
+    error_2: &PolynomialRingElement<Vector>,
     message: &PolynomialRingElement<Vector>,
-    result: &mut PolynomialRingElement<Vector>,
-    scratch: &mut Vector,
+    v: &mut PolynomialRingElement<Vector>,
 ) {
     // Using `hax_lib::fstar::verification_status(lax)` works but produces an error while extracting
     for i in 0..VECTORS_IN_RING_ELEMENT {
-        Vector::montgomery_multiply_by_constant(&mut result.coefficients[i], 1441);
+        Vector::montgomery_multiply_by_constant(&mut v.coefficients[i], 1441);
 
         // FIXME: Eurydice crashes with:
         //
@@ -203,10 +202,9 @@ fn add_message_error_reduce<Vector: Operations>(
         //     &Vector::add(myself.coefficients[i], &message.coefficients[i]),
         // ));
         // ```
-        *scratch = myself.coefficients[i].clone(); // XXX: Need this?
-        Vector::add(scratch, &message.coefficients[i]);
-        Vector::add(&mut result.coefficients[i], &scratch);
-        Vector::barrett_reduce(&mut result.coefficients[i]);
+        Vector::add(&mut v.coefficients[i], &message.coefficients[i]);
+        Vector::add(&mut v.coefficients[i], &error_2.coefficients[i]);
+        Vector::barrett_reduce(&mut v.coefficients[i]);
     }
 }
 
@@ -400,13 +398,8 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
     }
 
     #[inline(always)]
-    pub(crate) fn add_message_error_reduce(
-        &self,
-        message: &Self,
-        result: &mut Self,
-        scratch: &mut Vector,
-    ) {
-        add_message_error_reduce(self, message, result, scratch);
+    pub(crate) fn add_message_error_reduce(&self, message: &Self, v: &mut Self) {
+        add_message_error_reduce(self, message, v);
     }
 
     #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -314,40 +314,16 @@ impl Operations for PortableVector {
     }
 
     #[inline(always)]
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
-                       Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
-                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${lhs}) /\
-                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${rhs})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
-    fn ntt_multiply(
+    fn accumulating_ntt_multiply(
         lhs: &Self,
         rhs: &Self,
-        out: &mut Self,
+        out: &mut [i32],
         zeta0: i16,
         zeta1: i16,
         zeta2: i16,
         zeta3: i16,
     ) {
-        ntt_multiply(lhs, rhs, out, zeta0, zeta1, zeta2, zeta3)
-    }
-
-    #[inline(always)]
-    fn ntt_multiply_fill_cache(
-        lhs: &Self,
-        rhs: &Self,
-        out: &mut Self,
-        cache: &mut Self,
-        zeta0: i16,
-        zeta1: i16,
-        zeta2: i16,
-        zeta3: i16,
-    ) {
-        ntt_multiply_fill_cache(lhs, rhs, out, cache, zeta0, zeta1, zeta2, zeta3)
-    }
-
-    #[inline(always)]
-    fn ntt_multiply_use_cache(lhs: &Self, rhs: &Self, out: &mut Self, cache: &Self) {
-        ntt_multiply_use_cache(lhs, rhs, out, cache)
+        accumulating_ntt_multiply(lhs, rhs, out, zeta0, zeta1, zeta2, zeta3)
     }
 
     #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -1,5 +1,5 @@
 use super::Operations;
-mod arithmetic;
+pub(crate) mod arithmetic;
 mod compress;
 mod ntt;
 mod sampling;
@@ -328,7 +328,7 @@ impl Operations for PortableVector {
     fn ntt_multiply_caching(
         lhs: &Self,
         rhs: &Self,
-        out: &mut Self,
+        out: &mut [i32],
         cache: &mut Self,
         zeta0: i16,
         zeta1: i16,
@@ -339,7 +339,7 @@ impl Operations for PortableVector {
     }
 
     #[inline(always)]
-    fn ntt_multiply_cached(lhs: &Self, rhs: &Self, out: &mut Self, cache: &Self) {
+    fn ntt_multiply_cached(lhs: &Self, rhs: &Self, out: &mut [i32], cache: &Self) {
         ntt_multiply_cached(lhs, rhs, out, cache)
     }
 

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -173,7 +173,7 @@ impl Operations for PortableVector {
     fn sub(lhs: &mut Self, rhs: &Self) {
         sub(lhs, rhs)
     }
-    
+
     #[inline(always)]
     fn negate(vec: &mut Self) {
         negate(vec)
@@ -324,6 +324,23 @@ impl Operations for PortableVector {
         ntt_multiply(lhs, rhs, out, zeta0, zeta1, zeta2, zeta3)
     }
 
+    fn ntt_multiply_caching(
+        lhs: &Self,
+        rhs: &Self,
+        out: &mut Self,
+        cache: &mut Self,
+        zeta0: i16,
+        zeta1: i16,
+        zeta2: i16,
+        zeta3: i16,
+    ) {
+        ntt_multiply_caching(lhs, rhs, out, cache, zeta0, zeta1, zeta2, zeta3)
+    }
+
+    fn ntt_multiply_cached(lhs: &Self, rhs: &Self, out: &mut Self, cache: &Self) {
+        ntt_multiply_cached(lhs, rhs, out, cache)
+    }
+
     #[inline(always)]
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a)"#))]
     #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 1 (impl.f_repr $a) $out"#))]
@@ -381,7 +398,7 @@ impl Operations for PortableVector {
     fn serialize_11(a: Self, out: &mut [u8]) {
         serialize_11(a, out)
     }
-    
+
     #[inline(always)]
     #[requires(a.len() == 22)]
     fn deserialize_11(a: &[u8], out: &mut Self) {

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -324,6 +324,7 @@ impl Operations for PortableVector {
         ntt_multiply(lhs, rhs, out, zeta0, zeta1, zeta2, zeta3)
     }
 
+    #[inline(always)]
     fn ntt_multiply_caching(
         lhs: &Self,
         rhs: &Self,
@@ -337,6 +338,7 @@ impl Operations for PortableVector {
         ntt_multiply_caching(lhs, rhs, out, cache, zeta0, zeta1, zeta2, zeta3)
     }
 
+    #[inline(always)]
     fn ntt_multiply_cached(lhs: &Self, rhs: &Self, out: &mut Self, cache: &Self) {
         ntt_multiply_cached(lhs, rhs, out, cache)
     }

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -228,12 +228,19 @@ impl Operations for PortableVector {
         montgomery_multiply_by_constant(v, r)
     }
 
-    fn montgomery_butterfly(a: &mut Self, b: &mut Self, fer: i16) {
-        montgomery_butterfly(a, b, fer)
+    #[inline(always)]
+    fn montgomery_ct_butterfly(a: &mut Self, b: &mut Self, fer: i16) {
+        montgomery_ct_butterfly(a, b, fer)
     }
 
-    fn butterfly(a: &mut Self, b: &mut Self, fer: i16) {
-        butterfly(a, b, fer)
+    #[inline(always)]
+    fn ct_butterfly(a: &mut Self, b: &mut Self, fer: i16) {
+        ct_butterfly(a, b, fer)
+    }
+
+    #[inline(always)]
+    fn gs_butterfly(a: &mut Self, b: &mut Self, fer: i16) {
+        gs_butterfly(a, b, fer)
     }
 
     #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -137,6 +137,13 @@ impl Operations for PortableVector {
     }
 
     #[inline(always)]
+    #[requires(array.len() == 16)]
+    #[ensures(|out| fstar!(r#"impl.f_repr out == $array"#))]
+    fn reducing_from_i32_array(array: &[i32], out: &mut Self) {
+        reducing_from_i32_array(array, out)
+    }
+
+    #[inline(always)]
     #[ensures(|out| fstar!(r#"out == impl.f_repr $x"#))]
     fn to_i16_array(x: Self, out: &mut [i16; 16]) {
         to_i16_array(x, out)
@@ -322,6 +329,25 @@ impl Operations for PortableVector {
         zeta3: i16,
     ) {
         ntt_multiply(lhs, rhs, out, zeta0, zeta1, zeta2, zeta3)
+    }
+
+    #[inline(always)]
+    fn ntt_multiply_fill_cache(
+        lhs: &Self,
+        rhs: &Self,
+        out: &mut Self,
+        cache: &mut Self,
+        zeta0: i16,
+        zeta1: i16,
+        zeta2: i16,
+        zeta3: i16,
+    ) {
+        ntt_multiply_fill_cache(lhs, rhs, out, cache, zeta0, zeta1, zeta2, zeta3)
+    }
+
+    #[inline(always)]
+    fn ntt_multiply_use_cache(lhs: &Self, rhs: &Self, out: &mut Self, cache: &Self) {
+        ntt_multiply_use_cache(lhs, rhs, out, cache)
     }
 
     #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -325,7 +325,7 @@ impl Operations for PortableVector {
     }
 
     #[inline(always)]
-    fn ntt_multiply_caching(
+    fn accumulating_ntt_multiply_fill_cache(
         lhs: &Self,
         rhs: &Self,
         out: &mut [i32],
@@ -335,12 +335,12 @@ impl Operations for PortableVector {
         zeta2: i16,
         zeta3: i16,
     ) {
-        ntt_multiply_caching(lhs, rhs, out, cache, zeta0, zeta1, zeta2, zeta3)
+        accumulating_ntt_multiply_fill_cache(lhs, rhs, out, cache, zeta0, zeta1, zeta2, zeta3)
     }
 
     #[inline(always)]
-    fn ntt_multiply_cached(lhs: &Self, rhs: &Self, out: &mut [i32], cache: &Self) {
-        ntt_multiply_cached(lhs, rhs, out, cache)
+    fn accumulating_ntt_multiply_use_cache(lhs: &Self, rhs: &Self, out: &mut [i32], cache: &Self) {
+        accumulating_ntt_multiply_use_cache(lhs, rhs, out, cache)
     }
 
     #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -1,4 +1,4 @@
-use super::Operations;
+use super::{Operations, FIELD_ELEMENTS_IN_VECTOR, FIELD_MODULUS};
 pub(crate) mod arithmetic;
 mod compress;
 mod ntt;
@@ -159,6 +159,15 @@ impl Operations for PortableVector {
     #[requires(bytes.len() >= 32)]
     fn to_bytes(x: Self, bytes: &mut [u8]) {
         to_bytes(x, bytes)
+    }
+
+    #[inline(always)]
+    fn to_unsigned_representative(a: &mut Self) {
+        for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+            let mut tmp = a.elements[i] >> 15;
+            tmp &= FIELD_MODULUS;
+            a.elements[i] += tmp;
+        }
     }
 
     #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -228,6 +228,14 @@ impl Operations for PortableVector {
         montgomery_multiply_by_constant(v, r)
     }
 
+    fn montgomery_butterfly(a: &mut Self, b: &mut Self, fer: i16) {
+        montgomery_butterfly(a, b, fer)
+    }
+
+    fn butterfly(a: &mut Self, b: &mut Self, fer: i16) {
+        butterfly(a, b, fer)
+    }
+
     #[inline(always)]
     #[requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (impl.f_repr $a) i) >= 0 /\
         v (Seq.index (impl.f_repr $a) i) < 3329"#))]

--- a/libcrux/libcrux-ml-kem/src/vector/portable/arithmetic.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/arithmetic.rs
@@ -429,3 +429,39 @@ pub(crate) fn montgomery_multiply_by_constant(vec: &mut PortableVector, c: i16) 
         vec.elements[i] = montgomery_multiply_fe_by_fer(vec.elements[i], c)
     }
 }
+
+pub(crate) fn montgomery_butterfly(a: &mut PortableVector, b: &mut PortableVector, fer: i16) {
+    for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        hax_lib::loop_invariant!(|i: usize| {
+            fstar!(
+                r#"
+              (forall j. j < v i ==>
+	      	  (let vecj = Seq.index ${vec}.f_elements j in
+		       (Spec.Utils.is_i16b 3328 vecj /\
+                v vecj % 3329 == (v (Seq.index ${_vec0}.f_elements j) * v c * 169) % 3329))) /\
+              (forall j. j >= v i ==> (Seq.index ${vec}.f_elements j) == (Seq.index ${_vec0}.f_elements j))"#
+            )
+        });
+        let bi_zeta = montgomery_multiply_fe_by_fer(b.elements[i], fer);
+        b.elements[i] = a.elements[i] - bi_zeta;
+        a.elements[i] += bi_zeta;
+    }
+}
+
+pub(crate) fn butterfly(a: &mut PortableVector, b: &mut PortableVector, fer: i16) {
+    for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        hax_lib::loop_invariant!(|i: usize| {
+            fstar!(
+                r#"
+              (forall j. j < v i ==>
+	      	  (let vecj = Seq.index ${vec}.f_elements j in
+		       (Spec.Utils.is_i16b 3328 vecj /\
+                v vecj % 3329 == (v (Seq.index ${_vec0}.f_elements j) * v c * 169) % 3329))) /\
+              (forall j. j >= v i ==> (Seq.index ${vec}.f_elements j) == (Seq.index ${_vec0}.f_elements j))"#
+            )
+        });
+        let bi_zeta = b.elements[i] * fer;
+        b.elements[i] = a.elements[i] - bi_zeta;
+        a.elements[i] += bi_zeta;
+    }
+}

--- a/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
@@ -368,6 +368,7 @@ pub(crate) fn ntt_multiply_binomials(
     );
 }
 
+#[inline(always)]
 pub(crate) fn ntt_multiply_binomials_caching(
     a: &PortableVector,
     b: &PortableVector,
@@ -464,6 +465,7 @@ pub(crate) fn ntt_multiply_binomials_caching(
     );
 }
 
+#[inline(always)]
 pub(crate) fn ntt_multiply_binomials_cached(
     a: &PortableVector,
     b: &PortableVector,
@@ -612,6 +614,7 @@ pub(crate) fn ntt_multiply_caching(
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
 }
 
+#[inline(always)]
 pub(crate) fn ntt_multiply_cached(
     lhs: &PortableVector,
     rhs: &PortableVector,
@@ -640,7 +643,7 @@ pub(crate) fn ntt_multiply_cached(
     ntt_multiply_binomials_cached(lhs, rhs, 7, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
 }
-
+#[inline(always)]
 pub(crate) fn ntt_multiply(
     lhs: &PortableVector,
     rhs: &PortableVector,

--- a/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
@@ -369,7 +369,7 @@ pub(crate) fn ntt_multiply_binomials(
 }
 
 #[inline(always)]
-pub(crate) fn ntt_multiply_binomials_caching(
+pub(crate) fn accumulating_ntt_multiply_binomials_fill_cache(
     a: &PortableVector,
     b: &PortableVector,
     zeta: FieldElementTimesMontgomeryR,
@@ -465,7 +465,7 @@ pub(crate) fn ntt_multiply_binomials_caching(
 }
 
 #[inline(always)]
-pub(crate) fn ntt_multiply_binomials_cached(
+pub(crate) fn accumulating_ntt_multiply_binomials_use_cache(
     a: &PortableVector,
     b: &PortableVector,
     i: usize,
@@ -576,7 +576,7 @@ pub(crate) fn ntt_multiply_binomials_cached(
             let oj = Seq.index result.f_elements (2 * i + 1) in
             ((v oi % 3329) == (((v ai * v bi + (v aj * v bj * (Seq.index zetas i) * 169)) * 169) % 3329)) /\
             ((v oj % 3329) == (((v ai * v bj + v aj * v bi) * 169) % 3329)))))"#))]
-pub(crate) fn ntt_multiply_caching(
+pub(crate) fn accumulating_ntt_multiply_fill_cache(
     lhs: &PortableVector,
     rhs: &PortableVector,
     out: &mut [i32],
@@ -595,26 +595,26 @@ pub(crate) fn ntt_multiply_caching(
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, zeta0, 0, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, zeta0, 0, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, nzeta0, 1, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, nzeta0, 1, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, zeta1, 2, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, zeta1, 2, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, nzeta1, 3, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, nzeta1, 3, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, zeta2, 4, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, zeta2, 4, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, nzeta2, 5, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, nzeta2, 5, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, zeta3, 6, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, zeta3, 6, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, nzeta3, 7, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, nzeta3, 7, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
 }
 
 #[inline(always)]
-pub(crate) fn ntt_multiply_cached(
+pub(crate) fn accumulating_ntt_multiply_use_cache(
     lhs: &PortableVector,
     rhs: &PortableVector,
     out: &mut [i32],
@@ -625,21 +625,21 @@ pub(crate) fn ntt_multiply_cached(
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 0, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 0, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 1, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 1, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 2, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 2, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 3, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 3, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 4, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 4, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 5, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 5, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 6, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 6, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 7, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 7, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
 }
 #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
@@ -374,7 +374,7 @@ pub(crate) fn ntt_multiply_binomials_caching(
     b: &PortableVector,
     zeta: FieldElementTimesMontgomeryR,
     i: usize,
-    out: &mut PortableVector,
+    out: &mut [i32],
     cache: &mut PortableVector,
 ) {
     let ai = a.elements[2 * i];
@@ -401,7 +401,7 @@ pub(crate) fn ntt_multiply_binomials_caching(
     let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
-    let o0 = montgomery_reduce_element(ai_bi_aj_bj);
+    let o0 = ai_bi_aj_bj;
     hax_lib::fstar!(
         r#"calc  ( == ) {
         v $o0 % 3329;
@@ -438,7 +438,7 @@ pub(crate) fn ntt_multiply_binomials_caching(
     let ai_bj_aj_bi = ai_bj + aj_bi;
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*3328) ai_bj_aj_bi) "#);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 3328 <= 3328 * pow2 15)"#);
-    let o1 = montgomery_reduce_element(ai_bj_aj_bi);
+    let o1 = ai_bj_aj_bi;
     hax_lib::fstar!(
         "calc  ( == ) {
         v $o1 % 3329;
@@ -452,9 +452,8 @@ pub(crate) fn ntt_multiply_binomials_caching(
         ((v ai * v bj + v aj * v bi) * 169) % 3329;
     }"
     );
-    let _out0 = out.elements;
-    out.elements[2 * i] = o0;
-    out.elements[2 * i + 1] = o1;
+    out[2 * i] += o0;
+    out[2 * i + 1] += o1;
     hax_lib::fstar!(
         r#"assert (Seq.index out.f_elements (2 * v i) == o0);
                      assert (Seq.index out.f_elements (2 * v i + 1) == o1);
@@ -470,7 +469,8 @@ pub(crate) fn ntt_multiply_binomials_cached(
     a: &PortableVector,
     b: &PortableVector,
     i: usize,
-    out: &mut PortableVector,
+    out: &mut [i32],
+
     cache: &PortableVector,
 ) {
     let ai = a.elements[2 * i];
@@ -493,7 +493,7 @@ pub(crate) fn ntt_multiply_binomials_cached(
     let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
-    let o0 = montgomery_reduce_element(ai_bi_aj_bj);
+    let o0 = ai_bi_aj_bj;
     hax_lib::fstar!(
         r#"calc  ( == ) {
         v $o0 % 3329;
@@ -530,7 +530,7 @@ pub(crate) fn ntt_multiply_binomials_cached(
     let ai_bj_aj_bi = ai_bj + aj_bi;
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*3328) ai_bj_aj_bi) "#);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 3328 <= 3328 * pow2 15)"#);
-    let o1 = montgomery_reduce_element(ai_bj_aj_bi);
+    let o1 = ai_bj_aj_bi;
     hax_lib::fstar!(
         "calc  ( == ) {
         v $o1 % 3329;
@@ -544,9 +544,8 @@ pub(crate) fn ntt_multiply_binomials_cached(
         ((v ai * v bj + v aj * v bi) * 169) % 3329;
     }"
     );
-    let _out0 = out.elements;
-    out.elements[2 * i] = o0;
-    out.elements[2 * i + 1] = o1;
+    out[2 * i] += o0;
+    out[2 * i + 1] += o1;
     hax_lib::fstar!(
         r#"assert (Seq.index out.f_elements (2 * v i) == o0);
                      assert (Seq.index out.f_elements (2 * v i + 1) == o1);
@@ -580,7 +579,7 @@ pub(crate) fn ntt_multiply_binomials_cached(
 pub(crate) fn ntt_multiply_caching(
     lhs: &PortableVector,
     rhs: &PortableVector,
-    out: &mut PortableVector,
+    out: &mut [i32],
     cache: &mut PortableVector,
     zeta0: i16,
     zeta1: i16,
@@ -618,7 +617,7 @@ pub(crate) fn ntt_multiply_caching(
 pub(crate) fn ntt_multiply_cached(
     lhs: &PortableVector,
     rhs: &PortableVector,
-    out: &mut PortableVector,
+    out: &mut [i32],
     cache: &PortableVector,
 ) {
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta0)"#);

--- a/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
@@ -296,11 +296,198 @@ pub(crate) fn ntt_multiply_binomials(
     hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bi"#);
     let ai_bi = (ai as i32) * (bi as i32);
     hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bj"#);
-    let aj_bj_ = (aj as i32) * (bj as i32);
+    let bj_zeta_ = (bj as i32) * (zeta as i32);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 <= 3328 * pow2 15)"#);
-    let aj_bj = montgomery_reduce_element(aj_bj_);
+    let bj_zeta = montgomery_reduce_element(bj_zeta_);
     hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 1664 $aj_bj $zeta"#);
-    let aj_bj_zeta = (aj_bj as i32) * (zeta as i32);
+    let aj_bj_zeta = (aj as i32) * (bj_zeta as i32);
+    let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
+    hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
+    hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
+    let o0 = montgomery_reduce_element(ai_bi_aj_bj);
+    hax_lib::fstar!(
+        r#"calc  ( == ) {
+        v $o0 % 3329;
+        ( == ) { () }
+        (v $ai_bi_aj_bj * 169) % 3329;
+        ( == ) { assert(v $ai_bi_aj_bj == v $ai_bi + v $aj_bj_zeta) }
+        ((v $ai_bi + v $aj_bj_zeta) * 169) % 3329;
+        ( == ) { assert (v $ai_bi == v $ai * v $bi) }
+        (((v $ai * v $bi) + v $aj_bj_zeta) * 169) % 3329;
+        ( == ) { assert (v $aj_bj_zeta == v $aj_bj * v $zeta) }
+        (((v $ai * v $bi) + (v $aj_bj * v $zeta)) * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l ((v ai * v bi) + (v aj_bj * v zeta)) 169 3329 }
+        ((((v $ai * v $bi) + (v $aj_bj * v $zeta)) % 3329) * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_add_distr (v ai * v bi) (v aj_bj * v zeta) 3329 }
+        (((v $ai * v $bi) + ((v $aj_bj * v $zeta) % 3329)) % 3329 * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l (v aj_bj) (v zeta) 3329 }
+        (((v $ai * v $bi) + ((v $aj_bj % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
+        ( == ) { assert(v aj_bj % 3329 == (v $aj_bj_ * 169) % 3329) }
+        (((v $ai * v $bi) + (((v $aj_bj_ * 169) % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
+        ( == ) { assert(v $aj_bj_ == v $aj * v $bj) }
+        (((v $ai * v $bi) + (((v $aj * v $bj * 169) % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l (v $aj * v $bj * 169) (v $zeta) 3329 }
+        (((v $ai * v $bi) + (((v $aj * v $bj * 169 * v $zeta) % 3329))) % 3329 * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_add_distr (v $ai * v $bi) (v $aj * v $bj * 169 * v $zeta) 3329 }
+        (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) % 3329 * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l ((v ai * v bi) + ((v aj * v bj * 169 * v zeta))) 169 3329 }
+        (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) * 169) % 3329;
+        }"#
+    );
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bj"#);
+    let ai_bj = (ai as i32) * (bj as i32);
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bi"#);
+    let aj_bi = (aj as i32) * (bi as i32);
+    let ai_bj_aj_bi = ai_bj + aj_bi;
+    hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*3328) ai_bj_aj_bi) "#);
+    hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 3328 <= 3328 * pow2 15)"#);
+    let o1 = montgomery_reduce_element(ai_bj_aj_bi);
+    hax_lib::fstar!(
+        "calc  ( == ) {
+        v $o1 % 3329;
+        ( == ) { () }
+        (v $ai_bj_aj_bi * 169) % 3329;
+        ( == ) { assert(v $ai_bj_aj_bi == v $ai_bj + v $aj_bi) }
+        ((v $ai_bj + v $aj_bi) * 169) % 3329;
+        ( == ) { assert (v ai_bj == v ai * v bj) }
+        ((v ai * v bj + v aj_bi) * 169) % 3329;
+        ( == ) { assert (v aj_bi == v aj * v bi) }
+        ((v ai * v bj + v aj * v bi) * 169) % 3329;
+    }"
+    );
+    let _out0 = out.elements;
+    out.elements[2 * i] = o0;
+    out.elements[2 * i + 1] = o1;
+    hax_lib::fstar!(
+        r#"assert (Seq.index out.f_elements (2 * v i) == o0);
+                     assert (Seq.index out.f_elements (2 * v i + 1) == o1);
+                     assert (Spec.Utils.is_i16b_array 3328 out.f_elements);
+                     assert (forall k. (k <> 2 * v i /\ k <> 2 * v i + 1) ==>
+                                        Seq.index out.f_elements k ==
+                                        Seq.index ${_out0} k)"#
+    );
+}
+
+pub(crate) fn ntt_multiply_binomials_caching(
+    a: &PortableVector,
+    b: &PortableVector,
+    zeta: FieldElementTimesMontgomeryR,
+    i: usize,
+    out: &mut PortableVector,
+    cache: &mut PortableVector,
+) {
+    let ai = a.elements[2 * i];
+    let bi = b.elements[2 * i];
+    let aj = a.elements[2 * i + 1];
+    let bj = b.elements[2 * i + 1];
+    hax_lib::fstar!(
+        "assert(Spec.Utils.is_i16b 3328 $ai);
+                     assert(Spec.Utils.is_i16b 3328 $bi);
+                     assert(Spec.Utils.is_i16b 3328 $aj);
+                     assert(Spec.Utils.is_i16b 3328 $bj);
+                     assert_norm (3328 * 3328 < pow2 31)"
+    );
+
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bi"#);
+    let ai_bi = (ai as i32) * (bi as i32);
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bj"#);
+    let bj_zeta_ = (bj as i32) * (zeta as i32);
+    hax_lib::fstar!(r#"assert_norm (3328 * 3328 <= 3328 * pow2 15)"#);
+    let bj_zeta = montgomery_reduce_element(bj_zeta_);
+    cache.elements[i] = bj_zeta;
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 1664 $aj_bj $zeta"#);
+    let aj_bj_zeta = (aj as i32) * (bj_zeta as i32);
+    let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
+    hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
+    hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
+    let o0 = montgomery_reduce_element(ai_bi_aj_bj);
+    hax_lib::fstar!(
+        r#"calc  ( == ) {
+        v $o0 % 3329;
+        ( == ) { () }
+        (v $ai_bi_aj_bj * 169) % 3329;
+        ( == ) { assert(v $ai_bi_aj_bj == v $ai_bi + v $aj_bj_zeta) }
+        ((v $ai_bi + v $aj_bj_zeta) * 169) % 3329;
+        ( == ) { assert (v $ai_bi == v $ai * v $bi) }
+        (((v $ai * v $bi) + v $aj_bj_zeta) * 169) % 3329;
+        ( == ) { assert (v $aj_bj_zeta == v $aj_bj * v $zeta) }
+        (((v $ai * v $bi) + (v $aj_bj * v $zeta)) * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l ((v ai * v bi) + (v aj_bj * v zeta)) 169 3329 }
+        ((((v $ai * v $bi) + (v $aj_bj * v $zeta)) % 3329) * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_add_distr (v ai * v bi) (v aj_bj * v zeta) 3329 }
+        (((v $ai * v $bi) + ((v $aj_bj * v $zeta) % 3329)) % 3329 * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l (v aj_bj) (v zeta) 3329 }
+        (((v $ai * v $bi) + ((v $aj_bj % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
+        ( == ) { assert(v aj_bj % 3329 == (v $aj_bj_ * 169) % 3329) }
+        (((v $ai * v $bi) + (((v $aj_bj_ * 169) % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
+        ( == ) { assert(v $aj_bj_ == v $aj * v $bj) }
+        (((v $ai * v $bi) + (((v $aj * v $bj * 169) % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l (v $aj * v $bj * 169) (v $zeta) 3329 }
+        (((v $ai * v $bi) + (((v $aj * v $bj * 169 * v $zeta) % 3329))) % 3329 * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_add_distr (v $ai * v $bi) (v $aj * v $bj * 169 * v $zeta) 3329 }
+        (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) % 3329 * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l ((v ai * v bi) + ((v aj * v bj * 169 * v zeta))) 169 3329 }
+        (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) * 169) % 3329;
+        }"#
+    );
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bj"#);
+    let ai_bj = (ai as i32) * (bj as i32);
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bi"#);
+    let aj_bi = (aj as i32) * (bi as i32);
+    let ai_bj_aj_bi = ai_bj + aj_bi;
+    hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*3328) ai_bj_aj_bi) "#);
+    hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 3328 <= 3328 * pow2 15)"#);
+    let o1 = montgomery_reduce_element(ai_bj_aj_bi);
+    hax_lib::fstar!(
+        "calc  ( == ) {
+        v $o1 % 3329;
+        ( == ) { () }
+        (v $ai_bj_aj_bi * 169) % 3329;
+        ( == ) { assert(v $ai_bj_aj_bi == v $ai_bj + v $aj_bi) }
+        ((v $ai_bj + v $aj_bi) * 169) % 3329;
+        ( == ) { assert (v ai_bj == v ai * v bj) }
+        ((v ai * v bj + v aj_bi) * 169) % 3329;
+        ( == ) { assert (v aj_bi == v aj * v bi) }
+        ((v ai * v bj + v aj * v bi) * 169) % 3329;
+    }"
+    );
+    let _out0 = out.elements;
+    out.elements[2 * i] = o0;
+    out.elements[2 * i + 1] = o1;
+    hax_lib::fstar!(
+        r#"assert (Seq.index out.f_elements (2 * v i) == o0);
+                     assert (Seq.index out.f_elements (2 * v i + 1) == o1);
+                     assert (Spec.Utils.is_i16b_array 3328 out.f_elements);
+                     assert (forall k. (k <> 2 * v i /\ k <> 2 * v i + 1) ==>
+                                        Seq.index out.f_elements k ==
+                                        Seq.index ${_out0} k)"#
+    );
+}
+
+pub(crate) fn ntt_multiply_binomials_cached(
+    a: &PortableVector,
+    b: &PortableVector,
+    i: usize,
+    out: &mut PortableVector,
+    cache: &PortableVector,
+) {
+    let ai = a.elements[2 * i];
+    let bi = b.elements[2 * i];
+    let aj = a.elements[2 * i + 1];
+    let bj = b.elements[2 * i + 1];
+    hax_lib::fstar!(
+        "assert(Spec.Utils.is_i16b 3328 $ai);
+                     assert(Spec.Utils.is_i16b 3328 $bi);
+                     assert(Spec.Utils.is_i16b 3328 $aj);
+                     assert(Spec.Utils.is_i16b 3328 $bj);
+                     assert_norm (3328 * 3328 < pow2 31)"
+    );
+
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bi"#);
+    let ai_bi = (ai as i32) * (bi as i32);
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bj"#);
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 1664 $aj_bj $zeta"#);
+    let aj_bj_zeta = (aj as i32) * (cache.elements[i] as i32);
     let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
@@ -388,6 +575,72 @@ pub(crate) fn ntt_multiply_binomials(
             let oj = Seq.index result.f_elements (2 * i + 1) in
             ((v oi % 3329) == (((v ai * v bi + (v aj * v bj * (Seq.index zetas i) * 169)) * 169) % 3329)) /\
             ((v oj % 3329) == (((v ai * v bj + v aj * v bi) * 169) % 3329)))))"#))]
+pub(crate) fn ntt_multiply_caching(
+    lhs: &PortableVector,
+    rhs: &PortableVector,
+    out: &mut PortableVector,
+    cache: &mut PortableVector,
+    zeta0: i16,
+    zeta1: i16,
+    zeta2: i16,
+    zeta3: i16,
+) {
+    let nzeta0 = -zeta0;
+    let nzeta1 = -zeta1;
+    let nzeta2 = -zeta2;
+    let nzeta3 = -zeta3;
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta0)"#);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta1)"#);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_caching(lhs, rhs, zeta0, 0, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_caching(lhs, rhs, nzeta0, 1, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_caching(lhs, rhs, zeta1, 2, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_caching(lhs, rhs, nzeta1, 3, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_caching(lhs, rhs, zeta2, 4, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_caching(lhs, rhs, nzeta2, 5, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_caching(lhs, rhs, zeta3, 6, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_caching(lhs, rhs, nzeta3, 7, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+}
+
+pub(crate) fn ntt_multiply_cached(
+    lhs: &PortableVector,
+    rhs: &PortableVector,
+    out: &mut PortableVector,
+    cache: &PortableVector,
+) {
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta0)"#);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta1)"#);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_cached(lhs, rhs, 0, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_cached(lhs, rhs, 1, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_cached(lhs, rhs, 2, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_cached(lhs, rhs, 3, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_cached(lhs, rhs, 4, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_cached(lhs, rhs, 5, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_cached(lhs, rhs, 6, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    ntt_multiply_binomials_cached(lhs, rhs, 7, out, cache);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+}
+
 pub(crate) fn ntt_multiply(
     lhs: &PortableVector,
     rhs: &PortableVector,

--- a/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
@@ -274,101 +274,6 @@ pub(crate) fn inv_ntt_layer_3_step(vec: &mut PortableVector, zeta: i16) {
          let oj = Seq.index out_future.f_elements (2 * v $i + 1) in
          ((v oi % 3329) == (((v ai * v bi + (v aj * v bj * v zeta * 169)) * 169) % 3329)) /\
          ((v oj % 3329) == (((v ai * v bj + v aj * v bi) * 169) % 3329)))"#))]
-pub(crate) fn ntt_multiply_binomials(
-    a: &PortableVector,
-    b: &PortableVector,
-    zeta: FieldElementTimesMontgomeryR,
-    i: usize,
-    out: &mut PortableVector,
-) {
-    let ai = a.elements[2 * i];
-    let bi = b.elements[2 * i];
-    let aj = a.elements[2 * i + 1];
-    let bj = b.elements[2 * i + 1];
-    hax_lib::fstar!(
-        "assert(Spec.Utils.is_i16b 3328 $ai);
-                     assert(Spec.Utils.is_i16b 3328 $bi);
-                     assert(Spec.Utils.is_i16b 3328 $aj);
-                     assert(Spec.Utils.is_i16b 3328 $bj);
-                     assert_norm (3328 * 3328 < pow2 31)"
-    );
-
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bi"#);
-    let ai_bi = (ai as i32) * (bi as i32);
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bj"#);
-    let bj_zeta_ = (bj as i32) * (zeta as i32);
-    hax_lib::fstar!(r#"assert_norm (3328 * 3328 <= 3328 * pow2 15)"#);
-    let bj_zeta = montgomery_reduce_element(bj_zeta_);
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 1664 $aj_bj $zeta"#);
-    let aj_bj_zeta = (aj as i32) * (bj_zeta as i32);
-    let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
-    hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
-    hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
-    let o0 = montgomery_reduce_element(ai_bi_aj_bj);
-    hax_lib::fstar!(
-        r#"calc  ( == ) {
-        v $o0 % 3329;
-        ( == ) { () }
-        (v $ai_bi_aj_bj * 169) % 3329;
-        ( == ) { assert(v $ai_bi_aj_bj == v $ai_bi + v $aj_bj_zeta) }
-        ((v $ai_bi + v $aj_bj_zeta) * 169) % 3329;
-        ( == ) { assert (v $ai_bi == v $ai * v $bi) }
-        (((v $ai * v $bi) + v $aj_bj_zeta) * 169) % 3329;
-        ( == ) { assert (v $aj_bj_zeta == v $aj_bj * v $zeta) }
-        (((v $ai * v $bi) + (v $aj_bj * v $zeta)) * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l ((v ai * v bi) + (v aj_bj * v zeta)) 169 3329 }
-        ((((v $ai * v $bi) + (v $aj_bj * v $zeta)) % 3329) * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_add_distr (v ai * v bi) (v aj_bj * v zeta) 3329 }
-        (((v $ai * v $bi) + ((v $aj_bj * v $zeta) % 3329)) % 3329 * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l (v aj_bj) (v zeta) 3329 }
-        (((v $ai * v $bi) + ((v $aj_bj % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
-        ( == ) { assert(v aj_bj % 3329 == (v $aj_bj_ * 169) % 3329) }
-        (((v $ai * v $bi) + (((v $aj_bj_ * 169) % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
-        ( == ) { assert(v $aj_bj_ == v $aj * v $bj) }
-        (((v $ai * v $bi) + (((v $aj * v $bj * 169) % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l (v $aj * v $bj * 169) (v $zeta) 3329 }
-        (((v $ai * v $bi) + (((v $aj * v $bj * 169 * v $zeta) % 3329))) % 3329 * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_add_distr (v $ai * v $bi) (v $aj * v $bj * 169 * v $zeta) 3329 }
-        (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) % 3329 * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l ((v ai * v bi) + ((v aj * v bj * 169 * v zeta))) 169 3329 }
-        (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) * 169) % 3329;
-        }"#
-    );
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bj"#);
-    let ai_bj = (ai as i32) * (bj as i32);
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bi"#);
-    let aj_bi = (aj as i32) * (bi as i32);
-    let ai_bj_aj_bi = ai_bj + aj_bi;
-    hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*3328) ai_bj_aj_bi) "#);
-    hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 3328 <= 3328 * pow2 15)"#);
-    let o1 = montgomery_reduce_element(ai_bj_aj_bi);
-    hax_lib::fstar!(
-        "calc  ( == ) {
-        v $o1 % 3329;
-        ( == ) { () }
-        (v $ai_bj_aj_bi * 169) % 3329;
-        ( == ) { assert(v $ai_bj_aj_bi == v $ai_bj + v $aj_bi) }
-        ((v $ai_bj + v $aj_bi) * 169) % 3329;
-        ( == ) { assert (v ai_bj == v ai * v bj) }
-        ((v ai * v bj + v aj_bi) * 169) % 3329;
-        ( == ) { assert (v aj_bi == v aj * v bi) }
-        ((v ai * v bj + v aj * v bi) * 169) % 3329;
-    }"
-    );
-    let _out0 = out.elements;
-    out.elements[2 * i] = o0;
-    out.elements[2 * i + 1] = o1;
-    hax_lib::fstar!(
-        r#"assert (Seq.index out.f_elements (2 * v i) == o0);
-                     assert (Seq.index out.f_elements (2 * v i + 1) == o1);
-                     assert (Spec.Utils.is_i16b_array 3328 out.f_elements);
-                     assert (forall k. (k <> 2 * v i /\ k <> 2 * v i + 1) ==>
-                                        Seq.index out.f_elements k ==
-                                        Seq.index ${_out0} k)"#
-    );
-}
-
-#[inline(always)]
 pub(crate) fn accumulating_ntt_multiply_binomials_fill_cache(
     a: &PortableVector,
     b: &PortableVector,
@@ -557,13 +462,12 @@ pub(crate) fn accumulating_ntt_multiply_binomials_use_cache(
 }
 
 #[inline(always)]
-pub(crate) fn ntt_multiply_binomials_fill_cache(
+pub(crate) fn accumulating_ntt_multiply_binomials(
     a: &PortableVector,
     b: &PortableVector,
     zeta: FieldElementTimesMontgomeryR,
     i: usize,
-    out: &mut PortableVector,
-    cache: &mut PortableVector,
+    out: &mut [i32],
 ) {
     let ai = a.elements[2 * i];
     let bi = b.elements[2 * i];
@@ -583,13 +487,12 @@ pub(crate) fn ntt_multiply_binomials_fill_cache(
     let bj_zeta_ = (bj as i32) * (zeta as i32);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 <= 3328 * pow2 15)"#);
     let bj_zeta = montgomery_reduce_element(bj_zeta_);
-    cache.elements[i] = bj_zeta;
     hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 1664 $aj_bj $zeta"#);
     let aj_bj_zeta = (aj as i32) * (bj_zeta as i32);
     let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
-    let o0 = montgomery_reduce_element(ai_bi_aj_bj);
+    let o0 = ai_bi_aj_bj;
     hax_lib::fstar!(
         r#"calc  ( == ) {
         v $o0 % 3329;
@@ -626,7 +529,7 @@ pub(crate) fn ntt_multiply_binomials_fill_cache(
     let ai_bj_aj_bi = ai_bj + aj_bi;
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*3328) ai_bj_aj_bi) "#);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 3328 <= 3328 * pow2 15)"#);
-    let o1 = montgomery_reduce_element(ai_bj_aj_bi);
+    let o1 = ai_bj_aj_bi;
     hax_lib::fstar!(
         "calc  ( == ) {
         v $o1 % 3329;
@@ -640,9 +543,8 @@ pub(crate) fn ntt_multiply_binomials_fill_cache(
         ((v ai * v bj + v aj * v bi) * 169) % 3329;
     }"
     );
-    let _out0 = out.elements;
-    out.elements[2 * i] = o0;
-    out.elements[2 * i + 1] = o1;
+    out[2 * i] += o0;
+    out[2 * i + 1] += o1;
     hax_lib::fstar!(
         r#"assert (Seq.index out.f_elements (2 * v i) == o0);
                      assert (Seq.index out.f_elements (2 * v i + 1) == o1);
@@ -651,135 +553,6 @@ pub(crate) fn ntt_multiply_binomials_fill_cache(
                                         Seq.index out.f_elements k ==
                                         Seq.index ${_out0} k)"#
     );
-}
-
-#[inline(always)]
-pub(crate) fn ntt_multiply_binomials_use_cache(
-    a: &PortableVector,
-    b: &PortableVector,
-    i: usize,
-    out: &mut PortableVector,
-    cache: &PortableVector,
-) {
-    let ai = a.elements[2 * i];
-    let bi = b.elements[2 * i];
-    let aj = a.elements[2 * i + 1];
-    let bj = b.elements[2 * i + 1];
-    hax_lib::fstar!(
-        "assert(Spec.Utils.is_i16b 3328 $ai);
-                     assert(Spec.Utils.is_i16b 3328 $bi);
-                     assert(Spec.Utils.is_i16b 3328 $aj);
-                     assert(Spec.Utils.is_i16b 3328 $bj);
-                     assert_norm (3328 * 3328 < pow2 31)"
-    );
-
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bi"#);
-    let ai_bi = (ai as i32) * (bi as i32);
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bj"#);
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 1664 $aj_bj $zeta"#);
-    let aj_bj_zeta = (aj as i32) * (cache.elements[i] as i32);
-    let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
-    hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
-    hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
-    let o0 = montgomery_reduce_element(ai_bi_aj_bj);
-    hax_lib::fstar!(
-        r#"calc  ( == ) {
-        v $o0 % 3329;
-        ( == ) { () }
-        (v $ai_bi_aj_bj * 169) % 3329;
-        ( == ) { assert(v $ai_bi_aj_bj == v $ai_bi + v $aj_bj_zeta) }
-        ((v $ai_bi + v $aj_bj_zeta) * 169) % 3329;
-        ( == ) { assert (v $ai_bi == v $ai * v $bi) }
-        (((v $ai * v $bi) + v $aj_bj_zeta) * 169) % 3329;
-        ( == ) { assert (v $aj_bj_zeta == v $aj_bj * v $zeta) }
-        (((v $ai * v $bi) + (v $aj_bj * v $zeta)) * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l ((v ai * v bi) + (v aj_bj * v zeta)) 169 3329 }
-        ((((v $ai * v $bi) + (v $aj_bj * v $zeta)) % 3329) * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_add_distr (v ai * v bi) (v aj_bj * v zeta) 3329 }
-        (((v $ai * v $bi) + ((v $aj_bj * v $zeta) % 3329)) % 3329 * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l (v aj_bj) (v zeta) 3329 }
-        (((v $ai * v $bi) + ((v $aj_bj % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
-        ( == ) { assert(v aj_bj % 3329 == (v $aj_bj_ * 169) % 3329) }
-        (((v $ai * v $bi) + (((v $aj_bj_ * 169) % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
-        ( == ) { assert(v $aj_bj_ == v $aj * v $bj) }
-        (((v $ai * v $bi) + (((v $aj * v $bj * 169) % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l (v $aj * v $bj * 169) (v $zeta) 3329 }
-        (((v $ai * v $bi) + (((v $aj * v $bj * 169 * v $zeta) % 3329))) % 3329 * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_add_distr (v $ai * v $bi) (v $aj * v $bj * 169 * v $zeta) 3329 }
-        (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) % 3329 * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l ((v ai * v bi) + ((v aj * v bj * 169 * v zeta))) 169 3329 }
-        (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) * 169) % 3329;
-        }"#
-    );
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bj"#);
-    let ai_bj = (ai as i32) * (bj as i32);
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bi"#);
-    let aj_bi = (aj as i32) * (bi as i32);
-    let ai_bj_aj_bi = ai_bj + aj_bi;
-    hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*3328) ai_bj_aj_bi) "#);
-    hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 3328 <= 3328 * pow2 15)"#);
-    let o1 = montgomery_reduce_element(ai_bj_aj_bi);
-    hax_lib::fstar!(
-        "calc  ( == ) {
-        v $o1 % 3329;
-        ( == ) { () }
-        (v $ai_bj_aj_bi * 169) % 3329;
-        ( == ) { assert(v $ai_bj_aj_bi == v $ai_bj + v $aj_bi) }
-        ((v $ai_bj + v $aj_bi) * 169) % 3329;
-        ( == ) { assert (v ai_bj == v ai * v bj) }
-        ((v ai * v bj + v aj_bi) * 169) % 3329;
-        ( == ) { assert (v aj_bi == v aj * v bi) }
-        ((v ai * v bj + v aj * v bi) * 169) % 3329;
-    }"
-    );
-    let _out0 = out.elements;
-    out.elements[2 * i] = o0;
-    out.elements[2 * i + 1] = o1;
-    hax_lib::fstar!(
-        r#"assert (Seq.index out.f_elements (2 * v i) == o0);
-                     assert (Seq.index out.f_elements (2 * v i + 1) == o1);
-                     assert (Spec.Utils.is_i16b_array 3328 out.f_elements);
-                     assert (forall k. (k <> 2 * v i /\ k <> 2 * v i + 1) ==>
-                                        Seq.index out.f_elements k ==
-                                        Seq.index ${_out0} k)"#
-    );
-}
-
-#[inline(always)]
-pub(crate) fn ntt_multiply(
-    lhs: &PortableVector,
-    rhs: &PortableVector,
-    out: &mut PortableVector,
-    zeta0: i16,
-    zeta1: i16,
-    zeta2: i16,
-    zeta3: i16,
-) {
-    let nzeta0 = -zeta0;
-    let nzeta1 = -zeta1;
-    let nzeta2 = -zeta2;
-    let nzeta3 = -zeta3;
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta0)"#);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta1)"#);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta0, 0, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta0, 1, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta1, 2, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta1, 3, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta2, 4, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta2, 5, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta3, 6, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta3, 7, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
 }
 
 #[inline(always)]
@@ -802,11 +575,10 @@ pub(crate) fn ntt_multiply(
             let oj = Seq.index result.f_elements (2 * i + 1) in
             ((v oi % 3329) == (((v ai * v bi + (v aj * v bj * (Seq.index zetas i) * 169)) * 169) % 3329)) /\
             ((v oj % 3329) == (((v ai * v bj + v aj * v bi) * 169) % 3329)))))"#))]
-pub(crate) fn ntt_multiply_fill_cache(
+pub(crate) fn accumulating_ntt_multiply(
     lhs: &PortableVector,
     rhs: &PortableVector,
-    out: &mut PortableVector,
-    cache: &mut PortableVector,
+    out: &mut [i32],
     zeta0: i16,
     zeta1: i16,
     zeta2: i16,
@@ -821,21 +593,21 @@ pub(crate) fn ntt_multiply_fill_cache(
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_fill_cache(lhs, rhs, zeta0, 0, out, cache);
+    accumulating_ntt_multiply_binomials(lhs, rhs, zeta0, 0, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_fill_cache(lhs, rhs, nzeta0, 1, out, cache);
+    accumulating_ntt_multiply_binomials(lhs, rhs, nzeta0, 1, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_fill_cache(lhs, rhs, zeta1, 2, out, cache);
+    accumulating_ntt_multiply_binomials(lhs, rhs, zeta1, 2, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_fill_cache(lhs, rhs, nzeta1, 3, out, cache);
+    accumulating_ntt_multiply_binomials(lhs, rhs, nzeta1, 3, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_fill_cache(lhs, rhs, zeta2, 4, out, cache);
+    accumulating_ntt_multiply_binomials(lhs, rhs, zeta2, 4, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_fill_cache(lhs, rhs, nzeta2, 5, out, cache);
+    accumulating_ntt_multiply_binomials(lhs, rhs, nzeta2, 5, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_fill_cache(lhs, rhs, zeta3, 6, out, cache);
+    accumulating_ntt_multiply_binomials(lhs, rhs, zeta3, 6, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_fill_cache(lhs, rhs, nzeta3, 7, out, cache);
+    accumulating_ntt_multiply_binomials(lhs, rhs, nzeta3, 7, out);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
 }
 
@@ -923,35 +695,5 @@ pub(crate) fn accumulating_ntt_multiply_use_cache(
     accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 6, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
     accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 7, out, cache);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-}
-
-#[inline(always)]
-pub(crate) fn ntt_multiply_use_cache(
-    lhs: &PortableVector,
-    rhs: &PortableVector,
-    out: &mut PortableVector,
-    cache: &PortableVector,
-) {
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta0)"#);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta1)"#);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_use_cache(lhs, rhs, 0, out, cache);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_use_cache(lhs, rhs, 1, out, cache);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_use_cache(lhs, rhs, 2, out, cache);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_use_cache(lhs, rhs, 3, out, cache);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_use_cache(lhs, rhs, 4, out, cache);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_use_cache(lhs, rhs, 5, out, cache);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_use_cache(lhs, rhs, 6, out, cache);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_use_cache(lhs, rhs, 7, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
 }

--- a/libcrux/libcrux-ml-kem/src/vector/portable/vector_type.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/vector_type.rs
@@ -1,5 +1,7 @@
 use crate::vector::traits::FIELD_ELEMENTS_IN_VECTOR;
 
+use super::arithmetic::montgomery_reduce_element;
+
 /// Values having this type hold a representative 'x' of the ML-KEM field.
 /// We use 'fe' as a shorthand for this type.
 pub(crate) type FieldElement = i16;
@@ -28,6 +30,15 @@ pub fn to_i16_array(x: PortableVector, out: &mut [i16; 16]) {
 #[hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == $array"#))]
 pub fn from_i16_array(array: &[i16], out: &mut PortableVector) {
     out.elements = array[0..16].try_into().unwrap();
+}
+
+#[inline(always)]
+#[hax_lib::requires(array.len() == 16)]
+#[hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == $array"#))]
+pub fn reducing_from_i32_array(array: &[i32], out: &mut PortableVector) {
+    for i in 0..16 {
+        out.elements[i] = montgomery_reduce_element(array[i]);
+    }
 }
 
 #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/traits.rs
@@ -143,28 +143,15 @@ pub trait Operations: Copy + Clone + Repr {
                        Spec.Utils.is_i16b_array 3328 (f_repr ${lhs}) /\
                        Spec.Utils.is_i16b_array 3328 (f_repr ${rhs}) "#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#))]
-    fn ntt_multiply(
+    fn accumulating_ntt_multiply(
         lhs: &Self,
         rhs: &Self,
-        out: &mut Self,
+        out: &mut [i32],
         zeta0: i16,
         zeta1: i16,
         zeta2: i16,
         zeta3: i16,
     );
-
-    fn ntt_multiply_fill_cache(
-        lhs: &Self,
-        rhs: &Self,
-        out: &mut Self,
-        cache: &mut Self,
-        zeta0: i16,
-        zeta1: i16,
-        zeta2: i16,
-        zeta3: i16,
-    );
-
-    fn ntt_multiply_use_cache(lhs: &Self, rhs: &Self, out: &mut Self, cache: &Self);
 
     fn accumulating_ntt_multiply_fill_cache(
         lhs: &Self,

--- a/libcrux/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/traits.rs
@@ -149,7 +149,7 @@ pub trait Operations: Copy + Clone + Repr {
         zeta3: i16,
     );
 
-    fn ntt_multiply_caching(
+    fn accumulating_ntt_multiply_fill_cache(
         lhs: &Self,
         rhs: &Self,
         accumulator: &mut [i32], // length: 16
@@ -160,7 +160,12 @@ pub trait Operations: Copy + Clone + Repr {
         zeta3: i16,
     );
 
-    fn ntt_multiply_cached(lhs: &Self, rhs: &Self, accumulator: &mut [i32], cache: &Self);
+    fn accumulating_ntt_multiply_use_cache(
+        lhs: &Self,
+        rhs: &Self,
+        accumulator: &mut [i32],
+        cache: &Self,
+    );
 
     // Serialization and deserialization
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (f_repr $a)"#))]

--- a/libcrux/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/traits.rs
@@ -25,6 +25,10 @@ pub trait Operations: Copy + Clone + Repr {
     #[ensures(|result| fstar!(r#"f_repr $result == $array"#))]
     fn from_i16_array(array: &[i16], out: &mut Self);
 
+    #[requires(array.len() == 16)]
+    #[ensures(|result| fstar!(r#"f_repr $result == $array"#))]
+    fn reducing_from_i32_array(array: &[i32], out: &mut Self);
+
     #[requires(true)]
     #[ensures(|result| fstar!(r#"f_repr $x == $result"#))]
     fn to_i16_array(x: Self, out: &mut [i16; 16]);
@@ -148,6 +152,19 @@ pub trait Operations: Copy + Clone + Repr {
         zeta2: i16,
         zeta3: i16,
     );
+
+    fn ntt_multiply_fill_cache(
+        lhs: &Self,
+        rhs: &Self,
+        out: &mut Self,
+        cache: &mut Self,
+        zeta0: i16,
+        zeta1: i16,
+        zeta2: i16,
+        zeta3: i16,
+    );
+
+    fn ntt_multiply_use_cache(lhs: &Self, rhs: &Self, out: &mut Self, cache: &Self);
 
     fn accumulating_ntt_multiply_fill_cache(
         lhs: &Self,

--- a/libcrux/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/traits.rs
@@ -152,7 +152,7 @@ pub trait Operations: Copy + Clone + Repr {
     fn ntt_multiply_caching(
         lhs: &Self,
         rhs: &Self,
-        out: &mut Self,
+        accumulator: &mut [i32], // length: 16
         cache: &mut Self,
         zeta0: i16,
         zeta1: i16,
@@ -160,7 +160,7 @@ pub trait Operations: Copy + Clone + Repr {
         zeta3: i16,
     );
 
-    fn ntt_multiply_cached(lhs: &Self, rhs: &Self, out: &mut Self, cache: &Self);
+    fn ntt_multiply_cached(lhs: &Self, rhs: &Self, accumulator: &mut [i32], cache: &Self);
 
     // Serialization and deserialization
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (f_repr $a)"#))]

--- a/libcrux/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/traits.rs
@@ -216,6 +216,7 @@ pub trait Operations: Copy + Clone + Repr {
         fstar!(r#"Seq.length $out_future == Seq.length $out /\ v $result <= 16"#)
     )]
     fn rej_sample(a: &[u8], out: &mut [i16]) -> usize;
+    fn to_unsigned_representative(a: &mut Self);
 }
 
 // The trait is duplicated for Eurudice to avoid the trait inheritance between Operations and Repr

--- a/libcrux/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/traits.rs
@@ -84,8 +84,9 @@ pub trait Operations: Copy + Clone + Repr {
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 c"#))]
     fn montgomery_multiply_by_constant(v: &mut Self, c: i16);
 
-    fn montgomery_butterfly(a: &mut Self, b: &mut Self, fer: i16);
-    fn butterfly(a: &mut Self, b: &mut Self, fer: i16);
+    fn montgomery_ct_butterfly(a: &mut Self, b: &mut Self, fer: i16);
+    fn ct_butterfly(a: &mut Self, b: &mut Self, fer: i16);
+    fn gs_butterfly(a: &mut Self, b: &mut Self, fer: i16);
     // Compression
     #[requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (f_repr $a) i) >= 0 /\
         v (Seq.index (f_repr $a) i) < 3329"#))]
@@ -235,8 +236,9 @@ pub trait Operations: Copy + Clone {
     fn cond_subtract_3329(v: Self) -> Self;
     fn barrett_reduce(vector: Self) -> Self;
     fn montgomery_multiply_by_constant(v: Self, c: i16) -> Self;
-    fn montgomery_butterfly(a: &mut Self, b: &mut Self, fer: i16);
-    fn butterfly(a: &mut Self, b: &mut Self, fer: i16);
+    fn montgomery_ct_butterfly(a: &mut Self, b: &mut Self, fer: i16);
+    fn ct_butterfly(a: &mut Self, b: &mut Self, fer: i16);
+    fn gs_butterfly(a: &mut Self, b: &mut Self, fer: i16);
     fn compress_1(v: Self) -> Self;
     fn compress<const COEFFICIENT_BITS: i32>(v: Self) -> Self;
     fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(a: Self) -> Self;

--- a/libcrux/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/traits.rs
@@ -84,6 +84,8 @@ pub trait Operations: Copy + Clone + Repr {
     #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 c"#))]
     fn montgomery_multiply_by_constant(v: &mut Self, c: i16);
 
+    fn montgomery_butterfly(a: &mut Self, b: &mut Self, fer: i16);
+    fn butterfly(a: &mut Self, b: &mut Self, fer: i16);
     // Compression
     #[requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (f_repr $a) i) >= 0 /\
         v (Seq.index (f_repr $a) i) < 3329"#))]
@@ -233,6 +235,8 @@ pub trait Operations: Copy + Clone {
     fn cond_subtract_3329(v: Self) -> Self;
     fn barrett_reduce(vector: Self) -> Self;
     fn montgomery_multiply_by_constant(v: Self, c: i16) -> Self;
+    fn montgomery_butterfly(a: &mut Self, b: &mut Self, fer: i16);
+    fn butterfly(a: &mut Self, b: &mut Self, fer: i16);
     fn compress_1(v: Self) -> Self;
     fn compress<const COEFFICIENT_BITS: i32>(v: Self) -> Self;
     fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(a: Self) -> Self;

--- a/libcrux/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/traits.rs
@@ -149,6 +149,19 @@ pub trait Operations: Copy + Clone + Repr {
         zeta3: i16,
     );
 
+    fn ntt_multiply_caching(
+        lhs: &Self,
+        rhs: &Self,
+        out: &mut Self,
+        cache: &mut Self,
+        zeta0: i16,
+        zeta1: i16,
+        zeta2: i16,
+        zeta3: i16,
+    );
+
+    fn ntt_multiply_cached(lhs: &Self, rhs: &Self, out: &mut Self, cache: &Self);
+
     // Serialization and deserialization
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (f_repr $a)"#))]
     #[ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 1 (f_repr $a) ==> Spec.MLKEM.serialize_post 1 (f_repr $a) $result"#))]

--- a/sys/pqm4/build.rs
+++ b/sys/pqm4/build.rs
@@ -38,7 +38,7 @@ fn build() {
     {
         panic!("git could not update submodules.")
     }
-    
+
     if !std::process::Command::new("git")
         .arg("-C")
         .arg("pqm4")
@@ -50,7 +50,7 @@ fn build() {
     {
         panic!("git could not checkout submodule branch `origin/pqm4-bindings`.")
     }
-    
+
     if !std::process::Command::new("make")
         .arg("-C")
         .arg("pqm4")
@@ -68,9 +68,10 @@ fn build() {
 
     std::fs::create_dir(lib_path).unwrap();
 
-    
-    let lib_path = lib_path.canonicalize().unwrap_or_else(|_| panic!("Could not canonicalize {lib_path:?}"));
-    
+    let lib_path = lib_path
+        .canonicalize()
+        .unwrap_or_else(|_| panic!("Could not canonicalize {lib_path:?}"));
+
     // Tell cargo to look for shared libraries in the specified directory
     println!("cargo:rustc-link-search={}", lib_path.to_str().unwrap());
 
@@ -112,8 +113,9 @@ pub fn main() {
     // Build the C/ASM files
     build();
 
-    // Set re-run trigger for all of s
-    println!("cargo:rerun-if-changed=pqm4");
+    // XXX: Disabling this, since the `build` process will always
+    // update `pqm4/common/keccakf1600.S` and trigger a rebuild.
+    // println!("cargo:rerun-if-changed=pqm4");
 
     // Generate new bindings. This is a no-op on Windows.
     create_bindings(home_path);


### PR DESCRIPTION
This PR implements two optimizations for the NTT base multiplication, both described in [AHKS22, section 3.4](https://kannwischer.eu/papers/2022_fasterkyberdilithiumm4.pdf)
- Caching of intermediate results in the matrix vector product. Namely, when computing `A * s`,  for each entry of the output vector, the same products between entries of `s` and the twiddle factors (`zeta`s) have to be computed as an intermediate result. The optimization is to cache (in reduced form) these when computing the first output entry, and then to re-use the cached values on the remaining output entries. If the matrix-vector product is then followed by an inner product with the same vector operand as the matrix-vector product, the cache can be used again. This is the case during CPA encryption.
- Improved accumulation strategy. Each output entry of the matrix-vector product is the sum of `K` base multiplication results. As pointed out in the paper, with the given bounds on the inputs of the base multiplications, it is possible to delay reduction until all base multiplication results have been accumulated on the output entry, instead of reducing each multiplication result before adding it to the output vector. **NOTE:** Delaying these reductions will result in incorrect output if my understanding of the input bounds is incorrect (because it might be subtly different from e.g. the implementation the paper is based on). The test vectors are okay, but full confidence in the range analysis should come from a proof at some later point.

In addition, while I was touching many of these parts, I removed the necessity for `scratch` memory, hopefully reducing stack usage in the process. This didn't immediately help cycle performance, though.

For performance we have the following as a "before" state at https://github.com/cryspen/libcrux-iot/pull/71/commits/671b2ac3e1968fa9751e94ba1dd8a4a60a6c1840:
 ```
l,0,16000000,ML-KEM Benchmark
b,r,bench_keygen,0
b,d,bench_keygen,0,1853966
b,r,bench_keygen,1
b,d,bench_keygen,1,1853963
b,r,bench_keygen,2
b,d,bench_keygen,2,1853965
b,r,bench_keygen,3
b,d,bench_keygen,3,1853964
b,r,bench_keygen,4
b,d,bench_keygen,4,1853966
b,r,bench_encaps,0
b,d,bench_encaps,0,2031216
b,r,bench_encaps,1
b,d,bench_encaps,1,2031214
b,r,bench_encaps,2
b,d,bench_encaps,2,2031219
b,r,bench_encaps,3
b,d,bench_encaps,3,2031215
b,r,bench_encaps,4
b,d,bench_encaps,4,2031215
b,d,bench_decaps,0,2203216
b,r,bench_decaps,1
b,d,bench_decaps,1,2203220
b,r,bench_decaps,2
b,d,bench_decaps,2,2203217
b,r,bench_decaps,3
b,d,bench_decaps,3,2203216
b,r,bench_decaps,4
b,d,bench_decaps,4,2203215
```

And for the optimized version here:
```
l,0,16000000,ML-KEM Benchmark
b,r,bench_keygen,0
b,d,bench_keygen,0,1761452
b,r,bench_keygen,1
b,d,bench_keygen,1,1761454
b,r,bench_keygen,2
b,d,bench_keygen,2,1761454
b,r,bench_keygen,3
b,d,bench_keygen,3,1761452
b,r,bench_keygen,4
b,d,bench_keygen,4,1761452
b,r,bench_encaps,0
b,d,bench_encaps,0,1881337
b,r,bench_encaps,1
b,d,bench_encaps,1,1881339
b,r,bench_encaps,2
b,d,bench_encaps,2,1881340
b,r,bench_encaps,3
b,r,bench_encaps,4
b,d,bench_encaps,4,1881340
b,r,bench_decaps,0
b,d,bench_decaps,0,2051371
b,r,bench_decaps,1
b,d,bench_decaps,1,2051371
b,r,bench_decaps,2
b,d,bench_decaps,2,2051372
b,r,bench_decaps,3
b,d,bench_decaps,3,2051370
b,r,bench_decaps,4
b,d,bench_decaps,4,2051371
```

Thats around
- **5%** better for key generation
- **7%** better for encapsulation
- **7%** better for decapsulation

The caching and accumulation improvements are platform-independent as well. (Although the gains might of course not be the same on a different platform.)

Fixes #42 