### PR TITLE
Better accumulation strategy in NTT base multiplication

### DIFF
--- a/libcrux/libcrux-ml-kem/src/ind_cca.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca.rs
@@ -206,6 +206,7 @@ pub(crate) fn generate_keypair<
     let mut ind_cpa_private_key = [0u8; CPA_PRIVATE_KEY_SIZE];
     let mut public_key = [0u8; PUBLIC_KEY_SIZE];
     let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+    let mut accumulator = [0i32; 256];
     let mut s_cache = [PolynomialRingElement::<Vector>::ZERO(); K];
 
     crate::ind_cpa::generate_keypair::<
@@ -225,6 +226,7 @@ pub(crate) fn generate_keypair<
         &mut public_key,
         &mut scratch,
         &mut s_cache,
+        &mut accumulator,
     );
 
     let mut secret_key_serialized = [0u8; PRIVATE_KEY_SIZE];
@@ -302,6 +304,7 @@ pub(crate) fn encapsulate<
         core::array::from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
     let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
     let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+    let mut accumulator = [0i32; 256];
     let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
 
     crate::ind_cpa::encrypt::<
@@ -331,6 +334,7 @@ pub(crate) fn encapsulate<
         &mut error_2,
         &mut scratch,
         &mut cache,
+        &mut accumulator,
     );
 
     let ciphertext = MlKemCiphertext::from(ciphertext);
@@ -404,6 +408,7 @@ pub(crate) fn decapsulate<
     );
     let mut decrypted = [0u8; 32];
     let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+    let mut accumulator = [0i32; 256];
 
     crate::ind_cpa::decrypt::<
         K,
@@ -417,6 +422,7 @@ pub(crate) fn decapsulate<
         &ciphertext.value,
         &mut decrypted,
         &mut scratch,
+        &mut accumulator,
     );
 
     let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] = into_padded_array(&decrypted);
@@ -489,6 +495,7 @@ pub(crate) fn decapsulate<
         &mut error_2,
         &mut scratch,
         &mut cache,
+        &mut accumulator,
     );
 
     let mut implicit_rejection_shared_secret_kdf = [0u8; SHARED_SECRET_SIZE];
