### PR TITLE
[SHA3] Match mainline APIs

### DIFF
--- a/libcrux-iot/Cargo.toml
+++ b/libcrux-iot/Cargo.toml
@@ -14,6 +14,8 @@ readme = "README.md"
 [workspace.dependencies]
 libcrux-secrets = { version = "0.0.5" }
 libcrux-macros = { version = "0.0.3" }
+libcrux-traits = { git = "https://github.com/cryspen/libcrux" }
+
 cavp = { version = "0.0.2" }
 hax-lib = { version = "0.3.6" }
 

--- a/libcrux-iot/Cargo.toml
+++ b/libcrux-iot/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [workspace.dependencies]
 libcrux-secrets = { git = "https://github.com/cryspen/libcrux" }
 libcrux-macros = { version = "0.0.3" }
-libcrux-traits = { git = "https://github.com/cryspen/libcrux" }
+libcrux-traits = { version = "0.0.4" }
 
 cavp = { version = "0.0.2" }
 hax-lib = { version = "0.3.6" }

--- a/libcrux-iot/Cargo.toml
+++ b/libcrux-iot/Cargo.toml
@@ -12,9 +12,9 @@ repository = "https://github.com/cryspen/libcrux-iot"
 readme = "README.md"
 
 [workspace.dependencies]
-libcrux-secrets = { git = "https://github.com/cryspen/libcrux" }
+libcrux-secrets = { version = "0.0.5" }
 libcrux-macros = { version = "0.0.3" }
-libcrux-traits = { version = "0.0.4" }
+libcrux-traits = { version = "0.0.6" }
 
 cavp = { version = "0.0.2" }
 hax-lib = { version = "0.3.6" }

--- a/libcrux-iot/Cargo.toml
+++ b/libcrux-iot/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/cryspen/libcrux-iot"
 readme = "README.md"
 
 [workspace.dependencies]
-libcrux-secrets = { version = "0.0.5" }
+libcrux-secrets = { git = "https://github.com/cryspen/libcrux" }
 libcrux-macros = { version = "0.0.3" }
 libcrux-traits = { git = "https://github.com/cryspen/libcrux" }
 

--- a/libcrux-iot/sha3/Cargo.toml
+++ b/libcrux-iot/sha3/Cargo.toml
@@ -17,6 +17,7 @@ bench = false # so libtest doesn't eat the arguments to criterion
 
 [dependencies]
 libcrux-secrets.workspace = true
+libcrux-traits.workspace = true
 
 # This is only required for verification.
 # The hax config is set by the hax toolchain.
@@ -31,7 +32,7 @@ full-unroll = []
 unbuffered-xof = []
 
 # Turn on secret-independence checking via `libcrux-secrets`
-check-secret-independence = ["libcrux-secrets/check-secret-independence"]
+check-secret-independence = ["libcrux-secrets/check-secret-independence", "libcrux-traits/check-secret-independence"]
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/libcrux-iot/sha3/src/impl_digest_trait.rs
+++ b/libcrux-iot/sha3/src/impl_digest_trait.rs
@@ -21,13 +21,16 @@ macro_rules! impl_hash_traits {
                 digest: &mut [u8; $len],
                 payload: &[u8],
             ) -> Result<(), libcrux_traits::digest::arrayref::HashError> {
-                use libcrux_traits::libcrux_secrets::ClassifyRefMut;
+                use libcrux_traits::libcrux_secrets::{ClassifyRef, ClassifyRefMut};
 
                 if payload.len() > u32::MAX as usize {
                     return Err(libcrux_traits::digest::arrayref::HashError::InvalidPayloadLength);
                 }
 
-                $method(digest.as_mut_slice().classify_ref_mut(), payload);
+                $method(
+                    digest.as_mut_slice().classify_ref_mut(),
+                    payload.classify_ref(),
+                );
 
                 Ok(())
             }

