### PR TITLE
Fix ML-DSA CI

### DIFF
--- a/.github/workflows/get-hax-ref.yml
+++ b/.github/workflows/get-hax-ref.yml
@@ -1,0 +1,25 @@
+name: Get hax rev
+
+on:
+  workflow_call:
+    outputs:
+      hax_ref:
+        description: "the tag for the hax revision"
+        value: ${{ jobs.get-hax-ref.outputs.hax_ref }}
+
+
+    
+jobs:
+  get-hax-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      hax_ref: ${{ steps.step1.outputs.hax_ref }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: step1
+        working-directory: libcrux-iot
+        run: |
+          # use hax from the commit at which hax-lib is pinned in the Cargo.toml of libcrux.
+          HAX_VERSION="$(cargo metadata --format-version=1 | jq -r '.packages[] | select(.name=="hax-lib") | .version' | uniq)"
+          echo "hax_ref=hax-lib-v$HAX_VERSION" >> $GITHUB_OUTPUT
+          echo "Using hax $HAX_VERSION"

--- a/.github/workflows/mldsa-hax.yaml
+++ b/.github/workflows/mldsa-hax.yaml
@@ -45,7 +45,7 @@ jobs:
           fstar: v2025.03.25
 
       - name: 🏃 Extract ML-DSA crate
-        working-directory: libcrux-ml-dsa
+        working-directory: libcrux-iot/ml-dsa
         run: ./hax.sh extract
 
       - name: ↑ Upload F* extraction


### PR DESCRIPTION
This sets up the `get-hax-ref` job, which was missing before (so extraction didn't even run before). And it also fixes the ML-DSA extraction job to use the right working directory after those changed recently.