@@ -980,6 +987,8 @@ pub(crate) mod unpacked {
         let ind_cpa_keypair_randomness = &randomness[0..CPA_PKE_KEY_GENERATION_SEED_SIZE];
         let implicit_rejection_value = &randomness[CPA_PKE_KEY_GENERATION_SEED_SIZE..];
         let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+
+        let mut accumulator = [0i32; 256];
         let mut s_cache = [PolynomialRingElement::<Vector>::ZERO(); K];
         generate_keypair_unpacked::<
             K,
@@ -996,6 +1005,7 @@ pub(crate) mod unpacked {
             &mut out.public_key.ind_cpa_public_key,
             &mut scratch,
             &mut s_cache,
+            &mut accumulator,
         );
 
         #[allow(non_snake_case)]
@@ -1088,6 +1098,8 @@ pub(crate) mod unpacked {
             from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
         let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
         let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+
+        let mut accumulator = [0i32; 256];
         let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
         ind_cpa::encrypt_unpacked::<
             K,
@@ -1116,6 +1128,7 @@ pub(crate) mod unpacked {
             &mut error_2,
             &mut scratch,
             &mut cache,
+            &mut accumulator,
         );
         let mut shared_secret_array = [0u8; SHARED_SECRET_SIZE];
         shared_secret_array.copy_from_slice(shared_secret);
@@ -1203,6 +1216,8 @@ pub(crate) mod unpacked {
         let mut decrypted = [0u8; SHARED_SECRET_SIZE];
 
         let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+        let mut accumulator = [0i32; 256];
+
         ind_cpa::decrypt_unpacked::<
             K,
             CIPHERTEXT_SIZE,
@@ -1215,6 +1230,7 @@ pub(crate) mod unpacked {
             &ciphertext.value,
             &mut decrypted,
             &mut scratch,
+            &mut accumulator,
         );
 
         let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] = into_padded_array(&decrypted);
@@ -1276,6 +1292,7 @@ pub(crate) mod unpacked {
             &mut error_2,
             &mut scratch,
             &mut cache,
+            &mut accumulator,
         );
 
         let selector =

--- a/libcrux/libcrux-ml-kem/src/polynomial.rs
+++ b/libcrux/libcrux-ml-kem/src/polynomial.rs
@@ -72,6 +72,15 @@ fn from_i16_array<Vector: Operations>(a: &[i16], result: &mut PolynomialRingElem
     }
 }
 
+fn reducing_from_i32_array<Vector: Operations>(
+    a: &[i32],
+    result: &mut PolynomialRingElement<Vector>,
+) {
+    for i in 0..VECTORS_IN_RING_ELEMENT {
+        Vector::reducing_from_i32_array(&a[i * 16..(i + 1) * 16], &mut result.coefficients[i]);
+    }
+}
+
 #[allow(dead_code)]
 #[inline(always)]
 #[hax_lib::requires(out.len() >= VECTORS_IN_RING_ELEMENT * 16)]
@@ -142,19 +151,6 @@ pub(crate) fn vec_from_bytes<Vector: Operations>(
 #[allow(dead_code)]
 pub(crate) const fn vec_len_bytes<const K: usize, Vector: Operations>() -> usize {
     K * PolynomialRingElement::<Vector>::num_bytes()
-}
-
-/// Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
-/// sum of their constituent coefficients.
-#[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-fn add_to_ring_element<Vector: Operations, const K: usize>(
-    myself: &mut PolynomialRingElement<Vector>,
-    rhs: &PolynomialRingElement<Vector>,
-) {
-    for i in 0..myself.coefficients.len() {
-        Vector::add(&mut myself.coefficients[i], &rhs.coefficients[i]);
-    }
 }
 
 #[inline(always)]
@@ -283,17 +279,16 @@ fn add_standard_error_reduce<Vector: Operations>(
 //                 result.coefficients[i].abs() <= FIELD_MODULUS
 // ))))]
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-fn ntt_multiply<Vector: Operations>(
+fn accumulating_ntt_multiply<Vector: Operations>(
     myself: &PolynomialRingElement<Vector>,
     rhs: &PolynomialRingElement<Vector>,
-    out: &mut PolynomialRingElement<Vector>,
+    accumulator: &mut [i32; 256],
 ) {
     for i in 0..VECTORS_IN_RING_ELEMENT {
-        Vector::ntt_multiply(
+        Vector::accumulating_ntt_multiply(
             &myself.coefficients[i],
             &rhs.coefficients[i],
-            &mut out.coefficients[i],
+            &mut accumulator[i * 16..(i + 1) * 16],
             zeta(64 + 4 * i),
             zeta(64 + 4 * i + 1),
             zeta(64 + 4 * i + 2),
@@ -304,17 +299,17 @@ fn ntt_multiply<Vector: Operations>(
 
 #[inline(always)]
 #[hax_lib::fstar::verification_status(lax)]
-fn ntt_multiply_caching<Vector: Operations>(
+fn accumulating_ntt_multiply_fill_cache<Vector: Operations>(
     myself: &PolynomialRingElement<Vector>,
     rhs: &PolynomialRingElement<Vector>,
-    out: &mut PolynomialRingElement<Vector>,
+    accumulator: &mut [i32; 256],
     cache: &mut PolynomialRingElement<Vector>,
 ) {
     for i in 0..VECTORS_IN_RING_ELEMENT {
-        Vector::ntt_multiply_caching(
+        Vector::accumulating_ntt_multiply_fill_cache(
             &myself.coefficients[i],
             &rhs.coefficients[i],
-            &mut out.coefficients[i],
+            &mut accumulator[i * 16..(i + 1) * 16],
             &mut cache.coefficients[i],
             zeta(64 + 4 * i),
             zeta(64 + 4 * i + 1),
@@ -326,17 +321,17 @@ fn ntt_multiply_caching<Vector: Operations>(
 
 #[inline(always)]
 #[hax_lib::fstar::verification_status(lax)]
-fn ntt_multiply_cached<Vector: Operations>(
+fn accumulating_ntt_multiply_use_cache<Vector: Operations>(
     myself: &PolynomialRingElement<Vector>,
     rhs: &PolynomialRingElement<Vector>,
-    out: &mut PolynomialRingElement<Vector>,
+    accumulator: &mut [i32; 256],
     cache: &PolynomialRingElement<Vector>,
 ) {
     for i in 0..VECTORS_IN_RING_ELEMENT {
-        Vector::ntt_multiply_cached(
+        Vector::accumulating_ntt_multiply_use_cache(
             &myself.coefficients[i],
             &rhs.coefficients[i],
-            &mut out.coefficients[i],
+            &mut accumulator[i * 16..(i + 1) * 16],
             &cache.coefficients[i],
         );
     }
@@ -367,6 +362,12 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
         from_i16_array(a, out)
     }
 
+    #[inline(always)]
+    #[requires(VECTORS_IN_RING_ELEMENT * 16 <= a.len())]
+    pub(crate) fn reducing_from_i32_array(a: &[i32], out: &mut Self) {
+        reducing_from_i32_array(a, out)
+    }
+
     #[allow(dead_code)]
     #[inline(always)]
     #[requires(VECTORS_IN_RING_ELEMENT * 16 <= out.len())]
@@ -386,13 +387,6 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
     #[requires(VECTORS_IN_RING_ELEMENT * 16 * 2 <= out.len())]
     pub(crate) fn to_bytes(self, out: &mut [u8]) {
         to_bytes(self, out)
-    }
-
-    /// Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
-    /// sum of their constituent coefficients.
-    #[inline(always)]
-    pub(crate) fn add_to_ring_element<const K: usize>(&mut self, rhs: &Self) {
-        add_to_ring_element::<Vector, K>(self, rhs);
     }
 
     #[inline(always)]
@@ -426,18 +420,28 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
     }
 
     #[inline(always)]
-    pub(crate) fn ntt_multiply(&self, rhs: &Self, out: &mut Self) {
-        ntt_multiply(self, rhs, out)
+    pub(crate) fn accumulating_ntt_multiply(&self, rhs: &Self, accumulator: &mut [i32; 256]) {
+        accumulating_ntt_multiply(self, rhs, accumulator)
     }
 
     #[inline(always)]
-    pub(crate) fn ntt_multiply_caching(&self, rhs: &Self, out: &mut Self, cache: &mut Self) {
-        ntt_multiply_caching(self, rhs, out, cache)
+    pub(crate) fn accumulating_ntt_multiply_fill_cache(
+        &self,
+        rhs: &Self,
+        accumulator: &mut [i32; 256],
+        cache: &mut Self,
+    ) {
+        accumulating_ntt_multiply_fill_cache(self, rhs, accumulator, cache)
     }
 
     #[inline(always)]
-    pub(crate) fn ntt_multiply_cached(&self, rhs: &Self, out: &mut Self, cache: &Self) {
-        ntt_multiply_cached(self, rhs, out, cache)
+    pub(crate) fn accumulating_ntt_multiply_use_cache(
+        &self,
+        rhs: &Self,
+        accumulator: &mut [i32; 256],
+        cache: &Self,
+    ) {
+        accumulating_ntt_multiply_use_cache(self, rhs, accumulator, cache)
     }
 }
 

--- a/libcrux/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable.rs
@@ -1,5 +1,5 @@
 use super::Operations;
-mod arithmetic;
+pub(crate) mod arithmetic;
 mod compress;
 mod ntt;
 mod sampling;
@@ -134,6 +134,13 @@ impl Operations for PortableVector {
     #[ensures(|out| fstar!(r#"impl.f_repr out == $array"#))]
     fn from_i16_array(array: &[i16], out: &mut Self) {
         from_i16_array(array, out)
+    }
+
+    #[inline(always)]
+    #[requires(array.len() == 16)]
+    #[ensures(|out| fstar!(r#"impl.f_repr out == $array"#))]
+    fn reducing_from_i32_array(array: &[i32], out: &mut Self) {
+        reducing_from_i32_array(array, out)
     }
 
     #[inline(always)]
@@ -307,40 +314,35 @@ impl Operations for PortableVector {
     }
 
     #[inline(always)]
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
-                       Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
-                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${lhs}) /\
-                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${rhs})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
-    fn ntt_multiply(
+    fn accumulating_ntt_multiply(
         lhs: &Self,
         rhs: &Self,
-        out: &mut Self,
+        out: &mut [i32],
         zeta0: i16,
         zeta1: i16,
         zeta2: i16,
         zeta3: i16,
     ) {
-        ntt_multiply(lhs, rhs, out, zeta0, zeta1, zeta2, zeta3)
+        accumulating_ntt_multiply(lhs, rhs, out, zeta0, zeta1, zeta2, zeta3)
     }
 
     #[inline(always)]
-    fn ntt_multiply_caching(
+    fn accumulating_ntt_multiply_fill_cache(
         lhs: &Self,
         rhs: &Self,
-        out: &mut Self,
+        out: &mut [i32],
         cache: &mut Self,
         zeta0: i16,
         zeta1: i16,
         zeta2: i16,
         zeta3: i16,
     ) {
-        ntt_multiply_caching(lhs, rhs, out, cache, zeta0, zeta1, zeta2, zeta3)
+        accumulating_ntt_multiply_fill_cache(lhs, rhs, out, cache, zeta0, zeta1, zeta2, zeta3)
     }
 
     #[inline(always)]
-    fn ntt_multiply_cached(lhs: &Self, rhs: &Self, out: &mut Self, cache: &Self) {
-        ntt_multiply_cached(lhs, rhs, out, cache)
+    fn accumulating_ntt_multiply_use_cache(lhs: &Self, rhs: &Self, out: &mut [i32], cache: &Self) {
+        accumulating_ntt_multiply_use_cache(lhs, rhs, out, cache)
     }
 
     #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/ntt.rs
@@ -274,107 +274,12 @@ pub(crate) fn inv_ntt_layer_3_step(vec: &mut PortableVector, zeta: i16) {
          let oj = Seq.index out_future.f_elements (2 * v $i + 1) in
          ((v oi % 3329) == (((v ai * v bi + (v aj * v bj * v zeta * 169)) * 169) % 3329)) /\
          ((v oj % 3329) == (((v ai * v bj + v aj * v bi) * 169) % 3329)))"#))]
-pub(crate) fn ntt_multiply_binomials(
+pub(crate) fn accumulating_ntt_multiply_binomials_fill_cache(
     a: &PortableVector,
     b: &PortableVector,
     zeta: FieldElementTimesMontgomeryR,
     i: usize,
-    out: &mut PortableVector,
-) {
-    let ai = a.elements[2 * i];
-    let bi = b.elements[2 * i];
-    let aj = a.elements[2 * i + 1];
-    let bj = b.elements[2 * i + 1];
-    hax_lib::fstar!(
-        "assert(Spec.Utils.is_i16b 3328 $ai);
-                     assert(Spec.Utils.is_i16b 3328 $bi);
-                     assert(Spec.Utils.is_i16b 3328 $aj);
-                     assert(Spec.Utils.is_i16b 3328 $bj);
-                     assert_norm (3328 * 3328 < pow2 31)"
-    );
-
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bi"#);
-    let ai_bi = (ai as i32) * (bi as i32);
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bj"#);
-    let bj_zeta_ = (bj as i32) * (zeta as i32);
-    hax_lib::fstar!(r#"assert_norm (3328 * 3328 <= 3328 * pow2 15)"#);
-    let bj_zeta = montgomery_reduce_element(bj_zeta_);
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 1664 $aj_bj $zeta"#);
-    let aj_bj_zeta = (aj as i32) * (bj_zeta as i32);
-    let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
-    hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
-    hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
-    let o0 = montgomery_reduce_element(ai_bi_aj_bj);
-    hax_lib::fstar!(
-        r#"calc  ( == ) {
-        v $o0 % 3329;
-        ( == ) { () }
-        (v $ai_bi_aj_bj * 169) % 3329;
-        ( == ) { assert(v $ai_bi_aj_bj == v $ai_bi + v $aj_bj_zeta) }
-        ((v $ai_bi + v $aj_bj_zeta) * 169) % 3329;
-        ( == ) { assert (v $ai_bi == v $ai * v $bi) }
-        (((v $ai * v $bi) + v $aj_bj_zeta) * 169) % 3329;
-        ( == ) { assert (v $aj_bj_zeta == v $aj_bj * v $zeta) }
-        (((v $ai * v $bi) + (v $aj_bj * v $zeta)) * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l ((v ai * v bi) + (v aj_bj * v zeta)) 169 3329 }
-        ((((v $ai * v $bi) + (v $aj_bj * v $zeta)) % 3329) * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_add_distr (v ai * v bi) (v aj_bj * v zeta) 3329 }
-        (((v $ai * v $bi) + ((v $aj_bj * v $zeta) % 3329)) % 3329 * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l (v aj_bj) (v zeta) 3329 }
-        (((v $ai * v $bi) + ((v $aj_bj % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
-        ( == ) { assert(v aj_bj % 3329 == (v $aj_bj_ * 169) % 3329) }
-        (((v $ai * v $bi) + (((v $aj_bj_ * 169) % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
-        ( == ) { assert(v $aj_bj_ == v $aj * v $bj) }
-        (((v $ai * v $bi) + (((v $aj * v $bj * 169) % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l (v $aj * v $bj * 169) (v $zeta) 3329 }
-        (((v $ai * v $bi) + (((v $aj * v $bj * 169 * v $zeta) % 3329))) % 3329 * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_add_distr (v $ai * v $bi) (v $aj * v $bj * 169 * v $zeta) 3329 }
-        (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) % 3329 * 169) % 3329;
-        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l ((v ai * v bi) + ((v aj * v bj * 169 * v zeta))) 169 3329 }
-        (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) * 169) % 3329;
-        }"#
-    );
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bj"#);
-    let ai_bj = (ai as i32) * (bj as i32);
-    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bi"#);
-    let aj_bi = (aj as i32) * (bi as i32);
-    let ai_bj_aj_bi = ai_bj + aj_bi;
-    hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*3328) ai_bj_aj_bi) "#);
-    hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 3328 <= 3328 * pow2 15)"#);
-    let o1 = montgomery_reduce_element(ai_bj_aj_bi);
-    hax_lib::fstar!(
-        "calc  ( == ) {
-        v $o1 % 3329;
-        ( == ) { () }
-        (v $ai_bj_aj_bi * 169) % 3329;
-        ( == ) { assert(v $ai_bj_aj_bi == v $ai_bj + v $aj_bi) }
-        ((v $ai_bj + v $aj_bi) * 169) % 3329;
-        ( == ) { assert (v ai_bj == v ai * v bj) }
-        ((v ai * v bj + v aj_bi) * 169) % 3329;
-        ( == ) { assert (v aj_bi == v aj * v bi) }
-        ((v ai * v bj + v aj * v bi) * 169) % 3329;
-    }"
-    );
-    let _out0 = out.elements;
-    out.elements[2 * i] = o0;
-    out.elements[2 * i + 1] = o1;
-    hax_lib::fstar!(
-        r#"assert (Seq.index out.f_elements (2 * v i) == o0);
-                     assert (Seq.index out.f_elements (2 * v i + 1) == o1);
-                     assert (Spec.Utils.is_i16b_array 3328 out.f_elements);
-                     assert (forall k. (k <> 2 * v i /\ k <> 2 * v i + 1) ==>
-                                        Seq.index out.f_elements k ==
-                                        Seq.index ${_out0} k)"#
-    );
-}
-
-#[inline(always)]
-pub(crate) fn ntt_multiply_binomials_caching(
-    a: &PortableVector,
-    b: &PortableVector,
-    zeta: FieldElementTimesMontgomeryR,
-    i: usize,
-    out: &mut PortableVector,
+    out: &mut [i32],
     cache: &mut PortableVector,
 ) {
     let ai = a.elements[2 * i];
@@ -401,7 +306,7 @@ pub(crate) fn ntt_multiply_binomials_caching(
     let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
-    let o0 = montgomery_reduce_element(ai_bi_aj_bj);
+    let o0 = ai_bi_aj_bj;
     hax_lib::fstar!(
         r#"calc  ( == ) {
         v $o0 % 3329;
@@ -438,7 +343,7 @@ pub(crate) fn ntt_multiply_binomials_caching(
     let ai_bj_aj_bi = ai_bj + aj_bi;
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*3328) ai_bj_aj_bi) "#);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 3328 <= 3328 * pow2 15)"#);
-    let o1 = montgomery_reduce_element(ai_bj_aj_bi);
+    let o1 = ai_bj_aj_bi;
     hax_lib::fstar!(
         "calc  ( == ) {
         v $o1 % 3329;
@@ -452,9 +357,8 @@ pub(crate) fn ntt_multiply_binomials_caching(
         ((v ai * v bj + v aj * v bi) * 169) % 3329;
     }"
     );
-    let _out0 = out.elements;
-    out.elements[2 * i] = o0;
-    out.elements[2 * i + 1] = o1;
+    out[2 * i] += o0;
+    out[2 * i + 1] += o1;
     hax_lib::fstar!(
         r#"assert (Seq.index out.f_elements (2 * v i) == o0);
                      assert (Seq.index out.f_elements (2 * v i + 1) == o1);
@@ -466,11 +370,12 @@ pub(crate) fn ntt_multiply_binomials_caching(
 }
 
 #[inline(always)]
-pub(crate) fn ntt_multiply_binomials_cached(
+pub(crate) fn accumulating_ntt_multiply_binomials_use_cache(
     a: &PortableVector,
     b: &PortableVector,
     i: usize,
-    out: &mut PortableVector,
+    out: &mut [i32],
+
     cache: &PortableVector,
 ) {
     let ai = a.elements[2 * i];
@@ -493,7 +398,7 @@ pub(crate) fn ntt_multiply_binomials_cached(
     let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
-    let o0 = montgomery_reduce_element(ai_bi_aj_bj);
+    let o0 = ai_bi_aj_bj;
     hax_lib::fstar!(
         r#"calc  ( == ) {
         v $o0 % 3329;
@@ -530,7 +435,7 @@ pub(crate) fn ntt_multiply_binomials_cached(
     let ai_bj_aj_bi = ai_bj + aj_bi;
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*3328) ai_bj_aj_bi) "#);
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 3328 <= 3328 * pow2 15)"#);
-    let o1 = montgomery_reduce_element(ai_bj_aj_bi);
+    let o1 = ai_bj_aj_bi;
     hax_lib::fstar!(
         "calc  ( == ) {
         v $o1 % 3329;
@@ -544,9 +449,102 @@ pub(crate) fn ntt_multiply_binomials_cached(
         ((v ai * v bj + v aj * v bi) * 169) % 3329;
     }"
     );
-    let _out0 = out.elements;
-    out.elements[2 * i] = o0;
-    out.elements[2 * i + 1] = o1;
+    out[2 * i] += o0;
+    out[2 * i + 1] += o1;
+    hax_lib::fstar!(
+        r#"assert (Seq.index out.f_elements (2 * v i) == o0);
+                     assert (Seq.index out.f_elements (2 * v i + 1) == o1);
+                     assert (Spec.Utils.is_i16b_array 3328 out.f_elements);
+                     assert (forall k. (k <> 2 * v i /\ k <> 2 * v i + 1) ==>
+                                        Seq.index out.f_elements k ==
+                                        Seq.index ${_out0} k)"#
+    );
+}
+
+#[inline(always)]
+pub(crate) fn accumulating_ntt_multiply_binomials(
+    a: &PortableVector,
+    b: &PortableVector,
+    zeta: FieldElementTimesMontgomeryR,
+    i: usize,
+    out: &mut [i32],
+) {
+    let ai = a.elements[2 * i];
+    let bi = b.elements[2 * i];
+    let aj = a.elements[2 * i + 1];
+    let bj = b.elements[2 * i + 1];
+    hax_lib::fstar!(
+        "assert(Spec.Utils.is_i16b 3328 $ai);
+                     assert(Spec.Utils.is_i16b 3328 $bi);
+                     assert(Spec.Utils.is_i16b 3328 $aj);
+                     assert(Spec.Utils.is_i16b 3328 $bj);
+                     assert_norm (3328 * 3328 < pow2 31)"
+    );
+
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bi"#);
+    let ai_bi = (ai as i32) * (bi as i32);
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bj"#);
+    let bj_zeta_ = (bj as i32) * (zeta as i32);
+    hax_lib::fstar!(r#"assert_norm (3328 * 3328 <= 3328 * pow2 15)"#);
+    let bj_zeta = montgomery_reduce_element(bj_zeta_);
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 1664 $aj_bj $zeta"#);
+    let aj_bj_zeta = (aj as i32) * (bj_zeta as i32);
+    let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
+    hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
+    hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
+    let o0 = ai_bi_aj_bj;
+    hax_lib::fstar!(
+        r#"calc  ( == ) {
+        v $o0 % 3329;
+        ( == ) { () }
+        (v $ai_bi_aj_bj * 169) % 3329;
+        ( == ) { assert(v $ai_bi_aj_bj == v $ai_bi + v $aj_bj_zeta) }
+        ((v $ai_bi + v $aj_bj_zeta) * 169) % 3329;
+        ( == ) { assert (v $ai_bi == v $ai * v $bi) }
+        (((v $ai * v $bi) + v $aj_bj_zeta) * 169) % 3329;
+        ( == ) { assert (v $aj_bj_zeta == v $aj_bj * v $zeta) }
+        (((v $ai * v $bi) + (v $aj_bj * v $zeta)) * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l ((v ai * v bi) + (v aj_bj * v zeta)) 169 3329 }
+        ((((v $ai * v $bi) + (v $aj_bj * v $zeta)) % 3329) * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_add_distr (v ai * v bi) (v aj_bj * v zeta) 3329 }
+        (((v $ai * v $bi) + ((v $aj_bj * v $zeta) % 3329)) % 3329 * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l (v aj_bj) (v zeta) 3329 }
+        (((v $ai * v $bi) + ((v $aj_bj % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
+        ( == ) { assert(v aj_bj % 3329 == (v $aj_bj_ * 169) % 3329) }
+        (((v $ai * v $bi) + (((v $aj_bj_ * 169) % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
+        ( == ) { assert(v $aj_bj_ == v $aj * v $bj) }
+        (((v $ai * v $bi) + (((v $aj * v $bj * 169) % 3329 * v $zeta) % 3329)) % 3329 * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l (v $aj * v $bj * 169) (v $zeta) 3329 }
+        (((v $ai * v $bi) + (((v $aj * v $bj * 169 * v $zeta) % 3329))) % 3329 * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_add_distr (v $ai * v $bi) (v $aj * v $bj * 169 * v $zeta) 3329 }
+        (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) % 3329 * 169) % 3329;
+        ( == ) { Math.Lemmas.lemma_mod_mul_distr_l ((v ai * v bi) + ((v aj * v bj * 169 * v zeta))) 169 3329 }
+        (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) * 169) % 3329;
+        }"#
+    );
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bj"#);
+    let ai_bj = (ai as i32) * (bj as i32);
+    hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bi"#);
+    let aj_bi = (aj as i32) * (bi as i32);
+    let ai_bj_aj_bi = ai_bj + aj_bi;
+    hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*3328) ai_bj_aj_bi) "#);
+    hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 3328 <= 3328 * pow2 15)"#);
+    let o1 = ai_bj_aj_bi;
+    hax_lib::fstar!(
+        "calc  ( == ) {
+        v $o1 % 3329;
+        ( == ) { () }
+        (v $ai_bj_aj_bi * 169) % 3329;
+        ( == ) { assert(v $ai_bj_aj_bi == v $ai_bj + v $aj_bi) }
+        ((v $ai_bj + v $aj_bi) * 169) % 3329;
+        ( == ) { assert (v ai_bj == v ai * v bj) }
+        ((v ai * v bj + v aj_bi) * 169) % 3329;
+        ( == ) { assert (v aj_bi == v aj * v bi) }
+        ((v ai * v bj + v aj * v bi) * 169) % 3329;
+    }"
+    );
+    out[2 * i] += o0;
+    out[2 * i + 1] += o1;
     hax_lib::fstar!(
         r#"assert (Seq.index out.f_elements (2 * v i) == o0);
                      assert (Seq.index out.f_elements (2 * v i + 1) == o1);
@@ -577,10 +575,66 @@ pub(crate) fn ntt_multiply_binomials_cached(
             let oj = Seq.index result.f_elements (2 * i + 1) in
             ((v oi % 3329) == (((v ai * v bi + (v aj * v bj * (Seq.index zetas i) * 169)) * 169) % 3329)) /\
             ((v oj % 3329) == (((v ai * v bj + v aj * v bi) * 169) % 3329)))))"#))]
-pub(crate) fn ntt_multiply_caching(
+pub(crate) fn accumulating_ntt_multiply(
     lhs: &PortableVector,
     rhs: &PortableVector,
-    out: &mut PortableVector,
+    out: &mut [i32],
+    zeta0: i16,
+    zeta1: i16,
+    zeta2: i16,
+    zeta3: i16,
+) {
+    let nzeta0 = -zeta0;
+    let nzeta1 = -zeta1;
+    let nzeta2 = -zeta2;
+    let nzeta3 = -zeta3;
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta0)"#);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta1)"#);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    accumulating_ntt_multiply_binomials(lhs, rhs, zeta0, 0, out);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    accumulating_ntt_multiply_binomials(lhs, rhs, nzeta0, 1, out);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    accumulating_ntt_multiply_binomials(lhs, rhs, zeta1, 2, out);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    accumulating_ntt_multiply_binomials(lhs, rhs, nzeta1, 3, out);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    accumulating_ntt_multiply_binomials(lhs, rhs, zeta2, 4, out);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    accumulating_ntt_multiply_binomials(lhs, rhs, nzeta2, 5, out);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    accumulating_ntt_multiply_binomials(lhs, rhs, zeta3, 6, out);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    accumulating_ntt_multiply_binomials(lhs, rhs, nzeta3, 7, out);
+    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+}
+
+#[inline(always)]
+#[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::fstar::options("--z3rlimit 100")]
+#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 $zeta0 /\
+        Spec.Utils.is_i16b 1664 $zeta1 /\
+        Spec.Utils.is_i16b 1664 $zeta2 /\
+        Spec.Utils.is_i16b 1664 $zeta3 /\
+        Spec.Utils.is_i16b_array 3328 ${lhs}.f_elements /\
+        Spec.Utils.is_i16b_array 3328 ${rhs}.f_elements "#))]
+#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 ${result}.f_elements /\
+          (let zetas = Seq.seq_of_list [v zeta0; - v zeta0; v zeta1; - v zeta1; v zeta2; - v zeta2; v zeta3; - v zeta3] in
+          (forall (i:nat). i < 8 ==>
+           (let ai = Seq.index lhs.f_elements (2 * i) in
+            let aj = Seq.index lhs.f_elements (2 * i + 1) in
+            let bi = Seq.index rhs.f_elements (2 * i) in
+            let bj = Seq.index rhs.f_elements (2 * i + 1) in
+            let oi = Seq.index result.f_elements (2 * i) in
+            let oj = Seq.index result.f_elements (2 * i + 1) in
+            ((v oi % 3329) == (((v ai * v bi + (v aj * v bj * (Seq.index zetas i) * 169)) * 169) % 3329)) /\
+            ((v oj % 3329) == (((v ai * v bj + v aj * v bi) * 169) % 3329)))))"#))]
+pub(crate) fn accumulating_ntt_multiply_fill_cache(
+    lhs: &PortableVector,
+    rhs: &PortableVector,
+    out: &mut [i32],
     cache: &mut PortableVector,
     zeta0: i16,
     zeta1: i16,
@@ -596,29 +650,29 @@ pub(crate) fn ntt_multiply_caching(
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, zeta0, 0, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, zeta0, 0, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, nzeta0, 1, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, nzeta0, 1, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, zeta1, 2, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, zeta1, 2, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, nzeta1, 3, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, nzeta1, 3, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, zeta2, 4, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, zeta2, 4, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, nzeta2, 5, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, nzeta2, 5, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, zeta3, 6, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, zeta3, 6, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_caching(lhs, rhs, nzeta3, 7, out, cache);
+    accumulating_ntt_multiply_binomials_fill_cache(lhs, rhs, nzeta3, 7, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
 }
 
 #[inline(always)]
-pub(crate) fn ntt_multiply_cached(
+pub(crate) fn accumulating_ntt_multiply_use_cache(
     lhs: &PortableVector,
     rhs: &PortableVector,
-    out: &mut PortableVector,
+    out: &mut [i32],
     cache: &PortableVector,
 ) {
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta0)"#);
@@ -626,56 +680,20 @@ pub(crate) fn ntt_multiply_cached(
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 0, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 0, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 1, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 1, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 2, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 2, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 3, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 3, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 4, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 4, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 5, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 5, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 6, out, cache);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 6, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials_cached(lhs, rhs, 7, out, cache);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-}
-#[inline(always)]
-pub(crate) fn ntt_multiply(
-    lhs: &PortableVector,
-    rhs: &PortableVector,
-    out: &mut PortableVector,
-    zeta0: i16,
-    zeta1: i16,
-    zeta2: i16,
-    zeta3: i16,
-) {
-    let nzeta0 = -zeta0;
-    let nzeta1 = -zeta1;
-    let nzeta2 = -zeta2;
-    let nzeta3 = -zeta3;
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta0)"#);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta1)"#);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta0, 0, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta0, 1, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta1, 2, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta1, 3, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta2, 4, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta2, 5, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, zeta3, 6, out);
-    hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
-    ntt_multiply_binomials(lhs, rhs, nzeta3, 7, out);
+    accumulating_ntt_multiply_binomials_use_cache(lhs, rhs, 7, out, cache);
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
 }

--- a/libcrux/libcrux-ml-kem/src/vector/portable/vector_type.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/portable/vector_type.rs
@@ -1,5 +1,7 @@
 use crate::vector::traits::FIELD_ELEMENTS_IN_VECTOR;
 
+use super::arithmetic::montgomery_reduce_element;
+
 /// Values having this type hold a representative 'x' of the ML-KEM field.
 /// We use 'fe' as a shorthand for this type.
 pub(crate) type FieldElement = i16;
@@ -28,6 +30,15 @@ pub fn to_i16_array(x: PortableVector, out: &mut [i16; 16]) {
 #[hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == $array"#))]
 pub fn from_i16_array(array: &[i16], out: &mut PortableVector) {
     out.elements = array[0..16].try_into().unwrap();
+}
+
+#[inline(always)]
+#[hax_lib::requires(array.len() == 16)]
+#[hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == $array"#))]
+pub fn reducing_from_i32_array(array: &[i32], out: &mut PortableVector) {
+    for i in 0..16 {
+        out.elements[i] = montgomery_reduce_element(array[i]);
+    }
 }
 
 #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux/libcrux-ml-kem/src/vector/traits.rs
@@ -25,6 +25,10 @@ pub trait Operations: Copy + Clone + Repr {
     #[ensures(|result| fstar!(r#"f_repr $result == $array"#))]
     fn from_i16_array(array: &[i16], out: &mut Self);
 
+    #[requires(array.len() == 16)]
+    #[ensures(|result| fstar!(r#"f_repr $result == $array"#))]
+    fn reducing_from_i32_array(array: &[i32], out: &mut Self);
+
     #[requires(true)]
     #[ensures(|result| fstar!(r#"f_repr $x == $result"#))]
     fn to_i16_array(x: Self, out: &mut [i16; 16]);
@@ -139,20 +143,20 @@ pub trait Operations: Copy + Clone + Repr {
                        Spec.Utils.is_i16b_array 3328 (f_repr ${lhs}) /\
                        Spec.Utils.is_i16b_array 3328 (f_repr ${rhs}) "#))]
     #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#))]
-    fn ntt_multiply(
+    fn accumulating_ntt_multiply(
         lhs: &Self,
         rhs: &Self,
-        out: &mut Self,
+        out: &mut [i32],
         zeta0: i16,
         zeta1: i16,
         zeta2: i16,
         zeta3: i16,
     );
 
-    fn ntt_multiply_caching(
+    fn accumulating_ntt_multiply_fill_cache(
         lhs: &Self,
         rhs: &Self,
-        out: &mut Self,
+        accumulator: &mut [i32], // length: 16
         cache: &mut Self,
         zeta0: i16,
         zeta1: i16,
@@ -160,7 +164,12 @@ pub trait Operations: Copy + Clone + Repr {
         zeta3: i16,
     );
 
-    fn ntt_multiply_cached(lhs: &Self, rhs: &Self, out: &mut Self, cache: &Self);
+    fn accumulating_ntt_multiply_use_cache(
+        lhs: &Self,
+        rhs: &Self,
+        accumulator: &mut [i32],
+        cache: &Self,
+    );
 
     // Serialization and deserialization
     #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (f_repr $a)"#))]


### PR DESCRIPTION
This is the second part split off #73.

It saves on modular reductions during the multiplication in the NTT domain.
In detail: When we compute an NTT multiplication result entry we have to sum up `K` base multiplication results per output vector entry: `x[0]*y[0] + ... + x[k-1] * x[k-1]`. As described in [AHKS22, section 3.4](https://kannwischer.eu/papers/2022_fasterkyberdilithiumm4.pdf), we can bound the absolute value of each of the potential inputs by `q = 3329`, this means each product's absolute value can be bounded by `q^2`. If we assume the worst case `K = 4` for ML-KEM 1024, we can then bound the value of the above sum of products by `4*q^2`, which fits into an `i32` without overflowing. This means don't have to reduce the products immediately, but we can first add them up into an `i32` and then reduce their sum.