--- a/libcrux-iot/sha3/src/impl_digest_trait.rs
+++ b/libcrux-iot/sha3/src/impl_digest_trait.rs
@@ -1,0 +1,53 @@
+use crate::*;
+
+const SHA3_224_LEN: usize = 28;
+const SHA3_256_LEN: usize = 32;
+const SHA3_384_LEN: usize = 48;
+const SHA3_512_LEN: usize = 64;
+
+macro_rules! impl_hash_traits {
+    ($type:ident, $hasher:ident, $len:expr, $method:expr) => {
+        #[doc = concat!("A struct that implements [`libcrux_traits::digest`] traits.")]
+        #[doc = concat!("\n\n")]
+        #[doc = concat!("[`",stringify!($hasher), "`] is a convenient hasher for this struct.")]
+        pub struct $type;
+
+        #[doc = concat!("A hasher for [`",stringify!($type), "`].")]
+        pub type $hasher = libcrux_traits::digest::Hasher<$len, $type>;
+
+        impl libcrux_traits::digest::arrayref::Hash<$len> for $type {
+            #[inline(always)]
+            fn hash(
+                digest: &mut [u8; $len],
+                payload: &[u8],
+            ) -> Result<(), libcrux_traits::digest::arrayref::HashError> {
+                use libcrux_traits::libcrux_secrets::ClassifyRefMut;
+
+                if payload.len() > u32::MAX as usize {
+                    return Err(libcrux_traits::digest::arrayref::HashError::InvalidPayloadLength);
+                }
+
+                $method(digest.as_mut_slice().classify_ref_mut(), payload);
+
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_hash_traits!(Sha3_224, Sha3_224Hasher, SHA3_224_LEN, portable::sha224);
+impl_hash_traits!(Sha3_256, Sha3_256Hasher, SHA3_256_LEN, portable::sha256);
+impl_hash_traits!(Sha3_384, Sha3_384Hasher, SHA3_384_LEN, portable::sha384);
+impl_hash_traits!(Sha3_512, Sha3_512Hasher, SHA3_512_LEN, portable::sha512);
+
+// Implement the slice hash trait
+// This is excluded for the hax extraction
+#[cfg_attr(hax, hax_lib::exclude)]
+mod slice {
+    use super::*;
+
+    libcrux_traits::digest::slice::impl_hash_trait!(Sha3_224 => SHA3_224_LEN);
+    libcrux_traits::digest::slice::impl_hash_trait!(Sha3_256 => SHA3_256_LEN);
+    libcrux_traits::digest::slice::impl_hash_trait!(Sha3_384 => SHA3_384_LEN);
+    libcrux_traits::digest::slice::impl_hash_trait!(Sha3_512 => SHA3_512_LEN);
+}

--- a/libcrux-iot/sha3/src/impl_digest_trait.rs
+++ b/libcrux-iot/sha3/src/impl_digest_trait.rs
@@ -38,10 +38,10 @@ macro_rules! impl_hash_traits {
     };
 }
 
-impl_hash_traits!(Sha3_224, Sha3_224Hasher, SHA3_224_LEN, portable::sha224);
-impl_hash_traits!(Sha3_256, Sha3_256Hasher, SHA3_256_LEN, portable::sha256);
-impl_hash_traits!(Sha3_384, Sha3_384Hasher, SHA3_384_LEN, portable::sha384);
-impl_hash_traits!(Sha3_512, Sha3_512Hasher, SHA3_512_LEN, portable::sha512);
+impl_hash_traits!(Sha3_224, Sha3_224Hasher, SHA3_224_LEN, sha224_ema);
+impl_hash_traits!(Sha3_256, Sha3_256Hasher, SHA3_256_LEN, sha256_ema);
+impl_hash_traits!(Sha3_384, Sha3_384Hasher, SHA3_384_LEN, sha384_ema);
+impl_hash_traits!(Sha3_512, Sha3_512Hasher, SHA3_512_LEN, sha512_ema);
 
 // Implement the slice hash trait
 // This is excluded for the hax extraction

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -65,7 +65,12 @@ pub const SHA3_384_DIGEST_SIZE: usize = 48;
 /// Size in bytes of a SHA3 512 digest
 pub const SHA3_512_DIGEST_SIZE: usize = 64;
 
-/// The Digest Algorithm
+#[cfg(not(any(hax, eurydice)))]
+mod impl_digest_trait;
+#[cfg(not(any(hax, eurydice)))]
+pub use impl_digest_trait::*;
+
+/// The Digest Algorithm.
 #[cfg_attr(not(eurydice), derive(Copy, Clone, Debug, PartialEq))]
 #[repr(u32)]
 pub enum Algorithm {

--- a/libcrux-nrf52810/src/bin/mldsa_keygen.rs
+++ b/libcrux-nrf52810/src/bin/mldsa_keygen.rs
@@ -2,8 +2,12 @@
 #![no_std]
 #![cfg(feature = "mldsa87")]
 
+use embedded_alloc::LlffHeap as Heap;
 use libcrux_iot_ml_dsa::ml_dsa_87 as mldsa;
 use libcrux_nrf52810 as board; // global logger + panicking-behavior + memory layout
+
+#[global_allocator]
+static HEAP: Heap = Heap::empty();
 
 #[cortex_m_rt::entry]
 fn main() -> ! {

--- a/libcrux-nrf52810/src/bin/mldsa_sign.rs
+++ b/libcrux-nrf52810/src/bin/mldsa_sign.rs
@@ -4,7 +4,11 @@
 
 use libcrux_nrf52810 as board; // global logger + panicking-behavior + memory layout
 
+use embedded_alloc::LlffHeap as Heap;
 use libcrux_iot_ml_dsa::ml_dsa_87 as mldsa;
+
+#[global_allocator]
+static HEAP: Heap = Heap::empty();
 
 static SK: [u8; 4896] = [
     158, 41, 234, 146, 185, 41, 27, 225, 46, 178, 46, 248, 151, 40, 73, 59, 147, 27, 116, 81, 248,

--- a/libcrux-nrf52810/src/bin/mldsa_verify.rs
+++ b/libcrux-nrf52810/src/bin/mldsa_verify.rs
@@ -2,8 +2,12 @@
 #![no_std]
 #![cfg(feature = "mldsa87")]
 
+use embedded_alloc::LlffHeap as Heap;
 use libcrux_iot_ml_dsa::ml_dsa_87 as mldsa;
 use libcrux_nrf52810 as board; // global logger + panicking-behavior + memory layout
+
+#[global_allocator]
+static HEAP: Heap = Heap::empty();
 
 static SIGNATURE: [u8; 4627] = [
     154, 87, 4, 180, 140, 33, 3, 215, 213, 217, 228, 43, 218, 42, 215, 237, 7, 157, 76, 158, 95,


### PR DESCRIPTION
This PR ports the `Digest` trait API for SHA-3 from mainline libcrux.

Fixes https://github.com/cryspen/home/issues/433