### PR TITLE
Improve key generation stack usage

### DIFF
--- a/libcrux/libcrux-ml-kem/src/hash_functions.rs
+++ b/libcrux/libcrux-ml-kem/src/hash_functions.rs
@@ -53,17 +53,6 @@ pub(crate) mod portable {
         portable::shake256(out, input);
     }
 
-    #[hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_PRFxN $K $LEN $input"#))
-    ]
-    #[inline(always)]
-    fn PRFxN(input: &[[u8; 33]], outputs: &mut [u8], out_len: usize) {
-        for i in 0..input.len() {
-            portable::shake256(&mut outputs[i * out_len..(i + 1) * out_len], &input[i]);
-        }
-    }
-
     #[inline(always)]
     fn shake128_init_absorb_final(input: &[u8; 34]) -> PortableHash {
         let mut shake128_state = incremental::shake128_init();
@@ -107,16 +96,6 @@ pub(crate) mod portable {
         #[inline(always)]
         pub(crate) fn PRF<const LEN: usize>(input: &[u8], out: &mut [u8]) {
             PRF::<LEN>(input, out)
-        }
-
-        #[requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
-        #[ensures(|out|
-            fstar!(r#"(v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)) ==>
-                $out == Spec.Utils.v_PRFxN $K $LEN $input"#))
-        ]
-        #[inline(always)]
-        pub(crate) fn PRFxN(input: &[[u8; 33]], outputs: &mut [u8], out_len: usize) {
-            PRFxN(input, outputs, out_len)
         }
 
         #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/hash_functions.rs
+++ b/libcrux/libcrux-ml-kem/src/hash_functions.rs
@@ -14,59 +14,7 @@ pub(crate) const BLOCK_SIZE: usize = 168;
 /// The size of 3 SHA3 blocks.
 pub(crate) const THREE_BLOCKS: usize = BLOCK_SIZE * 3;
 
-/// Abstraction for the hashing, to pick the fastest version depending on the
-/// platform features available.
-///
-/// In libcrux-iot we currently support a portable instantiations of
-/// this trait right now, whereas mainline libcrux supports additional
-/// SIMD platform.
-#[hax_lib::attributes]
-pub(crate) trait Hash {
-    /// G aka SHA3 512
-    #[requires(true)]
-    #[ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_G $input"#))
-    ]
-    fn G(input: &[u8], output: &mut [u8]);
-
-    /// H aka SHA3 256
-    #[requires(true)]
-    #[ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_H $input"#))
-    ]
-    fn H(input: &[u8], output: &mut [u8]);
-
-    /// PRF aka SHAKE256
-    #[requires(fstar!(r#"v $LEN < pow2 32"#))]
-    #[ensures(|result|
-        // We need to repeat the pre-condition here because of https://github.com/hacspec/hax/issues/784
-        fstar!(r#"v $LEN < pow2 32 ==> $result == Spec.Utils.v_PRF $LEN $input"#))
-    ]
-    fn PRF<const LEN: usize>(input: &[u8], out: &mut [u8]);
-
-    /// PRFxN aka N SHAKE256
-    #[requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
-    #[ensures(|result|
-        // We need to repeat the pre-condition here because of https://github.com/hacspec/hax/issues/784
-        fstar!(r#"(v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)) ==>
-            $result == Spec.Utils.v_PRFxN $K $LEN $input"#))
-    ]
-    fn PRFxN(input: &[[u8; 33]], outputs: &mut [u8], out_len: usize);
-
-    /// Create a SHAKE128 state and absorb the input.
-    #[requires(true)]
-    fn shake128_init_absorb_final(input: &[[u8; 34]]) -> Self;
-
-    /// Squeeze 3 blocks out of the SHAKE128 state.
-    #[requires(true)]
-    fn shake128_squeeze_first_three_blocks(&mut self, output: &mut [[u8; THREE_BLOCKS]]);
-
-    /// Squeeze 1 block out of the SHAKE128 state.
-    #[requires(true)]
-    fn shake128_squeeze_next_block(&mut self, output: &mut [[u8; BLOCK_SIZE]]);
-}
-
-/// A portable implementation of [`Hash`]
+/// Portable hash function implementations as needed for ML-KEM.
 pub(crate) mod portable {
     use super::*;
     use libcrux_sha3::portable::{self, incremental, KeccakState};
@@ -77,7 +25,7 @@ pub(crate) mod portable {
     /// All other functions don't actually use any members.
     #[cfg_attr(hax, hax_lib::opaque)]
     pub(crate) struct PortableHash {
-        shake128_state: [KeccakState; 4],
+        shake128_state: KeccakState,
     }
 
     #[hax_lib::ensures(|result|
@@ -117,45 +65,29 @@ pub(crate) mod portable {
     }
 
     #[inline(always)]
-    fn shake128_init_absorb_final(input: &[[u8; 34]]) -> PortableHash {
-        // debug_assert!(input.len() == 2 || input.len() == 3 || input.len() == 4);
-
-        let mut shake128_state = [incremental::shake128_init(); 4];
-        for i in 0..input.len() {
-            incremental::shake128_absorb_final(&mut shake128_state[i], &input[i]);
-        }
+    fn shake128_init_absorb_final(input: &[u8; 34]) -> PortableHash {
+        let mut shake128_state = incremental::shake128_init();
+        incremental::shake128_absorb_final(&mut shake128_state, &input[..]);
         PortableHash { shake128_state }
     }
 
     #[inline(always)]
-    fn shake128_squeeze_first_three_blocks(
-        st: &mut PortableHash,
-        outputs: &mut [[u8; THREE_BLOCKS]],
-    ) {
-        // debug_assert!(outputs.len() == 2 || outputs.len() == 3 || outputs.len() == 4);
-
-        for i in 0..outputs.len() {
-            incremental::shake128_squeeze_first_three_blocks(
-                &mut st.shake128_state[i],
-                &mut outputs[i],
-            );
-        }
+    fn shake128_squeeze_first_three_blocks(st: &mut PortableHash, output: &mut [u8; THREE_BLOCKS]) {
+        incremental::shake128_squeeze_first_three_blocks(&mut st.shake128_state, &mut output[..]);
     }
 
     #[inline(always)]
-    fn shake128_squeeze_next_block(st: &mut PortableHash, outputs: &mut [[u8; BLOCK_SIZE]]) {
-        for i in 0..outputs.len() {
-            incremental::shake128_squeeze_next_block(&mut st.shake128_state[i], &mut outputs[i]);
-        }
+    fn shake128_squeeze_next_block(st: &mut PortableHash, output: &mut [u8; BLOCK_SIZE]) {
+        incremental::shake128_squeeze_next_block(&mut st.shake128_state, &mut output[..]);
     }
 
     #[hax_lib::attributes]
-    impl Hash for PortableHash {
+    impl PortableHash {
         #[ensures(|out|
             fstar!(r#"$out == Spec.Utils.v_G $input"#))
         ]
         #[inline(always)]
-        fn G(input: &[u8], output: &mut [u8]) {
+        pub(crate) fn G(input: &[u8], output: &mut [u8]) {
             G(input, output)
         }
 
@@ -163,7 +95,7 @@ pub(crate) mod portable {
             fstar!(r#"$out == Spec.Utils.v_H $input"#))
         ]
         #[inline(always)]
-        fn H(input: &[u8], output: &mut [u8]) {
+        pub(crate) fn H(input: &[u8], output: &mut [u8]) {
             H(input, output)
         }
 
@@ -173,7 +105,7 @@ pub(crate) mod portable {
             fstar!(r#"v $LEN < pow2 32 ==> $out == Spec.Utils.v_PRF $LEN $input"#))
         ]
         #[inline(always)]
-        fn PRF<const LEN: usize>(input: &[u8], out: &mut [u8]) {
+        pub(crate) fn PRF<const LEN: usize>(input: &[u8], out: &mut [u8]) {
             PRF::<LEN>(input, out)
         }
 
@@ -183,22 +115,25 @@ pub(crate) mod portable {
                 $out == Spec.Utils.v_PRFxN $K $LEN $input"#))
         ]
         #[inline(always)]
-        fn PRFxN(input: &[[u8; 33]], outputs: &mut [u8], out_len: usize) {
+        pub(crate) fn PRFxN(input: &[[u8; 33]], outputs: &mut [u8], out_len: usize) {
             PRFxN(input, outputs, out_len)
         }
 
         #[inline(always)]
-        fn shake128_init_absorb_final(input: &[[u8; 34]]) -> Self {
+        pub(crate) fn shake128_init_absorb_final(input: &[u8; 34]) -> Self {
             shake128_init_absorb_final(input)
         }
 
         #[inline(always)]
-        fn shake128_squeeze_first_three_blocks(&mut self, output: &mut [[u8; THREE_BLOCKS]]) {
+        pub(crate) fn shake128_squeeze_first_three_blocks(
+            &mut self,
+            output: &mut [u8; THREE_BLOCKS],
+        ) {
             shake128_squeeze_first_three_blocks(self, output)
         }
 
         #[inline(always)]
-        fn shake128_squeeze_next_block(&mut self, output: &mut [[u8; BLOCK_SIZE]]) {
+        pub(crate) fn shake128_squeeze_next_block(&mut self, output: &mut [u8; BLOCK_SIZE]) {
             shake128_squeeze_next_block(self, output)
         }
     }

--- a/libcrux/libcrux-ml-kem/src/ind_cca.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca.rs
@@ -202,10 +202,8 @@ pub(crate) fn generate_keypair<
 ) -> MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE> {
     let ind_cpa_keypair_randomness = &randomness[0..CPA_PKE_KEY_GENERATION_SEED_SIZE];
     let implicit_rejection_value = &randomness[CPA_PKE_KEY_GENERATION_SEED_SIZE..];
-
     let mut public_key = [0u8; PUBLIC_KEY_SIZE];
     let mut secret_key_serialized = [0u8; PRIVATE_KEY_SIZE];
-
     let mut ind_cpa_private_key = [0u8; CPA_PRIVATE_KEY_SIZE];
     let mut scratch = PolynomialRingElement::<Vector>::ZERO();
     let mut accumulator = [0i32; 256];
@@ -285,6 +283,22 @@ pub(crate) fn encapsulate<
     randomness: [u8; SHARED_SECRET_SIZE],
 ) -> (MlKemCiphertext<CIPHERTEXT_SIZE>, MlKemSharedSecret) {
     let mut processed_randomness = [0u8; 32];
+    let mut hashed = [0u8; G_DIGEST_SIZE];
+    let mut ciphertext = [0u8; CIPHERTEXT_SIZE];
+    let mut r_as_ntt: [PolynomialRingElement<Vector>; K] =
+        core::array::from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
+    let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
+    let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+    let mut v = PolynomialRingElement::<Vector>::ZERO();
+    let mut accumulator = [0i32; 256];
+    let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
+    let mut error_1 = [PolynomialRingElement::<Vector>::ZERO(); K];
+    let mut u = [PolynomialRingElement::<Vector>::ZERO(); K];
+    let mut matrix_entry = PolynomialRingElement::<Vector>::ZERO();
+    let mut shared_secret_array = [0u8; 32];
+    let mut prf_output = [0u8; ETA2_RANDOMNESS_SIZE];
+    let mut sampling_buffer = [0i16; 256];
+    let mut message_as_ring_element = PolynomialRingElement::<Vector>::ZERO();
     Scheme::entropy_preprocess::<K, Hasher>(&randomness, &mut processed_randomness);
     let mut to_hash: [u8; 2 * H_DIGEST_SIZE] = into_padded_array(&processed_randomness);
 
@@ -296,18 +310,9 @@ pub(crate) fn encapsulate<
         lemma_slice_append $to_hash $randomness (Spec.Utils.v_H ${public_key}.f_value);
         assert ($to_hash == concat $randomness (Spec.Utils.v_H ${public_key}.f_value))"
     );
-    let mut hashed = [0u8; G_DIGEST_SIZE];
+
     Hasher::G(&to_hash, &mut hashed);
     let (shared_secret, pseudorandomness) = hashed.split_at(SHARED_SECRET_SIZE);
-
-    let mut ciphertext = [0u8; CIPHERTEXT_SIZE];
-    let mut r_as_ntt: [PolynomialRingElement<Vector>; K] =
-        core::array::from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
-    let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
-    let mut scratch = PolynomialRingElement::<Vector>::ZERO();
-    let mut accumulator = [0i32; 256];
-    let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
-    let mut matrix_entry = PolynomialRingElement::<Vector>::ZERO();
 
     crate::ind_cpa::encrypt::<
         K,
@@ -338,10 +343,16 @@ pub(crate) fn encapsulate<
         &mut scratch,
         &mut cache,
         &mut accumulator,
+        &mut error_1,
+        &mut sampling_buffer,
+        &mut u,
+        &mut prf_output,
+        &mut message_as_ring_element,
+        &mut v,
     );
 
     let ciphertext = MlKemCiphertext::from(ciphertext);
-    let mut shared_secret_array = [0u8; 32];
+
     Scheme::kdf::<K, CIPHERTEXT_SIZE, Hasher>(shared_secret, &ciphertext, &mut shared_secret_array);
     (ciphertext, shared_secret_array)
 }
@@ -398,8 +409,30 @@ pub(crate) fn decapsulate<
     hax_lib::fstar!(
         r#"assert (v $CIPHERTEXT_SIZE == v $IMPLICIT_REJECTION_HASH_INPUT_SIZE - v $SHARED_SECRET_SIZE)"#
     );
+    let mut decrypted = [0u8; 32];
+    let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+    let mut v = PolynomialRingElement::<Vector>::ZERO();
+    let mut message = PolynomialRingElement::<Vector>::ZERO();
+    let mut accumulator = [0i32; 256];
+    let mut hashed = [0u8; G_DIGEST_SIZE];
+    let mut implicit_rejection_shared_secret = [0u8; SHARED_SECRET_SIZE];
+    let mut expected_ciphertext = [0u8; CIPHERTEXT_SIZE];
+    let mut secret_as_ntt = [PolynomialRingElement::<Vector>::ZERO(); K];
+    let mut r_as_ntt = [PolynomialRingElement::<Vector>::ZERO(); K];
+    let mut u_as_ntt = [PolynomialRingElement::<Vector>::ZERO(); K];
+    let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
+    let mut error_1 = [PolynomialRingElement::<Vector>::ZERO(); K];
+    let mut u = [PolynomialRingElement::<Vector>::ZERO(); K];
+    let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
+    let mut matrix_entry = PolynomialRingElement::<Vector>::ZERO();
+    let mut implicit_rejection_shared_secret_kdf = [0u8; SHARED_SECRET_SIZE];
+    let mut shared_secret_kdf = [0u8; SHARED_SECRET_SIZE];
     let (ind_cpa_secret_key, ind_cpa_public_key, ind_cpa_public_key_hash, implicit_rejection_value) =
         unpack_private_key::<CPA_SECRET_KEY_SIZE, PUBLIC_KEY_SIZE>(&private_key.value);
+    let mut shared_secret = [0u8; 32];
+    let mut prf_output = [0u8; ETA2_RANDOMNESS_SIZE];
+    let mut sampling_buffer = [0i16; 256];
+    let mut message_as_ring_element = PolynomialRingElement::<Vector>::ZERO();
 
     hax_lib::fstar!(
         r#"assert ($ind_cpa_secret_key == slice ${private_key}.f_value (sz 0) $CPA_SECRET_KEY_SIZE);
@@ -409,9 +442,6 @@ pub(crate) fn decapsulate<
         assert ($implicit_rejection_value == slice ${private_key}.f_value ($CPA_SECRET_KEY_SIZE +! $PUBLIC_KEY_SIZE +! Spec.MLKEM.v_H_DIGEST_SIZE)
             (length ${private_key}.f_value))"#
     );
-    let mut decrypted = [0u8; 32];
-    let mut scratch = PolynomialRingElement::<Vector>::ZERO();
-    let mut accumulator = [0i32; 256];
 
     crate::ind_cpa::decrypt::<
         K,
@@ -426,6 +456,10 @@ pub(crate) fn decapsulate<
         &mut decrypted,
         &mut scratch,
         &mut accumulator,
+        &mut secret_as_ntt,
+        &mut v,
+        &mut u_as_ntt,
+        &mut message,
     );
 
     let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] = into_padded_array(&decrypted);
@@ -437,9 +471,9 @@ pub(crate) fn decapsulate<
         assert ($decrypted == Spec.MLKEM.ind_cpa_decrypt $K $ind_cpa_secret_key ${ciphertext}.f_value);
         assert ($to_hash == concat $decrypted $ind_cpa_public_key_hash)"#
     );
-    let mut hashed = [0u8; G_DIGEST_SIZE];
+
     Hasher::G(&to_hash, &mut hashed);
-    let (shared_secret, pseudorandomness) = hashed.split_at(SHARED_SECRET_SIZE);
+    let (shared_secret_prime, derived_randomness) = hashed.split_at(SHARED_SECRET_SIZE);
 
     hax_lib::fstar!(
         r#"assert (($shared_secret , $pseudorandomness) == split $hashed $SHARED_SECRET_SIZE);
@@ -457,21 +491,13 @@ pub(crate) fn decapsulate<
         assert (i4.f_PRF_pre (sz 32) $to_hash);
         lemma_slice_append $to_hash $implicit_rejection_value ${ciphertext}.f_value"
     );
-    let mut implicit_rejection_shared_secret = [0u8; SHARED_SECRET_SIZE];
+
     Hasher::PRF::<32>(&to_hash, &mut implicit_rejection_shared_secret);
 
     hax_lib::fstar!(
         "assert ($implicit_rejection_shared_secret == Spec.Utils.v_PRF (sz 32) $to_hash);
         assert (Seq.length $ind_cpa_public_key == v $PUBLIC_KEY_SIZE)"
     );
-    let mut expected_ciphertext = [0u8; CIPHERTEXT_SIZE];
-    let mut r_as_ntt: [PolynomialRingElement<Vector>; K] =
-        core::array::from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
-    let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
-
-    let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
-
-    let mut matrix_entry = PolynomialRingElement::<Vector>::ZERO();
 
     crate::ind_cpa::encrypt::<
         K,
@@ -494,7 +520,7 @@ pub(crate) fn decapsulate<
     >(
         ind_cpa_public_key,
         decrypted,
-        pseudorandomness,
+        derived_randomness,
         &mut expected_ciphertext,
         &mut matrix_entry,
         &mut r_as_ntt,
@@ -502,18 +528,26 @@ pub(crate) fn decapsulate<
         &mut scratch,
         &mut cache,
         &mut accumulator,
+        &mut error_1,
+        &mut sampling_buffer,
+        &mut u,
+        &mut prf_output,
+        &mut message_as_ring_element,
+        &mut v,
     );
 
-    let mut implicit_rejection_shared_secret_kdf = [0u8; SHARED_SECRET_SIZE];
     Scheme::kdf::<K, CIPHERTEXT_SIZE, Hasher>(
         &implicit_rejection_shared_secret,
         ciphertext,
         &mut implicit_rejection_shared_secret_kdf,
     );
-    let mut shared_secret_kdf = [0u8; SHARED_SECRET_SIZE];
-    Scheme::kdf::<K, CIPHERTEXT_SIZE, Hasher>(shared_secret, ciphertext, &mut shared_secret_kdf);
 
-    let mut shared_secret = [0u8; 32];
+    Scheme::kdf::<K, CIPHERTEXT_SIZE, Hasher>(
+        shared_secret_prime,
+        ciphertext,
+        &mut shared_secret_kdf,
+    );
+
     compare_ciphertexts_select_shared_secret_in_constant_time(
         ciphertext.as_ref(),
         &expected_ciphertext,

--- a/libcrux/libcrux-ml-kem/src/ind_cca.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca.rs
@@ -288,7 +288,7 @@ pub(crate) fn encapsulate<
     let mut r_as_ntt: [PolynomialRingElement<Vector>; K] =
         core::array::from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
     let mut error_2 = PolynomialRingElement::<Vector>::ZERO();
-    let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+    let mut scratch = Vector::ZERO();
     let mut v = PolynomialRingElement::<Vector>::ZERO();
     let mut accumulator = [0i32; 256];
     let mut cache = [PolynomialRingElement::<Vector>::ZERO(); K];
@@ -410,7 +410,7 @@ pub(crate) fn decapsulate<
         r#"assert (v $CIPHERTEXT_SIZE == v $IMPLICIT_REJECTION_HASH_INPUT_SIZE - v $SHARED_SECRET_SIZE)"#
     );
     let mut decrypted = [0u8; 32];
-    let mut scratch = PolynomialRingElement::<Vector>::ZERO();
+    let mut scratch = Vector::ZERO();
     let mut v = PolynomialRingElement::<Vector>::ZERO();
     let mut message = PolynomialRingElement::<Vector>::ZERO();
     let mut accumulator = [0i32; 256];

--- a/libcrux/libcrux-ml-kem/src/ind_cca/instantiations.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cca/instantiations.rs
@@ -1,5 +1,5 @@
 macro_rules! instantiate {
-    ($modp:ident, $vector:path, $hash:path) => {
+    ($modp:ident, $vector:path) => {
         pub mod $modp {
             use crate::{
                 MlKemCiphertext, MlKemKeyPair, MlKemPrivateKey, MlKemPublicKey, MlKemSharedSecret,
@@ -35,7 +35,7 @@ macro_rules! instantiate {
                     ETA1_RANDOMNESS_SIZE,
                     PRF_OUTPUT_SIZE1,
                     $vector,
-                    $hash,
+
                     crate::variant::MlKem,
                 >(randomness)
             }
@@ -63,7 +63,7 @@ macro_rules! instantiate {
                     ETA1_RANDOMNESS_SIZE,
                     PRF_OUTPUT_SIZE1,
                     $vector,
-                    $hash,
+
                     crate::variant::Kyber,
                 >(randomness)
             }
@@ -98,7 +98,7 @@ macro_rules! instantiate {
                 private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
                 ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
             ) -> bool {
-                crate::ind_cca::validate_private_key::<K, SECRET_KEY_SIZE, CIPHERTEXT_SIZE, $hash>(
+                crate::ind_cca::validate_private_key::<K, SECRET_KEY_SIZE, CIPHERTEXT_SIZE>(
                     private_key,
                     ciphertext,
                 )
@@ -114,7 +114,7 @@ macro_rules! instantiate {
             >(
                 private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
             ) -> bool {
-                crate::ind_cca::validate_private_key_only::<K, SECRET_KEY_SIZE, $hash>(private_key)
+                crate::ind_cca::validate_private_key_only::<K, SECRET_KEY_SIZE>(private_key)
             }
 
             /// Portable encapsulate
@@ -159,7 +159,7 @@ macro_rules! instantiate {
                     PRF_OUTPUT_SIZE1,
                     PRF_OUTPUT_SIZE2,
                     $vector,
-                    $hash,
+
                     crate::variant::Kyber,
                 >(public_key, randomness)
             }
@@ -216,7 +216,7 @@ macro_rules! instantiate {
                     PRF_OUTPUT_SIZE1,
                     PRF_OUTPUT_SIZE2,
                     $vector,
-                    $hash,
+
                     crate::variant::MlKem,
                 >(public_key, randomness)
             }
@@ -268,7 +268,7 @@ macro_rules! instantiate {
                     PRF_OUTPUT_SIZE2,
                     IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                     $vector,
-                    $hash,
+
                     crate::variant::Kyber,
                 >(private_key, ciphertext)
             }
@@ -335,7 +335,7 @@ macro_rules! instantiate {
                     PRF_OUTPUT_SIZE2,
                     IMPLICIT_REJECTION_HASH_INPUT_SIZE,
                     $vector,
-                    $hash,
+
                     crate::variant::MlKem,
                 >(private_key, ciphertext)
             }
@@ -344,4 +344,4 @@ macro_rules! instantiate {
 }
 
 // Portable generic implementations.
-instantiate! {portable, crate::vector::portable::PortableVector, crate::hash_functions::portable::PortableHash}
+instantiate! {portable, crate::vector::portable::PortableVector}

--- a/libcrux/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cpa.rs
@@ -247,8 +247,8 @@ fn sample_ring_element_cbd<
 >(
     prf_input: [u8; 33],
     mut domain_separator: u8,
-    error_1: &mut [PolynomialRingElement<Vector>],
-    sample_buffer: &mut [i16; 256],
+    error_1: &mut [PolynomialRingElement<Vector>], // length k
+    sample_buffer: &mut [i16],                     // length 256
 ) -> u8 {
     let mut prf_inputs = [prf_input; K];
     // See https://github.com/hacspec/hax/issues/1167
@@ -658,7 +658,7 @@ fn compress_then_serialize_u<
     const BLOCK_LEN: usize,
     Vector: Operations,
 >(
-    input: [PolynomialRingElement<Vector>; K],
+    input: &[PolynomialRingElement<Vector>], // length k
     out: &mut [u8],
     scratch: &mut Vector,
 ) {
@@ -791,6 +791,12 @@ pub(crate) fn encrypt<
     scratch: &mut PolynomialRingElement<Vector>,
     cache: &mut [PolynomialRingElement<Vector>],
     accumulator: &mut [i32; 256],
+    error_1: &mut [PolynomialRingElement<Vector>], // length k, must be zero
+    sampling_buffer: &mut [i16],                   // length 256
+    u: &mut [PolynomialRingElement<Vector>],       // length k, must be zero
+    prf_output: &mut [u8],                         // length ETA2_RANDOMNESS_SIZE
+    message_as_ring_element: &mut PolynomialRingElement<Vector>, // must be zero
+    v: &mut PolynomialRingElement<Vector>,         // must be zero
 ) {
     encrypt_c1::<
         K,
@@ -816,6 +822,10 @@ pub(crate) fn encrypt<
         scratch,
         cache,
         accumulator,
+        error_1,
+        sampling_buffer,
+        u,
+        prf_output,
     );
 
     encrypt_c2::<K, V_COMPRESSION_FACTOR, C2_LEN, Vector>(
@@ -828,6 +838,8 @@ pub(crate) fn encrypt<
         scratch,
         &cache,
         accumulator,
+        message_as_ring_element,
+        v,
     );
 }
 
@@ -856,13 +868,18 @@ pub(crate) fn encrypt_c1<
     scratch: &mut PolynomialRingElement<Vector>,
     cache: &mut [PolynomialRingElement<Vector>],
     accumulator: &mut [i32; 256],
+    error_1: &mut [PolynomialRingElement<Vector>], // length k, must be zero
+    sampling_buffer: &mut [i16],                   // length 256
+    u: &mut [PolynomialRingElement<Vector>],       // length k, must be zero
+    prf_output: &mut [u8],                         // length ETA2_RANDOMNESS_SIZE
 ) {
+    let mut prf_input: [u8; 33] = into_padded_array(randomness);
+
     // for i from 0 to k−1 do
     //     r[i] := CBD{η1}(PRF(r, N))
     //     N := N + 1
     // end for
     // rˆ := NTT(r)
-    let mut prf_input: [u8; 33] = into_padded_array(randomness);
     let domain_separator = sample_vector_cbd_then_ntt::<
         K,
         ETA1,
@@ -880,15 +897,12 @@ pub(crate) fn encrypt_c1<
     //     e1[i] := CBD_{η2}(PRF(r,N))
     //     N := N + 1
     // end for
-    let mut error_1: [PolynomialRingElement<Vector>; K] =
-        from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
-    let mut sampling_buffer = [0i16; 256];
     let domain_separator =
         sample_ring_element_cbd::<K, ETA2_RANDOMNESS_SIZE, ETA2, PRF_OUTPUT_SIZE2, Vector, Hasher>(
             prf_input,
             domain_separator,
-            &mut error_1,
-            &mut sampling_buffer,
+            error_1,
+            sampling_buffer,
         );
 
     // e_2 := CBD{η2}(PRF(r, N))
@@ -897,20 +911,18 @@ pub(crate) fn encrypt_c1<
         "assert (Seq.equal $prf_input (Seq.append $randomness (Seq.create 1 $domain_separator)));
         assert ($prf_input == Seq.append $randomness (Seq.create 1 $domain_separator))"
     );
-    let mut prf_output = [0u8; ETA2_RANDOMNESS_SIZE];
-    Hasher::PRF::<32>(&prf_input, &mut prf_output);
-    sample_from_binomial_distribution::<ETA2, Vector>(&prf_output, &mut sampling_buffer);
+
+    Hasher::PRF::<32>(&prf_input, prf_output);
+    sample_from_binomial_distribution::<ETA2, Vector>(&prf_output, sampling_buffer);
     PolynomialRingElement::from_i16_array(&sampling_buffer, error_2);
 
     // u := NTT^{-1}(AˆT ◦ rˆ) + e_1
-    let mut u = from_fn(|_i| PolynomialRingElement::<Vector>::ZERO());
-
     compute_vector_u::<K, Vector, Hasher>(
         matrix_entry,
         seed_for_a,
         &r_as_ntt,
         &error_1,
-        &mut u,
+        u,
         scratch,
         cache,
         accumulator,
@@ -918,7 +930,7 @@ pub(crate) fn encrypt_c1<
 
     // c_1 := Encode_{du}(Compress_q(u,d_u))
     compress_then_serialize_u::<K, C1_LEN, U_COMPRESSION_FACTOR, BLOCK_LEN, Vector>(
-        u,
+        &u,
         ciphertext,
         &mut scratch.coefficients[0],
     );
@@ -940,18 +952,19 @@ pub(crate) fn encrypt_c2<
     scratch: &mut PolynomialRingElement<Vector>,
     cache: &[PolynomialRingElement<Vector>],
     accumulator: &mut [i32; 256],
+    message_as_ring_element: &mut PolynomialRingElement<Vector>, // must be zero
+    v: &mut PolynomialRingElement<Vector>,                       // must be zero
 ) {
+    deserialize_then_decompress_message(message, message_as_ring_element);
+
     // v := NTT^{−1}(tˆT ◦ rˆ) + e_2 + Decompress_q(Decode_1(m),1)
-    let mut message_as_ring_element = PolynomialRingElement::<Vector>::ZERO();
-    deserialize_then_decompress_message(message, &mut message_as_ring_element);
-    let mut v = PolynomialRingElement::<Vector>::ZERO();
     compute_ring_element_v::<K, Vector>(
         public_key,
         t_as_ntt_entry,
         r_as_ntt,
         error_2,
         &message_as_ring_element,
-        &mut v,
+        v,
         scratch,
         cache,
         accumulator,
@@ -1026,7 +1039,7 @@ fn deserialize_then_decompress_u<
 )]
 pub(crate) fn deserialize_vector<const K: usize, Vector: Operations>(
     secret_key: &[u8],
-    secret_as_ntt: &mut [PolynomialRingElement<Vector>],
+    secret_as_ntt: &mut [PolynomialRingElement<Vector>], // length k
 ) {
     for i in 0..K {
         hax_lib::loop_invariant!(|i: usize| {
@@ -1093,37 +1106,31 @@ pub(crate) fn decrypt_unpacked<
     const V_COMPRESSION_FACTOR: usize,
     Vector: Operations,
 >(
-    secret_key: &IndCpaPrivateKeyUnpacked<K, Vector>,
+    secret_as_ntt: &[PolynomialRingElement<Vector>], // length k
     ciphertext: &[u8; CIPHERTEXT_SIZE],
     decrypted: &mut [u8],
     scratch: &mut PolynomialRingElement<Vector>,
     accumulator: &mut [i32; 256],
+    v: &mut PolynomialRingElement<Vector>, // needs to be zero
+    u_as_ntt: &mut [PolynomialRingElement<Vector>], // length K, needs to be zero
+    message: &mut PolynomialRingElement<Vector>, // needs to be zero
 ) {
     // u := Decompress_q(Decode_{d_u}(c), d_u)
-    let mut u_as_ntt = from_fn(|_| PolynomialRingElement::<Vector>::ZERO());
     deserialize_then_decompress_u::<K, CIPHERTEXT_SIZE, U_COMPRESSION_FACTOR, Vector>(
         ciphertext,
-        &mut u_as_ntt,
+        u_as_ntt,
         &mut scratch.coefficients[0],
     );
 
     // v := Decompress_q(Decode_{d_v}(c + d_u·k·n / 8), d_v)
-    let mut v = PolynomialRingElement::<Vector>::ZERO();
     deserialize_then_decompress_ring_element_v::<K, V_COMPRESSION_FACTOR, Vector>(
         &ciphertext[VECTOR_U_ENCODED_SIZE..],
-        &mut v,
+        v,
     );
 
     // m := Encode_1(Compress_q(v − NTT^{−1}(sˆT ◦ NTT(u)) , 1))
-    let mut message = PolynomialRingElement::<Vector>::ZERO();
-    compute_message(
-        &v,
-        &secret_key.secret_as_ntt,
-        &u_as_ntt,
-        &mut message,
-        scratch,
-        accumulator,
-    );
+    compute_message::<K, Vector>(&v, secret_as_ntt, u_as_ntt, message, scratch, accumulator);
+
     compress_then_serialize_message(&message, decrypted, &mut scratch.coefficients[0]);
 }
 
@@ -1151,12 +1158,14 @@ pub(crate) fn decrypt<
     decrypted: &mut [u8],
     scratch: &mut PolynomialRingElement<Vector>,
     accumulator: &mut [i32; 256],
+    secret_as_ntt: &mut [PolynomialRingElement<Vector>], // length k, needs to be zero
+    v: &mut PolynomialRingElement<Vector>,               // needs to be zero
+    u_as_ntt: &mut [PolynomialRingElement<Vector>],      // length K, needs to be zero
+    message: &mut PolynomialRingElement<Vector>,         // needs to be zero
 ) {
     hax_lib::fstar!(r#"reveal_opaque (`%Spec.MLKEM.ind_cpa_decrypt) Spec.MLKEM.ind_cpa_decrypt"#);
     // sˆ := Decode_12(sk)
-    let mut secret_as_ntt = from_fn(|_| PolynomialRingElement::<Vector>::ZERO());
-    deserialize_vector::<K, Vector>(secret_key, &mut secret_as_ntt);
-    let secret_key_unpacked = IndCpaPrivateKeyUnpacked { secret_as_ntt };
+    deserialize_vector::<K, Vector>(secret_key, secret_as_ntt);
 
     decrypt_unpacked::<
         K,
@@ -1166,10 +1175,13 @@ pub(crate) fn decrypt<
         V_COMPRESSION_FACTOR,
         Vector,
     >(
-        &secret_key_unpacked,
+        &secret_as_ntt,
         ciphertext,
         decrypted,
         scratch,
         accumulator,
+        v,
+        u_as_ntt,
+        message,
     );
 }

--- a/libcrux/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cpa.rs
@@ -359,38 +359,19 @@ fn sample_vector_cbd_then_ntt<
     Vector: Operations,
 >(
     re_as_ntt: &mut [PolynomialRingElement<Vector>],
-    prf_input: [u8; 33],
-    mut domain_separator: u8,
+    prf_input: &mut [u8; 33],
+    start: u8,
     scratch: &mut Vector,
-) -> u8 {
-    let mut prf_inputs = [prf_input; K];
-    let _domain_separator_init = domain_separator;
-    domain_separator = prf_input_inc::<K>(&mut prf_inputs, domain_separator);
-    hax_lib::fstar!(
-        "sample_vector_cbd_then_ntt_helper_1 $K $prf_inputs $prf_input $_domain_separator_init"
-    );
-    let mut prf_outputs = [0u8; PRF_OUTPUT_SIZE];
-    PortableHash::PRFxN(&prf_inputs, &mut prf_outputs, ETA_RANDOMNESS_SIZE);
+) {
+    let mut prf_output = [0u8; ETA_RANDOMNESS_SIZE];
     for i in 0..K {
-        hax_lib::loop_invariant!(|i: usize| {
-            fstar!(
-                r#"forall (j:nat). j < v $i ==>
-            Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector re_as_ntt.[ sz j ] ==
-              Spec.MLKEM.poly_ntt (Spec.MLKEM.sample_poly_cbd $ETA ${prf_outputs}.[ sz j ]) /\
-            Libcrux_ml_kem.Serialize.coefficients_field_modulus_range #$:Vector re_as_ntt.[ sz j ]"#
-            )
-        });
-        let randomness = &prf_outputs[i * ETA_RANDOMNESS_SIZE..(i + 1) * ETA_RANDOMNESS_SIZE];
+        prf_input[32] = i as u8 + start;
+        PortableHash::PRF::<ETA_RANDOMNESS_SIZE>(prf_input, &mut prf_output);
         let mut sample_buffer = [0i16; 256];
-        sample_from_binomial_distribution::<ETA, Vector>(randomness, &mut sample_buffer);
+        sample_from_binomial_distribution::<ETA, Vector>(&prf_output, &mut sample_buffer);
         PolynomialRingElement::from_i16_array(&sample_buffer, &mut re_as_ntt[i]);
         ntt_binomially_sampled_ring_element(&mut re_as_ntt[i], scratch);
     }
-    hax_lib::fstar!(
-        "sample_vector_cbd_then_ntt_helper_2
-        $K $ETA $ETA_RANDOMNESS_SIZE #$:Vector re_as_ntt $prf_input $_domain_separator_init"
-    );
-    domain_separator
 }
 
 /// This function implements most of <strong>Algorithm 12</strong> of the
@@ -482,22 +463,21 @@ pub(crate) fn generate_keypair_unpacked<
         r#"let (matrix_A_as_ntt, valid) = Spec.MLKEM.sample_matrix_A_ntt #$K $seed_for_A in
         assert (valid ==> matrix_A_as_ntt == Libcrux_ml_kem.Polynomial.to_spec_matrix_t public_key.f_A)"#
     );
-    let prf_input: [u8; 33] = into_padded_array(seed_for_secret_and_error);
+    let mut prf_input: [u8; 33] = into_padded_array(seed_for_secret_and_error);
     hax_lib::fstar!(
         "Lib.Sequence.eq_intro #u8 #32 $seed_for_secret_and_error (Seq.slice $prf_input 0 32)"
     );
-    let domain_separator =
-        sample_vector_cbd_then_ntt::<K, ETA1, ETA1_RANDOMNESS_SIZE, PRF_OUTPUT_SIZE1, Vector>(
-            &mut private_key.secret_as_ntt,
-            prf_input,
-            0,
-            &mut scratch.coefficients[0],
-        );
+    sample_vector_cbd_then_ntt::<K, ETA1, ETA1_RANDOMNESS_SIZE, PRF_OUTPUT_SIZE1, Vector>(
+        &mut private_key.secret_as_ntt,
+        &mut prf_input,
+        0,
+        &mut scratch.coefficients[0],
+    );
     let mut error_as_ntt = from_fn(|_| PolynomialRingElement::<Vector>::ZERO());
-    let _ = sample_vector_cbd_then_ntt::<K, ETA1, ETA1_RANDOMNESS_SIZE, PRF_OUTPUT_SIZE1, Vector>(
+    sample_vector_cbd_then_ntt::<K, ETA1, ETA1_RANDOMNESS_SIZE, PRF_OUTPUT_SIZE1, Vector>(
         &mut error_as_ntt,
-        prf_input,
-        domain_separator,
+        &mut prf_input,
+        K as u8,
         &mut scratch.coefficients[0],
     );
 
@@ -859,10 +839,12 @@ pub(crate) fn encrypt_c1<
     //     N := N + 1
     // end for
     // rˆ := NTT(r)
-    let domain_separator =
-        sample_vector_cbd_then_ntt::<K, ETA1, ETA1_RANDOMNESS_SIZE, PRF_OUTPUT_SIZE1, Vector>(
-            r_as_ntt, prf_input, 0, scratch,
-        );
+    sample_vector_cbd_then_ntt::<K, ETA1, ETA1_RANDOMNESS_SIZE, PRF_OUTPUT_SIZE1, Vector>(
+        r_as_ntt,
+        &mut prf_input,
+        0,
+        scratch,
+    );
     hax_lib::fstar!(
         "Lib.Sequence.eq_intro #u8 #32 $randomness (Seq.slice $prf_input 0 32);
         assert (v $domain_separator == v $K)"
@@ -872,16 +854,16 @@ pub(crate) fn encrypt_c1<
     //     e1[i] := CBD_{η2}(PRF(r,N))
     //     N := N + 1
     // end for
-    let domain_separator = sample_ring_element_cbd::<
+    let _domain_separator = sample_ring_element_cbd::<
         K,
         ETA2_RANDOMNESS_SIZE,
         ETA2,
         PRF_OUTPUT_SIZE2,
         Vector,
-    >(prf_input, domain_separator, error_1, sampling_buffer);
+    >(prf_input, K as u8, error_1, sampling_buffer);
 
     // e_2 := CBD{η2}(PRF(r, N))
-    prf_input[32] = domain_separator;
+    prf_input[32] = 2 * K as u8;
     hax_lib::fstar!(
         "assert (Seq.equal $prf_input (Seq.append $randomness (Seq.create 1 $domain_separator)));
         assert ($prf_input == Seq.append $randomness (Seq.create 1 $domain_separator))"

--- a/libcrux/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux/libcrux-ml-kem/src/ind_cpa.rs
@@ -17,7 +17,7 @@ use crate::{
         deserialize_then_decompress_ring_element_u, deserialize_then_decompress_ring_element_v,
         deserialize_to_uncompressed_ring_element, serialize_uncompressed_ring_element,
     },
-    utils::{into_padded_array, prf_input_inc},
+    utils::into_padded_array,
     variant::Variant,
     vector::Operations,
 };
@@ -247,7 +247,6 @@ fn sample_ring_element_cbd<
     prf_input: &mut [u8; 33],
     start: u8,
     error_1: &mut [PolynomialRingElement<Vector>], // length k
-    sample_buffer: &mut [i16],                     // length 256
 ) {
     let mut prf_output = [0u8; ETA2_RANDOMNESS_SIZE];
     for i in 0..K {
@@ -836,13 +835,12 @@ pub(crate) fn encrypt_c1<
     //     e1[i] := CBD_{η2}(PRF(r,N))
     //     N := N + 1
     // end for
-    let _domain_separator = sample_ring_element_cbd::<
-        K,
-        ETA2_RANDOMNESS_SIZE,
-        ETA2,
-        PRF_OUTPUT_SIZE2,
-        Vector,
-    >(&mut prf_input, K as u8, error_1, sampling_buffer);
+    let _domain_separator =
+        sample_ring_element_cbd::<K, ETA2_RANDOMNESS_SIZE, ETA2, PRF_OUTPUT_SIZE2, Vector>(
+            &mut prf_input,
+            K as u8,
+            error_1,
+        );
 
     // e_2 := CBD{η2}(PRF(r, N))
     prf_input[32] = 2 * K as u8;

--- a/libcrux/libcrux-ml-kem/src/invert_ntt.rs
+++ b/libcrux/libcrux-ml-kem/src/invert_ntt.rs
@@ -205,7 +205,6 @@ pub(crate) fn invert_ntt_at_layer_4_plus<Vector: Operations>(
     for _round in 0..(128 >> layer) {
         *zeta_i -= 1;
 
-        // XXX: split_at_mut this
         let (a, rest) = remaining_elements.split_at_mut(step_vec);
         let (b, rest) = rest.split_at_mut(step_vec);
         remaining_elements = rest;

--- a/libcrux/libcrux-ml-kem/src/matrix.rs
+++ b/libcrux/libcrux-ml-kem/src/matrix.rs
@@ -105,8 +105,8 @@ pub(crate) fn sample_matrix_A<const K: usize, Vector: Operations, Hasher: Hash>(
 )]
 pub(crate) fn compute_message<const K: usize, Vector: Operations>(
     v: &PolynomialRingElement<Vector>,
-    secret_as_ntt: &[PolynomialRingElement<Vector>; K],
-    u_as_ntt: &[PolynomialRingElement<Vector>; K],
+    secret_as_ntt: &[PolynomialRingElement<Vector>], // length k
+    u_as_ntt: &[PolynomialRingElement<Vector>],      // length k
     result: &mut PolynomialRingElement<Vector>,
     scratch: &mut PolynomialRingElement<Vector>,
     accumulator: &mut [i32; 256],

--- a/libcrux/libcrux-ml-kem/src/matrix.rs
+++ b/libcrux/libcrux-ml-kem/src/matrix.rs
@@ -108,7 +108,7 @@ pub(crate) fn compute_message<const K: usize, Vector: Operations>(
     secret_as_ntt: &[PolynomialRingElement<Vector>], // length k
     u_as_ntt: &[PolynomialRingElement<Vector>],      // length k
     result: &mut PolynomialRingElement<Vector>,
-    scratch: &mut PolynomialRingElement<Vector>,
+    scratch: &mut Vector,
     accumulator: &mut [i32; 256],
 ) {
     *accumulator = [0i32; 256];
@@ -117,7 +117,7 @@ pub(crate) fn compute_message<const K: usize, Vector: Operations>(
     }
 
     PolynomialRingElement::reducing_from_i32_array(accumulator, result);
-    invert_ntt_montgomery::<K, Vector>(result, &mut scratch.coefficients[0]);
+    invert_ntt_montgomery::<K, Vector>(result, scratch);
     v.subtract_reduce(result);
 }
 
@@ -142,7 +142,7 @@ pub(crate) fn compute_ring_element_v<const K: usize, Vector: Operations>(
     error_2: &PolynomialRingElement<Vector>,
     message: &PolynomialRingElement<Vector>,
     result: &mut PolynomialRingElement<Vector>,
-    scratch: &mut PolynomialRingElement<Vector>,
+    scratch: &mut Vector,
     cache: &[PolynomialRingElement<Vector>],
     accumulator: &mut [i32; 256],
 ) {
@@ -153,8 +153,8 @@ pub(crate) fn compute_ring_element_v<const K: usize, Vector: Operations>(
     }
     PolynomialRingElement::reducing_from_i32_array(accumulator, result);
 
-    invert_ntt_montgomery::<K, Vector>(result, &mut scratch.coefficients[0]);
-    error_2.add_message_error_reduce(message, result, &mut scratch.coefficients[0]);
+    invert_ntt_montgomery::<K, Vector>(result, scratch);
+    error_2.add_message_error_reduce(message, result);
 }
 
 /// Compute u := InvertNTT(Aᵀ ◦ r̂) + e₁
@@ -177,7 +177,7 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations, Hasher: Hash>
     r_as_ntt: &[PolynomialRingElement<Vector>],
     error_1: &[PolynomialRingElement<Vector>],
     result: &mut [PolynomialRingElement<Vector>],
-    scratch: &mut PolynomialRingElement<Vector>,
+    scratch: &mut Vector,
     cache: &mut [PolynomialRingElement<Vector>],
     accumulator: &mut [i32; 256],
 ) {
@@ -190,7 +190,7 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations, Hasher: Hash>
         matrix_entry.accumulating_ntt_multiply_fill_cache(&r_as_ntt[j], accumulator, &mut cache[j]);
     }
     PolynomialRingElement::reducing_from_i32_array(accumulator, &mut result[0]);
-    invert_ntt_montgomery::<K, Vector>(&mut result[0], &mut scratch.coefficients[0]);
+    invert_ntt_montgomery::<K, Vector>(&mut result[0], scratch);
     result[0].add_error_reduce(&error_1[0]);
 
     for i in 1..K {
@@ -201,7 +201,7 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations, Hasher: Hash>
         }
         PolynomialRingElement::reducing_from_i32_array(accumulator, &mut result[i]);
 
-        invert_ntt_montgomery::<K, Vector>(&mut result[i], &mut scratch.coefficients[0]);
+        invert_ntt_montgomery::<K, Vector>(&mut result[i], scratch);
         result[i].add_error_reduce(&error_1[i]);
     }
 }

--- a/libcrux/libcrux-ml-kem/src/polynomial.rs
+++ b/libcrux/libcrux-ml-kem/src/polynomial.rs
@@ -182,7 +182,6 @@ fn add_message_error_reduce<Vector: Operations>(
     myself: &PolynomialRingElement<Vector>,
     message: &PolynomialRingElement<Vector>,
     result: &mut PolynomialRingElement<Vector>,
-    scratch: &mut Vector,
 ) {
     // Using `hax_lib::fstar::verification_status(lax)` works but produces an error while extracting
     for i in 0..VECTORS_IN_RING_ELEMENT {
@@ -203,9 +202,8 @@ fn add_message_error_reduce<Vector: Operations>(
         //     &Vector::add(myself.coefficients[i], &message.coefficients[i]),
         // ));
         // ```
-        *scratch = myself.coefficients[i].clone(); // XXX: Need this?
-        Vector::add(scratch, &message.coefficients[i]);
-        Vector::add(&mut result.coefficients[i], &scratch);
+        Vector::add(&mut result.coefficients[i], &message.coefficients[i]);
+        Vector::add(&mut result.coefficients[i], &myself.coefficients[i]);
         Vector::barrett_reduce(&mut result.coefficients[i]);
     }
 }
@@ -400,13 +398,8 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
     }
 
     #[inline(always)]
-    pub(crate) fn add_message_error_reduce(
-        &self,
-        message: &Self,
-        result: &mut Self,
-        scratch: &mut Vector,
-    ) {
-        add_message_error_reduce(self, message, result, scratch);
+    pub(crate) fn add_message_error_reduce(&self, message: &Self, result: &mut Self) {
+        add_message_error_reduce(self, message, result);
     }
 
     #[inline(always)]

--- a/libcrux/libcrux-ml-kem/src/sampling.rs
+++ b/libcrux/libcrux-ml-kem/src/sampling.rs
@@ -209,7 +209,7 @@ fn sample_from_binomial_distribution_2<Vector: Operations>(
 #[hax_lib::fstar::options("--z3rlimit 800")]
 fn sample_from_binomial_distribution_3<Vector: Operations>(
     randomness: &[u8],
-    sampled_i16s: &mut [i16; 256],
+    sampled_i16s: &mut [i16], // length 256
 ) {
     hax_lib::fstar!(
         "assert (v (sz 3 *! sz 64) == 192);
@@ -259,7 +259,7 @@ fn sample_from_binomial_distribution_3<Vector: Operations>(
         Spec.MLKEM.sample_poly_cbd $ETA $randomness"#))]
 pub(super) fn sample_from_binomial_distribution<const ETA: usize, Vector: Operations>(
     randomness: &[u8],
-    output: &mut [i16; 256],
+    output: &mut [i16], // length 256
 ) {
     hax_lib::fstar!(
         r#"assert (

--- a/libcrux/libcrux-ml-kem/src/sampling.rs
+++ b/libcrux/libcrux-ml-kem/src/sampling.rs
@@ -1,5 +1,8 @@
 use crate::{
-    constants::COEFFICIENTS_IN_RING_ELEMENT, hash_functions::*, helper::cloop, vector::Operations,
+    constants::COEFFICIENTS_IN_RING_ELEMENT,
+    hash_functions::{portable::PortableHash, *},
+    helper::cloop,
+    vector::Operations,
 };
 
 /// If `bytes` contains a set of uniformly random bytes, this function
@@ -42,63 +45,60 @@ use crate::{
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[inline(always)]
 fn sample_from_uniform_distribution_next<Vector: Operations, const K: usize, const N: usize>(
-    randomness: &[[u8; N]],
-    sampled_coefficients: &mut [usize],
-    out: &mut [[i16; 272]],
+    randomness: &[u8; N],
+    sampled_coefficients: &mut usize,
+    out: &mut [i16; 272],
 ) -> bool {
-    // Would be great to trigger auto-vectorization or at least loop unrolling here
-    for i in 0..K {
-        for r in 0..N / 24 {
-            if sampled_coefficients[i] < COEFFICIENTS_IN_RING_ELEMENT {
-                let sampled = Vector::rej_sample(
-                    &randomness[i][r * 24..(r * 24) + 24],
-                    &mut out[i][sampled_coefficients[i]..sampled_coefficients[i] + 16],
-                );
-                sampled_coefficients[i] += sampled;
-            }
+    for r in 0..N / 24 {
+        if *sampled_coefficients < COEFFICIENTS_IN_RING_ELEMENT {
+            let sampled = Vector::rej_sample(
+                &randomness[r * 24..(r * 24) + 24],
+                &mut out[*sampled_coefficients..*sampled_coefficients + 16],
+            );
+            *sampled_coefficients += sampled;
         }
     }
-    let mut done = true;
-    for i in 0..K {
-        if sampled_coefficients[i] >= COEFFICIENTS_IN_RING_ELEMENT {
-            sampled_coefficients[i] = COEFFICIENTS_IN_RING_ELEMENT;
-        } else {
-            done = false
-        }
+
+    if *sampled_coefficients >= COEFFICIENTS_IN_RING_ELEMENT {
+        *sampled_coefficients = COEFFICIENTS_IN_RING_ELEMENT;
+        true
+    } else {
+        false
     }
-    done
 }
 
 #[inline(always)]
 #[hax_lib::fstar::verification_status(lax)]
-pub(super) fn sample_from_xof<const K: usize, Vector: Operations, Hasher: Hash>(
+pub(super) fn sample_from_xof<const K: usize, Vector: Operations>(
     seeds: &[[u8; 34]],
     sampled_coefficients: &mut [usize],
     out: &mut [[i16; 272]],
 ) {
-    let mut xof_state = Hasher::shake128_init_absorb_final(seeds);
-    let mut randomness = [[0u8; THREE_BLOCKS]; K];
-    let mut randomness_blocksize = [[0u8; BLOCK_SIZE]; K];
-    xof_state.shake128_squeeze_first_three_blocks(&mut randomness);
+    for i in 0..K {
+        let mut xof_state = PortableHash::shake128_init_absorb_final(&seeds[i]);
+        let mut randomness = [0u8; THREE_BLOCKS];
+        let mut randomness_blocksize = [0u8; BLOCK_SIZE];
+        xof_state.shake128_squeeze_first_three_blocks(&mut randomness);
 
-    let mut done = sample_from_uniform_distribution_next::<Vector, K, THREE_BLOCKS>(
-        &randomness,
-        sampled_coefficients,
-        out,
-    );
-
-    // Requiring more than 5 blocks to sample a ring element should be very
-    // unlikely according to:
-    // https://eprint.iacr.org/2023/708.pdf
-    // To avoid failing here, we squeeze more blocks out of the state until
-    // we have enough.
-    while !done {
-        xof_state.shake128_squeeze_next_block(&mut randomness_blocksize);
-        done = sample_from_uniform_distribution_next::<Vector, K, BLOCK_SIZE>(
-            &randomness_blocksize,
-            sampled_coefficients,
-            out,
+        let mut done = sample_from_uniform_distribution_next::<Vector, K, THREE_BLOCKS>(
+            &randomness,
+            &mut sampled_coefficients[i],
+            &mut out[i],
         );
+
+        // Requiring more than 5 blocks to sample a ring element should be very
+        // unlikely according to:
+        // https://eprint.iacr.org/2023/708.pdf
+        // To avoid failing here, we squeeze more blocks out of the state until
+        // we have enough.
+        while !done {
+            xof_state.shake128_squeeze_next_block(&mut randomness_blocksize);
+            done = sample_from_uniform_distribution_next::<Vector, K, BLOCK_SIZE>(
+                &randomness_blocksize,
+                &mut sampled_coefficients[i],
+                &mut out[i],
+            );
+        }
     }
 }
 

--- a/libcrux/libcrux-ml-kem/src/serialize.rs
+++ b/libcrux/libcrux-ml-kem/src/serialize.rs
@@ -269,7 +269,7 @@ pub(super) fn compress_then_serialize_ring_element_u<
     fstar!(r#"${serialized_future.len()} == ${serialized.len()}"#)
 )]
 fn compress_then_serialize_4<Vector: Operations>(
-    re: PolynomialRingElement<Vector>,
+    re: &PolynomialRingElement<Vector>,
     serialized: &mut [u8],
     scratch: &mut Vector,
 ) {
@@ -303,7 +303,7 @@ fn compress_then_serialize_4<Vector: Operations>(
     fstar!(r#"${serialized_future.len()} == ${serialized.len()}"#)
 )]
 fn compress_then_serialize_5<Vector: Operations>(
-    re: PolynomialRingElement<Vector>,
+    re: &PolynomialRingElement<Vector>,
     serialized: &mut [u8],
     scratch: &mut Vector,
 ) {
@@ -332,7 +332,7 @@ pub(super) fn compress_then_serialize_ring_element_v<
     const OUT_LEN: usize,
     Vector: Operations,
 >(
-    re: PolynomialRingElement<Vector>,
+    re: &PolynomialRingElement<Vector>,
     out: &mut [u8],
     scratch: &mut Vector,
 ) {

--- a/libcrux/libcrux-ml-kem/src/utils.rs
+++ b/libcrux/libcrux-ml-kem/src/utils.rs
@@ -29,37 +29,6 @@ pub(crate) fn into_padded_array<const LEN: usize>(slice: &[u8]) -> [u8; LEN] {
     out
 }
 
-#[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 200")]
-#[hax_lib::requires(fstar!(r#"range (v $domain_separator + v $K) u8_inttype"#))]
-#[hax_lib::ensures(|ds|
-    fstar!(r#"v $ds == v $domain_separator + v $K /\
-            (forall (i:nat). i < v $K ==>
-                v (Seq.index (Seq.index ${prf_inputs}_future i) 32) == v $domain_separator + i /\
-                Seq.slice (Seq.index ${prf_inputs}_future i) 0 32 == Seq.slice (Seq.index $prf_inputs i) 0 32)"#)
-)]
-pub(crate) fn prf_input_inc<const K: usize>(
-    prf_inputs: &mut [[u8; 33]; K],
-    mut domain_separator: u8,
-) -> u8 {
-    let _domain_separator_init = domain_separator;
-    let _prf_inputs_init = prf_inputs.clone();
-    for i in 0..K {
-        hax_lib::loop_invariant!(|i: usize| {
-            fstar!(
-                r#"v $domain_separator == v $_domain_separator_init + v $i /\
-          (v $i < v $K ==> (forall (j:nat). (j >= v $i /\ j < v $K) ==>
-            prf_inputs.[ sz j ] == ${_prf_inputs_init}.[ sz j ])) /\
-          (forall (j:nat). j < v $i ==> v (Seq.index (Seq.index prf_inputs j) 32) == v $_domain_separator_init + j /\
-            Seq.slice (Seq.index prf_inputs j) 0 32 == Seq.slice (Seq.index $_prf_inputs_init j) 0 32)"#
-            )
-        });
-        prf_inputs[i][32] = domain_separator;
-        domain_separator += 1;
-    }
-    domain_separator
-}
-
 // C extraction:
 //
 // This is only enabled when extracting.

--- a/libcrux/libcrux-ml-kem/src/variant.rs
+++ b/libcrux/libcrux-ml-kem/src/variant.rs
@@ -2,7 +2,10 @@
 //! differences between the NIST standard FIPS 203 (ML-KEM) and the
 //! Round 3 CRYSTALS-Kyber submissions in the NIST PQ competition.
 
-use crate::{constants::CPA_PKE_KEY_GENERATION_SEED_SIZE, hash_functions::Hash, MlKemCiphertext};
+use crate::{
+    constants::CPA_PKE_KEY_GENERATION_SEED_SIZE, hash_functions::portable::PortableHash,
+    MlKemCiphertext,
+};
 
 /// This trait collects differences in specification between ML-KEM
 /// (FIPS 203) and the Round 3 CRYSTALS-Kyber submission in the
@@ -13,19 +16,19 @@ use crate::{constants::CPA_PKE_KEY_GENERATION_SEED_SIZE, hash_functions::Hash, M
 pub(crate) trait Variant {
     #[requires(shared_secret.len() == 32)]
     #[ensures(|res| fstar!(r#"$res == $shared_secret"#))] // We only have post-conditions for ML-KEM, not Kyber
-    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash>(
+    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize>(
         shared_secret: &[u8],
         ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
         out: &mut [u8],
     );
     #[requires(randomness.len() == 32)]
     #[ensures(|res| fstar!(r#"$res == $randomness"#))] // We only have post-conditions for ML-KEM, not Kyber
-    fn entropy_preprocess<const K: usize, Hasher: Hash>(randomness: &[u8], out: &mut [u8]);
+    fn entropy_preprocess<const K: usize>(randomness: &[u8], out: &mut [u8]);
     #[requires(seed.len() == 32)]
     #[ensures(|res| fstar!(r#"Seq.length $seed == 32 ==> $res == Spec.Utils.v_G
         (Seq.append $seed (Seq.create 1 (cast $K <: u8)))"#)
     )]
-    fn cpa_keygen_seed<const K: usize, Hasher: Hash>(seed: &[u8], out: &mut [u8]);
+    fn cpa_keygen_seed<const K: usize>(seed: &[u8], out: &mut [u8]);
 }
 
 /// Implements [`Variant`], to perform the Kyber-specific actions
@@ -40,7 +43,7 @@ pub(crate) struct Kyber {}
 #[cfg(feature = "kyber")]
 impl Variant for Kyber {
     #[inline(always)]
-    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash>(
+    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize>(
         shared_secret: &[u8],
         ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
         out: &mut [u8],
@@ -48,21 +51,18 @@ impl Variant for Kyber {
         use crate::{constants::H_DIGEST_SIZE, utils::into_padded_array};
 
         let mut kdf_input: [u8; 2 * H_DIGEST_SIZE] = into_padded_array(&shared_secret);
-        Hasher::H(ciphertext.as_slice(), &mut kdf_input[H_DIGEST_SIZE..]);
-        Hasher::PRF::<32>(&kdf_input, out)
+        PortableHash::H(ciphertext.as_slice(), &mut kdf_input[H_DIGEST_SIZE..]);
+        PortableHash::PRF::<32>(&kdf_input, out)
     }
 
     #[inline(always)]
-    fn entropy_preprocess<const K: usize, Hasher: Hash>(randomness: &[u8], out: &mut [u8]) {
-        Hasher::H(&randomness, out)
+    fn entropy_preprocess<const K: usize>(randomness: &[u8], out: &mut [u8]) {
+        PortableHash::H(&randomness, out)
     }
 
     #[inline(always)]
-    fn cpa_keygen_seed<const K: usize, Hasher: Hash>(
-        key_generation_seed: &[u8],
-        out: &mut [u8],
-    ) {
-        Hasher::G(key_generation_seed, out)
+    fn cpa_keygen_seed<const K: usize>(key_generation_seed: &[u8], out: &mut [u8]) {
+        PortableHash::G(key_generation_seed, out)
     }
 }
 
@@ -79,7 +79,7 @@ impl Variant for MlKem {
     #[inline(always)]
     #[requires(shared_secret.len() == 32)]
     #[ensures(|res| fstar!(r#"$res == $shared_secret"#))]
-    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash>(
+    fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize>(
         shared_secret: &[u8],
         _: &MlKemCiphertext<CIPHERTEXT_SIZE>,
         out: &mut [u8],
@@ -90,7 +90,7 @@ impl Variant for MlKem {
     #[inline(always)]
     #[requires(randomness.len() == 32)]
     #[ensures(|res| fstar!(r#"$res == $randomness"#))]
-    fn entropy_preprocess<const K: usize, Hasher: Hash>(randomness: &[u8], out: &mut [u8]) {
+    fn entropy_preprocess<const K: usize>(randomness: &[u8], out: &mut [u8]) {
         out.copy_from_slice(randomness);
     }
 
@@ -99,7 +99,7 @@ impl Variant for MlKem {
     #[ensures(|res| fstar!(r#"Seq.length $key_generation_seed == 32 ==> $res == Spec.Utils.v_G
         (Seq.append $key_generation_seed (Seq.create 1 (cast $K <: u8)))"#)
     )]
-    fn cpa_keygen_seed<const K: usize, Hasher: Hash>(key_generation_seed: &[u8], out: &mut [u8]) {
+    fn cpa_keygen_seed<const K: usize>(key_generation_seed: &[u8], out: &mut [u8]) {
         let mut seed = [0u8; CPA_PKE_KEY_GENERATION_SEED_SIZE + 1];
         seed[0..CPA_PKE_KEY_GENERATION_SEED_SIZE].copy_from_slice(key_generation_seed);
         seed[CPA_PKE_KEY_GENERATION_SEED_SIZE] = K as u8;
@@ -107,6 +107,6 @@ impl Variant for MlKem {
             "Lib.Sequence.eq_intro #u8 #33 $seed
             (Seq.append $key_generation_seed (Seq.create 1 (cast $K <: u8)))"
         );
-        Hasher::G(&seed, out);
+        PortableHash::G(&seed, out);
     }
 }


### PR DESCRIPTION
This PR was an attempt to address #82, but after many tries, it turned out that manually re-using allocations usually made stack usage worse.
There are two things that can be salvaged from all these trials:
- For `shake128` we were always initializing four `KeccakState` structs, even if we only need one, as is the case for on-the-fly sampling (and we don't have any parallelism to exploit on the IoT target anyway).
- We were using `PRFxN` for sampling ring elements, meaning we would sample a lot of randomness first and then generating ring elements from that. Splitting that up and sampling randomness for individual ring elements reduces stack usage in key generation by about 20%.

In the course of these changes I removed the `Hash` abstraction and we should use `PortableHash` everywhere now.