### PR TITLE
sha3: code changes to aid lean extraction

### DIFF
--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -164,19 +164,19 @@ impl<const RATE: usize> KeccakXofState<RATE> {
         // XXX: Eurydice does not extract `core::cmp::min`, so we do
         // this instead. (cf. https://github.com/AeneasVerif/eurydice/issues/49)
         let mid = if RATE >= out_len { out_len } else { RATE };
-        self.inner.store::<RATE>(out);
+        self.inner.store::<RATE>(&mut out[..mid]);
 
         // If we got asked for more than one block, squeeze out more.
         let mut offset = mid;
         for _ in 1..blocks {
             // Here we know that we always have full blocks to write out.
             keccakf1600(&mut self.inner);
-            self.inner.store::<RATE>(&mut out[offset..]);
-            // out_rest = tmp;
+            self.inner.store::<RATE>(&mut out[offset..offset + RATE]);
             offset += RATE;
         }
 
         if last > 0 && last < out_len {
+            debug_assert_eq!(last, offset);
             // Squeeze out the last partial block
             keccakf1600(&mut self.inner);
             self.inner.store::<RATE>(&mut out[offset..]);
@@ -445,7 +445,7 @@ pub(crate) fn keccakf1600_round0_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut K
 
         // [hax] uninitialized variables are note supported yet in lean.
         #[allow(unused_assignments)]
-        let mut ax0 = 0;
+        let mut ax0 = 0.classify();
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 0];
@@ -488,7 +488,7 @@ pub(crate) fn keccakf1600_round0_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut K
 
         // [hax] uninitialized variables are note supported yet in lean.
         #[allow(unused_assignments)]
-        let mut ax0 = 0;
+        let mut ax0 = 0.classify();
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 0];
@@ -949,7 +949,7 @@ pub(crate) fn keccakf1600_round1_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut K
 
         // [hax] uninitialized variables are note supported yet in lean.
         #[allow(unused_assignments)]
-        let mut ax0 = 0;
+        let mut ax0 = 0.classify();
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 1];
@@ -992,7 +992,7 @@ pub(crate) fn keccakf1600_round1_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut K
 
         // [hax] uninitialized variables are note supported yet in lean.
         #[allow(unused_assignments)]
-        let mut ax0 = 0;
+        let mut ax0 = 0.classify();
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 1];
@@ -1453,7 +1453,7 @@ pub(crate) fn keccakf1600_round2_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut K
 
         // [hax] uninitialized variables are note supported yet in lean.
         #[allow(unused_assignments)]
-        let mut ax0 = 0;
+        let mut ax0 = 0.classify();
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 2];
@@ -1496,7 +1496,7 @@ pub(crate) fn keccakf1600_round2_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut K
 
         // [hax] uninitialized variables are note supported yet in lean.
         #[allow(unused_assignments)]
-        let mut ax0 = 0;
+        let mut ax0 = 0.classify();
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 2];
@@ -1958,7 +1958,7 @@ pub(crate) fn keccakf1600_round3_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut K
 
         // [hax] uninitialized variables are note supported yet in lean.
         #[allow(unused_assignments)]
-        let mut ax0 = 0;
+        let mut ax0 = 0.classify();
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 3];
@@ -2001,7 +2001,7 @@ pub(crate) fn keccakf1600_round3_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut K
 
         // [hax] uninitialized variables are note supported yet in lean.
         #[allow(unused_assignments)]
-        let mut ax0 = 0;
+        let mut ax0 = 0.classify();
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 3];
@@ -2423,6 +2423,7 @@ pub(crate) fn keccak<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut 
             offset += RATE;
         }
         if last < outlen {
+            debug_assert_eq!(last, offset);
             squeeze_last::<RATE>(s, &mut out[offset..])
         }
     }

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -5,11 +5,10 @@ use libcrux_secrets::{Classify, U8};
 #[cfg(feature = "check-secret-independence")]
 use libcrux_secrets::{Declassify, U32};
 
-use crate::{lane::Lane2U32, state::KeccakState};
+use crate::state::KeccakState;
 
 /// The internal keccak state that can also buffer inputs to absorb.
 /// This is used in the general xof APIs.
-#[cfg_attr(hax, hax_lib::opaque)]
 pub(crate) struct KeccakXofState<const RATE: usize> {
     inner: KeccakState,
 
@@ -165,22 +164,22 @@ impl<const RATE: usize> KeccakXofState<RATE> {
         // XXX: Eurydice does not extract `core::cmp::min`, so we do
         // this instead. (cf. https://github.com/AeneasVerif/eurydice/issues/49)
         let mid = if RATE >= out_len { out_len } else { RATE };
-        let (out0, mut out_rest) = Lane2U32::split_at_mut_n(out, mid);
-        self.inner.store::<RATE>(out0);
+        self.inner.store::<RATE>(out);
 
         // If we got asked for more than one block, squeeze out more.
+        let mut offset = mid;
         for _ in 1..blocks {
             // Here we know that we always have full blocks to write out.
-            let (out0, tmp) = Lane2U32::split_at_mut_n(out_rest, RATE);
             keccakf1600(&mut self.inner);
-            self.inner.store::<RATE>(out0);
-            out_rest = tmp;
+            self.inner.store::<RATE>(&mut out[offset..]);
+            // out_rest = tmp;
+            offset += RATE;
         }
 
-        if last < out_len {
+        if last > 0 && last < out_len {
             // Squeeze out the last partial block
             keccakf1600(&mut self.inner);
-            self.inner.store::<RATE>(out_rest);
+            self.inner.store::<RATE>(&mut out[offset..]);
         }
 
         self.sponge = true;
@@ -189,6 +188,7 @@ impl<const RATE: usize> KeccakXofState<RATE> {
 
 //// From here, everything is generic
 
+#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
 const RC_INTERLEAVED_0: [u32; 255] = [
     0x00000001, 0x00000000, 0x00000000, 0x00000000, 0x00000001, 0x00000001, 0x00000001, 0x00000001,
     0x00000000, 0x00000000, 0x00000001, 0x00000000, 0x00000001, 0x00000001, 0x00000001, 0x00000001,
@@ -224,6 +224,7 @@ const RC_INTERLEAVED_0: [u32; 255] = [
     0x00000000, 0x00000001, 0x00000001, 0x00000001, 0x00000000, 0x00000000, 0x00000000,
 ];
 
+#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
 const RC_INTERLEAVED_1: [u32; 255] = [
     0x00000000, 0x00000089, 0x8000008b, 0x80008080, 0x0000008b, 0x00008000, 0x80008088, 0x80000082,
     0x0000000b, 0x0000000a, 0x00008082, 0x00008003, 0x0000808b, 0x8000000b, 0x8000008a, 0x80000081,
@@ -264,119 +265,160 @@ const RC_INTERLEAVED_1: [u32; 255] = [
 // :r !python libcrux/libcrux-sha3/codegen.py
 // ```
 #[inline(always)]
-pub(crate) fn keccakf1600_round0<const BASE_ROUND: usize>(s: &mut KeccakState) {
-    {
-        let ax_0 = s.get_with_zeta(0, 0, 0);
-        let ax_1 = s.get_with_zeta(1, 0, 0);
-        let ax_2 = s.get_with_zeta(2, 0, 0);
-        let ax_3 = s.get_with_zeta(3, 0, 0);
-        let ax_4 = s.get_with_zeta(4, 0, 0);
-        s.c[0][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_0 = s.get_with_zeta(0, 0, 1);
-        let ax_1 = s.get_with_zeta(1, 0, 1);
-        let ax_2 = s.get_with_zeta(2, 0, 1);
-        let ax_3 = s.get_with_zeta(3, 0, 1);
-        let ax_4 = s.get_with_zeta(4, 0, 1);
-        s.c[0][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_0 = s.get_with_zeta(0, 1, 0);
-        let ax_1 = s.get_with_zeta(1, 1, 0);
-        let ax_2 = s.get_with_zeta(2, 1, 0);
-        let ax_3 = s.get_with_zeta(3, 1, 0);
-        let ax_4 = s.get_with_zeta(4, 1, 0);
-        s.c[1][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_0 = s.get_with_zeta(0, 1, 1);
-        let ax_1 = s.get_with_zeta(1, 1, 1);
-        let ax_2 = s.get_with_zeta(2, 1, 1);
-        let ax_3 = s.get_with_zeta(3, 1, 1);
-        let ax_4 = s.get_with_zeta(4, 1, 1);
-        s.c[1][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_0 = s.get_with_zeta(0, 2, 0);
-        let ax_1 = s.get_with_zeta(1, 2, 0);
-        let ax_2 = s.get_with_zeta(2, 2, 0);
-        let ax_3 = s.get_with_zeta(3, 2, 0);
-        let ax_4 = s.get_with_zeta(4, 2, 0);
-        s.c[2][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_0 = s.get_with_zeta(0, 2, 1);
-        let ax_1 = s.get_with_zeta(1, 2, 1);
-        let ax_2 = s.get_with_zeta(2, 2, 1);
-        let ax_3 = s.get_with_zeta(3, 2, 1);
-        let ax_4 = s.get_with_zeta(4, 2, 1);
-        s.c[2][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_0 = s.get_with_zeta(0, 3, 0);
-        let ax_1 = s.get_with_zeta(1, 3, 0);
-        let ax_2 = s.get_with_zeta(2, 3, 0);
-        let ax_3 = s.get_with_zeta(3, 3, 0);
-        let ax_4 = s.get_with_zeta(4, 3, 0);
-        s.c[3][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_0 = s.get_with_zeta(0, 3, 1);
-        let ax_1 = s.get_with_zeta(1, 3, 1);
-        let ax_2 = s.get_with_zeta(2, 3, 1);
-        let ax_3 = s.get_with_zeta(3, 3, 1);
-        let ax_4 = s.get_with_zeta(4, 3, 1);
-        s.c[3][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_0 = s.get_with_zeta(0, 4, 0);
-        let ax_1 = s.get_with_zeta(1, 4, 0);
-        let ax_2 = s.get_with_zeta(2, 4, 0);
-        let ax_3 = s.get_with_zeta(3, 4, 0);
-        let ax_4 = s.get_with_zeta(4, 4, 0);
-        s.c[4][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_0 = s.get_with_zeta(0, 4, 1);
-        let ax_1 = s.get_with_zeta(1, 4, 1);
-        let ax_2 = s.get_with_zeta(2, 4, 1);
-        let ax_3 = s.get_with_zeta(3, 4, 1);
-        let ax_4 = s.get_with_zeta(4, 4, 1);
-        s.c[4][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let c_x4_zeta0 = s.c[4][0];
-        let c_x1_zeta1 = s.c[1][1];
-        let c_x3_zeta0 = s.c[3][0];
-        let c_x0_zeta1 = s.c[0][1];
-        let c_x2_zeta0 = s.c[2][0];
-        let c_x4_zeta1 = s.c[4][1];
-        let d_x0_zeta0 = c_x4_zeta0 ^ c_x1_zeta1.rotate_left(1);
-        s.d[0][0] = d_x0_zeta0;
-        let d_x2_zeta1 = c_x1_zeta1 ^ c_x3_zeta0;
-        s.d[2][1] = d_x2_zeta1;
-        let d_x4_zeta0 = c_x3_zeta0 ^ c_x0_zeta1.rotate_left(1);
-        s.d[4][0] = d_x4_zeta0;
-        let d_x1_zeta1 = c_x0_zeta1 ^ c_x2_zeta0;
-        s.d[1][1] = d_x1_zeta1;
-        let d_x3_zeta0 = c_x2_zeta0 ^ c_x4_zeta1.rotate_left(1);
-        s.d[3][0] = d_x3_zeta0;
-        let c_x1_zeta0 = s.c[1][0];
-        let c_x3_zeta1 = s.c[3][1];
-        let c_x2_zeta1 = s.c[2][1];
-        let c_x0_zeta0 = s.c[0][0];
-        let d_x0_zeta1 = c_x4_zeta1 ^ c_x1_zeta0;
-        s.d[0][1] = d_x0_zeta1;
-        let d_x2_zeta0 = c_x1_zeta0 ^ c_x3_zeta1.rotate_left(1);
-        s.d[2][0] = d_x2_zeta0;
-        let d_x4_zeta1 = c_x3_zeta1 ^ c_x0_zeta0;
-        s.d[4][1] = d_x4_zeta1;
-        let d_x1_zeta0 = c_x0_zeta0 ^ c_x2_zeta1.rotate_left(1);
-        s.d[1][0] = d_x1_zeta0;
-        let d_x3_zeta1 = c_x2_zeta1 ^ c_x4_zeta0;
-        s.d[3][1] = d_x3_zeta1;
-    }
+pub(crate) fn keccakf1600_round0_theta_c_x0_z0(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 0, 0);
+    let ax_1 = s.get_with_zeta(1, 0, 0);
+    let ax_2 = s.get_with_zeta(2, 0, 0);
+    let ax_3 = s.get_with_zeta(3, 0, 0);
+    let ax_4 = s.get_with_zeta(4, 0, 0);
+    s.set_lane_value(0, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round0_theta_c_x0_z1(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 0, 1);
+    let ax_1 = s.get_with_zeta(1, 0, 1);
+    let ax_2 = s.get_with_zeta(2, 0, 1);
+    let ax_3 = s.get_with_zeta(3, 0, 1);
+    let ax_4 = s.get_with_zeta(4, 0, 1);
+    s.set_lane_value(0, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round0_theta_c_x1_z0(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 1, 0);
+    let ax_1 = s.get_with_zeta(1, 1, 0);
+    let ax_2 = s.get_with_zeta(2, 1, 0);
+    let ax_3 = s.get_with_zeta(3, 1, 0);
+    let ax_4 = s.get_with_zeta(4, 1, 0);
+    s.set_lane_value(1, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round0_theta_c_x1_z1(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 1, 1);
+    let ax_1 = s.get_with_zeta(1, 1, 1);
+    let ax_2 = s.get_with_zeta(2, 1, 1);
+    let ax_3 = s.get_with_zeta(3, 1, 1);
+    let ax_4 = s.get_with_zeta(4, 1, 1);
+    s.set_lane_value(1, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round0_theta_c_x2_z0(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 2, 0);
+    let ax_1 = s.get_with_zeta(1, 2, 0);
+    let ax_2 = s.get_with_zeta(2, 2, 0);
+    let ax_3 = s.get_with_zeta(3, 2, 0);
+    let ax_4 = s.get_with_zeta(4, 2, 0);
+    s.set_lane_value(2, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round0_theta_c_x2_z1(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 2, 1);
+    let ax_1 = s.get_with_zeta(1, 2, 1);
+    let ax_2 = s.get_with_zeta(2, 2, 1);
+    let ax_3 = s.get_with_zeta(3, 2, 1);
+    let ax_4 = s.get_with_zeta(4, 2, 1);
+    s.set_lane_value(2, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round0_theta_c_x3_z0(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 3, 0);
+    let ax_1 = s.get_with_zeta(1, 3, 0);
+    let ax_2 = s.get_with_zeta(2, 3, 0);
+    let ax_3 = s.get_with_zeta(3, 3, 0);
+    let ax_4 = s.get_with_zeta(4, 3, 0);
+    s.set_lane_value(3, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round0_theta_c_x3_z1(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 3, 1);
+    let ax_1 = s.get_with_zeta(1, 3, 1);
+    let ax_2 = s.get_with_zeta(2, 3, 1);
+    let ax_3 = s.get_with_zeta(3, 3, 1);
+    let ax_4 = s.get_with_zeta(4, 3, 1);
+    s.set_lane_value(3, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round0_theta_c_x4_z0(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 4, 0);
+    let ax_1 = s.get_with_zeta(1, 4, 0);
+    let ax_2 = s.get_with_zeta(2, 4, 0);
+    let ax_3 = s.get_with_zeta(3, 4, 0);
+    let ax_4 = s.get_with_zeta(4, 4, 0);
+    s.set_lane_value(4, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round0_theta_c_x4_z1(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 4, 1);
+    let ax_1 = s.get_with_zeta(1, 4, 1);
+    let ax_2 = s.get_with_zeta(2, 4, 1);
+    let ax_3 = s.get_with_zeta(3, 4, 1);
+    let ax_4 = s.get_with_zeta(4, 4, 1);
+    s.set_lane_value(4, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round0_theta_d(s: &mut KeccakState) {
+    // D[x] = C[x-1] XOR ROT64(C[x+1], 1)
+    let c_x4_zeta0 = s.c[4][0];
+    let c_x1_zeta1 = s.c[1][1];
+    let c_x3_zeta0 = s.c[3][0];
+    let c_x0_zeta1 = s.c[0][1];
+    let c_x2_zeta0 = s.c[2][0];
+    let c_x4_zeta1 = s.c[4][1];
+    let d_x0_zeta0 = c_x4_zeta0 ^ c_x1_zeta1.rotate_left(1);
+    s.d[0].0[0] = d_x0_zeta0;
+    let d_x2_zeta1 = c_x1_zeta1 ^ c_x3_zeta0;
+    s.d[2].0[1] = d_x2_zeta1;
+    let d_x4_zeta0 = c_x3_zeta0 ^ c_x0_zeta1.rotate_left(1);
+    s.d[4].0[0] = d_x4_zeta0;
+    let d_x1_zeta1 = c_x0_zeta1 ^ c_x2_zeta0;
+    s.d[1].0[1] = d_x1_zeta1;
+    let d_x3_zeta0 = c_x2_zeta0 ^ c_x4_zeta1.rotate_left(1);
+    s.d[3].0[0] = d_x3_zeta0;
+    let c_x1_zeta0 = s.c[1][0];
+    let c_x3_zeta1 = s.c[3][1];
+    let c_x2_zeta1 = s.c[2][1];
+    let c_x0_zeta0 = s.c[0][0];
+    let d_x0_zeta1 = c_x4_zeta1 ^ c_x1_zeta0;
+    s.d[0].0[1] = d_x0_zeta1;
+    let d_x2_zeta0 = c_x1_zeta0 ^ c_x3_zeta1.rotate_left(1);
+    s.d[2].0[0] = d_x2_zeta0;
+    let d_x4_zeta1 = c_x3_zeta1 ^ c_x0_zeta0;
+    s.d[4].0[1] = d_x4_zeta1;
+    let d_x1_zeta0 = c_x0_zeta0 ^ c_x2_zeta1.rotate_left(1);
+    s.d[1].0[0] = d_x1_zeta0;
+    let d_x3_zeta1 = c_x2_zeta1 ^ c_x4_zeta0;
+    s.d[3].0[1] = d_x3_zeta1;
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round0_theta(s: &mut KeccakState) {
+    // C[x][zeta] = A[0,x][zeta] ^ A[1,x][zeta] ^ A[2,x][zeta] ^ A[3,x][zeta] ^ A[4,x][zeta]
+    // https://github.com/hacl-star/hacl-star/blob/main/specs/Spec.SHA3.fst#L28C1-L29C74
+    keccakf1600_round0_theta_c_x0_z0(s);
+    keccakf1600_round0_theta_c_x0_z1(s);
+    keccakf1600_round0_theta_c_x1_z0(s);
+    keccakf1600_round0_theta_c_x1_z1(s);
+    keccakf1600_round0_theta_c_x2_z0(s);
+    keccakf1600_round0_theta_c_x2_z1(s);
+    keccakf1600_round0_theta_c_x3_z0(s);
+    keccakf1600_round0_theta_c_x3_z1(s);
+    keccakf1600_round0_theta_c_x4_z0(s);
+    keccakf1600_round0_theta_c_x4_z1(s);
+    keccakf1600_round0_theta_d(s);
+}
+
+#[inline(always)]
+#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
+pub(crate) fn keccakf1600_round0_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
     #[cfg(not(feature = "full-unroll"))]
     let i = s.i;
     {
@@ -400,7 +442,10 @@ pub(crate) fn keccakf1600_round0<const BASE_ROUND: usize>(s: &mut KeccakState) {
                 (a4 ^ d4).rotate_left(7),
             )
         };
-        let ax0;
+
+        // [hax] uninitialized variables are note supported yet in lean.
+        #[allow(unused_assignments)]
+        let mut ax0 = 0;
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 0];
@@ -440,7 +485,10 @@ pub(crate) fn keccakf1600_round0<const BASE_ROUND: usize>(s: &mut KeccakState) {
                 (a4 ^ d4).rotate_left(7),
             )
         };
-        let ax0;
+
+        // [hax] uninitialized variables are note supported yet in lean.
+        #[allow(unused_assignments)]
+        let mut ax0 = 0;
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 0];
@@ -524,6 +572,11 @@ pub(crate) fn keccakf1600_round0<const BASE_ROUND: usize>(s: &mut KeccakState) {
         let ax4 = bx4 ^ ((!bx0) & bx1);
         s.set_with_zeta(1, 4, 1, ax4);
     }
+}
+
+#[inline(always)]
+#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1500 in"))]
+pub(crate) fn keccakf1600_round0_pi_rho_chi_2(s: &mut KeccakState) {
     {
         let (bx4, bx0) = {
             let a0 = s.get_with_zeta(4, 0, 0);
@@ -719,119 +772,157 @@ pub(crate) fn keccakf1600_round0<const BASE_ROUND: usize>(s: &mut KeccakState) {
 }
 
 #[inline(always)]
-pub(crate) fn keccakf1600_round1<const BASE_ROUND: usize>(s: &mut KeccakState) {
-    {
-        let ax_0 = s.get_with_zeta(0, 0, 0);
-        let ax_2 = s.get_with_zeta(2, 0, 1);
-        let ax_4 = s.get_with_zeta(4, 0, 0);
-        let ax_1 = s.get_with_zeta(1, 0, 0);
-        let ax_3 = s.get_with_zeta(3, 0, 1);
-        s.c[0][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_0 = s.get_with_zeta(0, 0, 1);
-        let ax_2 = s.get_with_zeta(2, 0, 0);
-        let ax_4 = s.get_with_zeta(4, 0, 1);
-        let ax_1 = s.get_with_zeta(1, 0, 1);
-        let ax_3 = s.get_with_zeta(3, 0, 0);
-        s.c[0][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_1 = s.get_with_zeta(1, 1, 0);
-        let ax_3 = s.get_with_zeta(3, 1, 1);
-        let ax_0 = s.get_with_zeta(0, 1, 1);
-        let ax_2 = s.get_with_zeta(2, 1, 0);
-        let ax_4 = s.get_with_zeta(4, 1, 0);
-        s.c[1][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_1 = s.get_with_zeta(1, 1, 1);
-        let ax_3 = s.get_with_zeta(3, 1, 0);
-        let ax_0 = s.get_with_zeta(0, 1, 0);
-        let ax_2 = s.get_with_zeta(2, 1, 1);
-        let ax_4 = s.get_with_zeta(4, 1, 1);
-        s.c[1][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_2 = s.get_with_zeta(2, 2, 1);
-        let ax_4 = s.get_with_zeta(4, 2, 1);
-        let ax_1 = s.get_with_zeta(1, 2, 0);
-        let ax_3 = s.get_with_zeta(3, 2, 1);
-        let ax_0 = s.get_with_zeta(0, 2, 0);
-        s.c[2][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_2 = s.get_with_zeta(2, 2, 0);
-        let ax_4 = s.get_with_zeta(4, 2, 0);
-        let ax_1 = s.get_with_zeta(1, 2, 1);
-        let ax_3 = s.get_with_zeta(3, 2, 0);
-        let ax_0 = s.get_with_zeta(0, 2, 1);
-        s.c[2][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_3 = s.get_with_zeta(3, 3, 1);
-        let ax_0 = s.get_with_zeta(0, 3, 0);
-        let ax_2 = s.get_with_zeta(2, 3, 1);
-        let ax_4 = s.get_with_zeta(4, 3, 0);
-        let ax_1 = s.get_with_zeta(1, 3, 1);
-        s.c[3][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_3 = s.get_with_zeta(3, 3, 0);
-        let ax_0 = s.get_with_zeta(0, 3, 1);
-        let ax_2 = s.get_with_zeta(2, 3, 0);
-        let ax_4 = s.get_with_zeta(4, 3, 1);
-        let ax_1 = s.get_with_zeta(1, 3, 0);
-        s.c[3][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_4 = s.get_with_zeta(4, 4, 0);
-        let ax_1 = s.get_with_zeta(1, 4, 0);
-        let ax_3 = s.get_with_zeta(3, 4, 0);
-        let ax_0 = s.get_with_zeta(0, 4, 1);
-        let ax_2 = s.get_with_zeta(2, 4, 1);
-        s.c[4][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_4 = s.get_with_zeta(4, 4, 1);
-        let ax_1 = s.get_with_zeta(1, 4, 1);
-        let ax_3 = s.get_with_zeta(3, 4, 1);
-        let ax_0 = s.get_with_zeta(0, 4, 0);
-        let ax_2 = s.get_with_zeta(2, 4, 0);
-        s.c[4][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let c_x4_zeta0 = s.c[4][0];
-        let c_x1_zeta1 = s.c[1][1];
-        let c_x3_zeta0 = s.c[3][0];
-        let c_x0_zeta1 = s.c[0][1];
-        let c_x2_zeta0 = s.c[2][0];
-        let c_x4_zeta1 = s.c[4][1];
-        let d_x0_zeta0 = c_x4_zeta0 ^ c_x1_zeta1.rotate_left(1);
-        s.d[0][0] = d_x0_zeta0;
-        let d_x2_zeta1 = c_x1_zeta1 ^ c_x3_zeta0;
-        s.d[2][1] = d_x2_zeta1;
-        let d_x4_zeta0 = c_x3_zeta0 ^ c_x0_zeta1.rotate_left(1);
-        s.d[4][0] = d_x4_zeta0;
-        let d_x1_zeta1 = c_x0_zeta1 ^ c_x2_zeta0;
-        s.d[1][1] = d_x1_zeta1;
-        let d_x3_zeta0 = c_x2_zeta0 ^ c_x4_zeta1.rotate_left(1);
-        s.d[3][0] = d_x3_zeta0;
-        let c_x1_zeta0 = s.c[1][0];
-        let c_x3_zeta1 = s.c[3][1];
-        let c_x2_zeta1 = s.c[2][1];
-        let c_x0_zeta0 = s.c[0][0];
-        let d_x0_zeta1 = c_x4_zeta1 ^ c_x1_zeta0;
-        s.d[0][1] = d_x0_zeta1;
-        let d_x2_zeta0 = c_x1_zeta0 ^ c_x3_zeta1.rotate_left(1);
-        s.d[2][0] = d_x2_zeta0;
-        let d_x4_zeta1 = c_x3_zeta1 ^ c_x0_zeta0;
-        s.d[4][1] = d_x4_zeta1;
-        let d_x1_zeta0 = c_x0_zeta0 ^ c_x2_zeta1.rotate_left(1);
-        s.d[1][0] = d_x1_zeta0;
-        let d_x3_zeta1 = c_x2_zeta1 ^ c_x4_zeta0;
-        s.d[3][1] = d_x3_zeta1;
-    }
+pub(crate) fn keccakf1600_round1_theta_c_x0_z0(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 0, 0);
+    let ax_2 = s.get_with_zeta(2, 0, 1);
+    let ax_4 = s.get_with_zeta(4, 0, 0);
+    let ax_1 = s.get_with_zeta(1, 0, 0);
+    let ax_3 = s.get_with_zeta(3, 0, 1);
+    s.set_lane_value(0, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round1_theta_c_x0_z1(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 0, 1);
+    let ax_2 = s.get_with_zeta(2, 0, 0);
+    let ax_4 = s.get_with_zeta(4, 0, 1);
+    let ax_1 = s.get_with_zeta(1, 0, 1);
+    let ax_3 = s.get_with_zeta(3, 0, 0);
+    s.set_lane_value(0, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round1_theta_c_x1_z0(s: &mut KeccakState) {
+    let ax_1 = s.get_with_zeta(1, 1, 0);
+    let ax_3 = s.get_with_zeta(3, 1, 1);
+    let ax_0 = s.get_with_zeta(0, 1, 1);
+    let ax_2 = s.get_with_zeta(2, 1, 0);
+    let ax_4 = s.get_with_zeta(4, 1, 0);
+    s.set_lane_value(1, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round1_theta_c_x1_z1(s: &mut KeccakState) {
+    let ax_1 = s.get_with_zeta(1, 1, 1);
+    let ax_3 = s.get_with_zeta(3, 1, 0);
+    let ax_0 = s.get_with_zeta(0, 1, 0);
+    let ax_2 = s.get_with_zeta(2, 1, 1);
+    let ax_4 = s.get_with_zeta(4, 1, 1);
+    s.set_lane_value(1, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round1_theta_c_x2_z0(s: &mut KeccakState) {
+    let ax_2 = s.get_with_zeta(2, 2, 1);
+    let ax_4 = s.get_with_zeta(4, 2, 1);
+    let ax_1 = s.get_with_zeta(1, 2, 0);
+    let ax_3 = s.get_with_zeta(3, 2, 1);
+    let ax_0 = s.get_with_zeta(0, 2, 0);
+    s.set_lane_value(2, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round1_theta_c_x2_z1(s: &mut KeccakState) {
+    let ax_2 = s.get_with_zeta(2, 2, 0);
+    let ax_4 = s.get_with_zeta(4, 2, 0);
+    let ax_1 = s.get_with_zeta(1, 2, 1);
+    let ax_3 = s.get_with_zeta(3, 2, 0);
+    let ax_0 = s.get_with_zeta(0, 2, 1);
+    s.set_lane_value(2, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round1_theta_c_x3_z0(s: &mut KeccakState) {
+    let ax_3 = s.get_with_zeta(3, 3, 1);
+    let ax_0 = s.get_with_zeta(0, 3, 0);
+    let ax_2 = s.get_with_zeta(2, 3, 1);
+    let ax_4 = s.get_with_zeta(4, 3, 0);
+    let ax_1 = s.get_with_zeta(1, 3, 1);
+    s.set_lane_value(3, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round1_theta_c_x3_z1(s: &mut KeccakState) {
+    let ax_3 = s.get_with_zeta(3, 3, 0);
+    let ax_0 = s.get_with_zeta(0, 3, 1);
+    let ax_2 = s.get_with_zeta(2, 3, 0);
+    let ax_4 = s.get_with_zeta(4, 3, 1);
+    let ax_1 = s.get_with_zeta(1, 3, 0);
+    s.set_lane_value(3, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round1_theta_c_x4_z0(s: &mut KeccakState) {
+    let ax_4 = s.get_with_zeta(4, 4, 0);
+    let ax_1 = s.get_with_zeta(1, 4, 0);
+    let ax_3 = s.get_with_zeta(3, 4, 0);
+    let ax_0 = s.get_with_zeta(0, 4, 1);
+    let ax_2 = s.get_with_zeta(2, 4, 1);
+    s.set_lane_value(4, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round1_theta_c_x4_z1(s: &mut KeccakState) {
+    let ax_4 = s.get_with_zeta(4, 4, 1);
+    let ax_1 = s.get_with_zeta(1, 4, 1);
+    let ax_3 = s.get_with_zeta(3, 4, 1);
+    let ax_0 = s.get_with_zeta(0, 4, 0);
+    let ax_2 = s.get_with_zeta(2, 4, 0);
+    s.set_lane_value(4, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round1_theta_d(s: &mut KeccakState) {
+    let c_x4_zeta0 = s.c[4][0];
+    let c_x1_zeta1 = s.c[1][1];
+    let c_x3_zeta0 = s.c[3][0];
+    let c_x0_zeta1 = s.c[0][1];
+    let c_x2_zeta0 = s.c[2][0];
+    let c_x4_zeta1 = s.c[4][1];
+    let d_x0_zeta0 = c_x4_zeta0 ^ c_x1_zeta1.rotate_left(1);
+    s.d[0].0[0] = d_x0_zeta0;
+    let d_x2_zeta1 = c_x1_zeta1 ^ c_x3_zeta0;
+    s.d[2].0[1] = d_x2_zeta1;
+    let d_x4_zeta0 = c_x3_zeta0 ^ c_x0_zeta1.rotate_left(1);
+    s.d[4].0[0] = d_x4_zeta0;
+    let d_x1_zeta1 = c_x0_zeta1 ^ c_x2_zeta0;
+    s.d[1].0[1] = d_x1_zeta1;
+    let d_x3_zeta0 = c_x2_zeta0 ^ c_x4_zeta1.rotate_left(1);
+    s.d[3].0[0] = d_x3_zeta0;
+    let c_x1_zeta0 = s.c[1][0];
+    let c_x3_zeta1 = s.c[3][1];
+    let c_x2_zeta1 = s.c[2][1];
+    let c_x0_zeta0 = s.c[0][0];
+    let d_x0_zeta1 = c_x4_zeta1 ^ c_x1_zeta0;
+    s.d[0].0[1] = d_x0_zeta1;
+    let d_x2_zeta0 = c_x1_zeta0 ^ c_x3_zeta1.rotate_left(1);
+    s.d[2].0[0] = d_x2_zeta0;
+    let d_x4_zeta1 = c_x3_zeta1 ^ c_x0_zeta0;
+    s.d[4].0[1] = d_x4_zeta1;
+    let d_x1_zeta0 = c_x0_zeta0 ^ c_x2_zeta1.rotate_left(1);
+    s.d[1].0[0] = d_x1_zeta0;
+    let d_x3_zeta1 = c_x2_zeta1 ^ c_x4_zeta0;
+    s.d[3].0[1] = d_x3_zeta1;
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round1_theta(s: &mut KeccakState) {
+    keccakf1600_round1_theta_c_x0_z0(s);
+    keccakf1600_round1_theta_c_x0_z1(s);
+    keccakf1600_round1_theta_c_x1_z0(s);
+    keccakf1600_round1_theta_c_x1_z1(s);
+    keccakf1600_round1_theta_c_x2_z0(s);
+    keccakf1600_round1_theta_c_x2_z1(s);
+    keccakf1600_round1_theta_c_x3_z0(s);
+    keccakf1600_round1_theta_c_x3_z1(s);
+    keccakf1600_round1_theta_c_x4_z0(s);
+    keccakf1600_round1_theta_c_x4_z1(s);
+    keccakf1600_round1_theta_d(s);
+}
+
+#[inline(always)]
+#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
+pub(crate) fn keccakf1600_round1_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
     #[cfg(not(feature = "full-unroll"))]
     let i = s.i;
     {
@@ -855,7 +946,10 @@ pub(crate) fn keccakf1600_round1<const BASE_ROUND: usize>(s: &mut KeccakState) {
                 (a4 ^ d4).rotate_left(7),
             )
         };
-        let ax0;
+
+        // [hax] uninitialized variables are note supported yet in lean.
+        #[allow(unused_assignments)]
+        let mut ax0 = 0;
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 1];
@@ -895,7 +989,10 @@ pub(crate) fn keccakf1600_round1<const BASE_ROUND: usize>(s: &mut KeccakState) {
                 (a4 ^ d4).rotate_left(7),
             )
         };
-        let ax0;
+
+        // [hax] uninitialized variables are note supported yet in lean.
+        #[allow(unused_assignments)]
+        let mut ax0 = 0;
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 1];
@@ -979,6 +1076,11 @@ pub(crate) fn keccakf1600_round1<const BASE_ROUND: usize>(s: &mut KeccakState) {
         let ax4 = bx4 ^ ((!bx0) & bx1);
         s.set_with_zeta(1, 4, 1, ax4);
     }
+}
+
+#[inline(always)]
+#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1500 in"))]
+pub(crate) fn keccakf1600_round1_pi_rho_chi_2(s: &mut KeccakState) {
     {
         let (bx4, bx0) = {
             let a0 = s.get_with_zeta(3, 0, 1);
@@ -1174,119 +1276,157 @@ pub(crate) fn keccakf1600_round1<const BASE_ROUND: usize>(s: &mut KeccakState) {
 }
 
 #[inline(always)]
-pub(crate) fn keccakf1600_round2<const BASE_ROUND: usize>(s: &mut KeccakState) {
-    {
-        let ax_0 = s.get_with_zeta(0, 0, 0);
-        let ax_4 = s.get_with_zeta(4, 0, 1);
-        let ax_3 = s.get_with_zeta(3, 0, 1);
-        let ax_2 = s.get_with_zeta(2, 0, 1);
-        let ax_1 = s.get_with_zeta(1, 0, 1);
-        s.c[0][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_0 = s.get_with_zeta(0, 0, 1);
-        let ax_4 = s.get_with_zeta(4, 0, 0);
-        let ax_3 = s.get_with_zeta(3, 0, 0);
-        let ax_2 = s.get_with_zeta(2, 0, 0);
-        let ax_1 = s.get_with_zeta(1, 0, 0);
-        s.c[0][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_3 = s.get_with_zeta(3, 1, 1);
-        let ax_2 = s.get_with_zeta(2, 1, 1);
-        let ax_1 = s.get_with_zeta(1, 1, 1);
-        let ax_0 = s.get_with_zeta(0, 1, 1);
-        let ax_4 = s.get_with_zeta(4, 1, 0);
-        s.c[1][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_3 = s.get_with_zeta(3, 1, 0);
-        let ax_2 = s.get_with_zeta(2, 1, 0);
-        let ax_1 = s.get_with_zeta(1, 1, 0);
-        let ax_0 = s.get_with_zeta(0, 1, 0);
-        let ax_4 = s.get_with_zeta(4, 1, 1);
-        s.c[1][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_1 = s.get_with_zeta(1, 2, 1);
-        let ax_0 = s.get_with_zeta(0, 2, 1);
-        let ax_4 = s.get_with_zeta(4, 2, 1);
-        let ax_3 = s.get_with_zeta(3, 2, 0);
-        let ax_2 = s.get_with_zeta(2, 2, 1);
-        s.c[2][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_1 = s.get_with_zeta(1, 2, 0);
-        let ax_0 = s.get_with_zeta(0, 2, 0);
-        let ax_4 = s.get_with_zeta(4, 2, 0);
-        let ax_3 = s.get_with_zeta(3, 2, 1);
-        let ax_2 = s.get_with_zeta(2, 2, 0);
-        s.c[2][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_4 = s.get_with_zeta(4, 3, 1);
-        let ax_3 = s.get_with_zeta(3, 3, 1);
-        let ax_2 = s.get_with_zeta(2, 3, 0);
-        let ax_1 = s.get_with_zeta(1, 3, 1);
-        let ax_0 = s.get_with_zeta(0, 3, 1);
-        s.c[3][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_4 = s.get_with_zeta(4, 3, 0);
-        let ax_3 = s.get_with_zeta(3, 3, 0);
-        let ax_2 = s.get_with_zeta(2, 3, 1);
-        let ax_1 = s.get_with_zeta(1, 3, 0);
-        let ax_0 = s.get_with_zeta(0, 3, 0);
-        s.c[3][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_2 = s.get_with_zeta(2, 4, 1);
-        let ax_1 = s.get_with_zeta(1, 4, 0);
-        let ax_0 = s.get_with_zeta(0, 4, 1);
-        let ax_4 = s.get_with_zeta(4, 4, 1);
-        let ax_3 = s.get_with_zeta(3, 4, 1);
-        s.c[4][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_2 = s.get_with_zeta(2, 4, 0);
-        let ax_1 = s.get_with_zeta(1, 4, 1);
-        let ax_0 = s.get_with_zeta(0, 4, 0);
-        let ax_4 = s.get_with_zeta(4, 4, 0);
-        let ax_3 = s.get_with_zeta(3, 4, 0);
-        s.c[4][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let c_x4_zeta0 = s.c[4][0];
-        let c_x1_zeta1 = s.c[1][1];
-        let c_x3_zeta0 = s.c[3][0];
-        let c_x0_zeta1 = s.c[0][1];
-        let c_x2_zeta0 = s.c[2][0];
-        let c_x4_zeta1 = s.c[4][1];
-        let d_x0_zeta0 = c_x4_zeta0 ^ c_x1_zeta1.rotate_left(1);
-        s.d[0][0] = d_x0_zeta0;
-        let d_x2_zeta1 = c_x1_zeta1 ^ c_x3_zeta0;
-        s.d[2][1] = d_x2_zeta1;
-        let d_x4_zeta0 = c_x3_zeta0 ^ c_x0_zeta1.rotate_left(1);
-        s.d[4][0] = d_x4_zeta0;
-        let d_x1_zeta1 = c_x0_zeta1 ^ c_x2_zeta0;
-        s.d[1][1] = d_x1_zeta1;
-        let d_x3_zeta0 = c_x2_zeta0 ^ c_x4_zeta1.rotate_left(1);
-        s.d[3][0] = d_x3_zeta0;
-        let c_x1_zeta0 = s.c[1][0];
-        let c_x3_zeta1 = s.c[3][1];
-        let c_x2_zeta1 = s.c[2][1];
-        let c_x0_zeta0 = s.c[0][0];
-        let d_x0_zeta1 = c_x4_zeta1 ^ c_x1_zeta0;
-        s.d[0][1] = d_x0_zeta1;
-        let d_x2_zeta0 = c_x1_zeta0 ^ c_x3_zeta1.rotate_left(1);
-        s.d[2][0] = d_x2_zeta0;
-        let d_x4_zeta1 = c_x3_zeta1 ^ c_x0_zeta0;
-        s.d[4][1] = d_x4_zeta1;
-        let d_x1_zeta0 = c_x0_zeta0 ^ c_x2_zeta1.rotate_left(1);
-        s.d[1][0] = d_x1_zeta0;
-        let d_x3_zeta1 = c_x2_zeta1 ^ c_x4_zeta0;
-        s.d[3][1] = d_x3_zeta1;
-    }
+pub(crate) fn keccakf1600_round2_theta_c_x0_z0(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 0, 0);
+    let ax_4 = s.get_with_zeta(4, 0, 1);
+    let ax_3 = s.get_with_zeta(3, 0, 1);
+    let ax_2 = s.get_with_zeta(2, 0, 1);
+    let ax_1 = s.get_with_zeta(1, 0, 1);
+    s.set_lane_value(0, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round2_theta_c_x0_z1(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 0, 1);
+    let ax_4 = s.get_with_zeta(4, 0, 0);
+    let ax_3 = s.get_with_zeta(3, 0, 0);
+    let ax_2 = s.get_with_zeta(2, 0, 0);
+    let ax_1 = s.get_with_zeta(1, 0, 0);
+    s.set_lane_value(0, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round2_theta_c_x1_z0(s: &mut KeccakState) {
+    let ax_3 = s.get_with_zeta(3, 1, 1);
+    let ax_2 = s.get_with_zeta(2, 1, 1);
+    let ax_1 = s.get_with_zeta(1, 1, 1);
+    let ax_0 = s.get_with_zeta(0, 1, 1);
+    let ax_4 = s.get_with_zeta(4, 1, 0);
+    s.set_lane_value(1, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round2_theta_c_x1_z1(s: &mut KeccakState) {
+    let ax_3 = s.get_with_zeta(3, 1, 0);
+    let ax_2 = s.get_with_zeta(2, 1, 0);
+    let ax_1 = s.get_with_zeta(1, 1, 0);
+    let ax_0 = s.get_with_zeta(0, 1, 0);
+    let ax_4 = s.get_with_zeta(4, 1, 1);
+    s.set_lane_value(1, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round2_theta_c_x2_z0(s: &mut KeccakState) {
+    let ax_1 = s.get_with_zeta(1, 2, 1);
+    let ax_0 = s.get_with_zeta(0, 2, 1);
+    let ax_4 = s.get_with_zeta(4, 2, 1);
+    let ax_3 = s.get_with_zeta(3, 2, 0);
+    let ax_2 = s.get_with_zeta(2, 2, 1);
+    s.set_lane_value(2, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round2_theta_c_x2_z1(s: &mut KeccakState) {
+    let ax_1 = s.get_with_zeta(1, 2, 0);
+    let ax_0 = s.get_with_zeta(0, 2, 0);
+    let ax_4 = s.get_with_zeta(4, 2, 0);
+    let ax_3 = s.get_with_zeta(3, 2, 1);
+    let ax_2 = s.get_with_zeta(2, 2, 0);
+    s.set_lane_value(2, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round2_theta_c_x3_z0(s: &mut KeccakState) {
+    let ax_4 = s.get_with_zeta(4, 3, 1);
+    let ax_3 = s.get_with_zeta(3, 3, 1);
+    let ax_2 = s.get_with_zeta(2, 3, 0);
+    let ax_1 = s.get_with_zeta(1, 3, 1);
+    let ax_0 = s.get_with_zeta(0, 3, 1);
+    s.set_lane_value(3, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round2_theta_c_x3_z1(s: &mut KeccakState) {
+    let ax_4 = s.get_with_zeta(4, 3, 0);
+    let ax_3 = s.get_with_zeta(3, 3, 0);
+    let ax_2 = s.get_with_zeta(2, 3, 1);
+    let ax_1 = s.get_with_zeta(1, 3, 0);
+    let ax_0 = s.get_with_zeta(0, 3, 0);
+    s.set_lane_value(3, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round2_theta_c_x4_z0(s: &mut KeccakState) {
+    let ax_2 = s.get_with_zeta(2, 4, 1);
+    let ax_1 = s.get_with_zeta(1, 4, 0);
+    let ax_0 = s.get_with_zeta(0, 4, 1);
+    let ax_4 = s.get_with_zeta(4, 4, 1);
+    let ax_3 = s.get_with_zeta(3, 4, 1);
+    s.set_lane_value(4, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round2_theta_c_x4_z1(s: &mut KeccakState) {
+    let ax_2 = s.get_with_zeta(2, 4, 0);
+    let ax_1 = s.get_with_zeta(1, 4, 1);
+    let ax_0 = s.get_with_zeta(0, 4, 0);
+    let ax_4 = s.get_with_zeta(4, 4, 0);
+    let ax_3 = s.get_with_zeta(3, 4, 0);
+    s.set_lane_value(4, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round2_theta_d(s: &mut KeccakState) {
+    let c_x4_zeta0 = s.c[4][0];
+    let c_x1_zeta1 = s.c[1][1];
+    let c_x3_zeta0 = s.c[3][0];
+    let c_x0_zeta1 = s.c[0][1];
+    let c_x2_zeta0 = s.c[2][0];
+    let c_x4_zeta1 = s.c[4][1];
+    let d_x0_zeta0 = c_x4_zeta0 ^ c_x1_zeta1.rotate_left(1);
+    s.d[0].0[0] = d_x0_zeta0;
+    let d_x2_zeta1 = c_x1_zeta1 ^ c_x3_zeta0;
+    s.d[2].0[1] = d_x2_zeta1;
+    let d_x4_zeta0 = c_x3_zeta0 ^ c_x0_zeta1.rotate_left(1);
+    s.d[4].0[0] = d_x4_zeta0;
+    let d_x1_zeta1 = c_x0_zeta1 ^ c_x2_zeta0;
+    s.d[1].0[1] = d_x1_zeta1;
+    let d_x3_zeta0 = c_x2_zeta0 ^ c_x4_zeta1.rotate_left(1);
+    s.d[3].0[0] = d_x3_zeta0;
+    let c_x1_zeta0 = s.c[1][0];
+    let c_x3_zeta1 = s.c[3][1];
+    let c_x2_zeta1 = s.c[2][1];
+    let c_x0_zeta0 = s.c[0][0];
+    let d_x0_zeta1 = c_x4_zeta1 ^ c_x1_zeta0;
+    s.d[0].0[1] = d_x0_zeta1;
+    let d_x2_zeta0 = c_x1_zeta0 ^ c_x3_zeta1.rotate_left(1);
+    s.d[2].0[0] = d_x2_zeta0;
+    let d_x4_zeta1 = c_x3_zeta1 ^ c_x0_zeta0;
+    s.d[4].0[1] = d_x4_zeta1;
+    let d_x1_zeta0 = c_x0_zeta0 ^ c_x2_zeta1.rotate_left(1);
+    s.d[1].0[0] = d_x1_zeta0;
+    let d_x3_zeta1 = c_x2_zeta1 ^ c_x4_zeta0;
+    s.d[3].0[1] = d_x3_zeta1;
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round2_theta(s: &mut KeccakState) {
+    keccakf1600_round2_theta_c_x0_z0(s);
+    keccakf1600_round2_theta_c_x0_z1(s);
+    keccakf1600_round2_theta_c_x1_z0(s);
+    keccakf1600_round2_theta_c_x1_z1(s);
+    keccakf1600_round2_theta_c_x2_z0(s);
+    keccakf1600_round2_theta_c_x2_z1(s);
+    keccakf1600_round2_theta_c_x3_z0(s);
+    keccakf1600_round2_theta_c_x3_z1(s);
+    keccakf1600_round2_theta_c_x4_z0(s);
+    keccakf1600_round2_theta_c_x4_z1(s);
+    keccakf1600_round2_theta_d(s);
+}
+
+#[inline(always)]
+#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
+pub(crate) fn keccakf1600_round2_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
     #[cfg(not(feature = "full-unroll"))]
     let i = s.i;
     {
@@ -1310,7 +1450,10 @@ pub(crate) fn keccakf1600_round2<const BASE_ROUND: usize>(s: &mut KeccakState) {
                 (a4 ^ d4).rotate_left(7),
             )
         };
-        let ax0;
+
+        // [hax] uninitialized variables are note supported yet in lean.
+        #[allow(unused_assignments)]
+        let mut ax0 = 0;
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 2];
@@ -1350,7 +1493,10 @@ pub(crate) fn keccakf1600_round2<const BASE_ROUND: usize>(s: &mut KeccakState) {
                 (a4 ^ d4).rotate_left(7),
             )
         };
-        let ax0;
+
+        // [hax] uninitialized variables are note supported yet in lean.
+        #[allow(unused_assignments)]
+        let mut ax0 = 0;
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 2];
@@ -1434,6 +1580,11 @@ pub(crate) fn keccakf1600_round2<const BASE_ROUND: usize>(s: &mut KeccakState) {
         let ax4 = bx4 ^ ((!bx0) & bx1);
         s.set_with_zeta(1, 4, 1, ax4);
     }
+}
+
+#[inline(always)]
+#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1500 in"))]
+pub(crate) fn keccakf1600_round2_pi_rho_chi_2(s: &mut KeccakState) {
     {
         let (bx4, bx0) = {
             let a0 = s.get_with_zeta(1, 0, 1);
@@ -1629,119 +1780,158 @@ pub(crate) fn keccakf1600_round2<const BASE_ROUND: usize>(s: &mut KeccakState) {
 }
 
 #[inline(always)]
-pub(crate) fn keccakf1600_round3<const BASE_ROUND: usize>(s: &mut KeccakState) {
-    {
-        let ax_0 = s.get_with_zeta(0, 0, 0);
-        let ax_3 = s.get_with_zeta(3, 0, 0);
-        let ax_1 = s.get_with_zeta(1, 0, 1);
-        let ax_4 = s.get_with_zeta(4, 0, 1);
-        let ax_2 = s.get_with_zeta(2, 0, 0);
-        s.c[0][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_0 = s.get_with_zeta(0, 0, 1);
-        let ax_3 = s.get_with_zeta(3, 0, 1);
-        let ax_1 = s.get_with_zeta(1, 0, 0);
-        let ax_4 = s.get_with_zeta(4, 0, 0);
-        let ax_2 = s.get_with_zeta(2, 0, 1);
-        s.c[0][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_2 = s.get_with_zeta(2, 1, 1);
-        let ax_0 = s.get_with_zeta(0, 1, 0);
-        let ax_3 = s.get_with_zeta(3, 1, 0);
-        let ax_1 = s.get_with_zeta(1, 1, 1);
-        let ax_4 = s.get_with_zeta(4, 1, 0);
-        s.c[1][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_2 = s.get_with_zeta(2, 1, 0);
-        let ax_0 = s.get_with_zeta(0, 1, 1);
-        let ax_3 = s.get_with_zeta(3, 1, 1);
-        let ax_1 = s.get_with_zeta(1, 1, 0);
-        let ax_4 = s.get_with_zeta(4, 1, 1);
-        s.c[1][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_4 = s.get_with_zeta(4, 2, 0);
-        let ax_2 = s.get_with_zeta(2, 2, 0);
-        let ax_0 = s.get_with_zeta(0, 2, 1);
-        let ax_3 = s.get_with_zeta(3, 2, 1);
-        let ax_1 = s.get_with_zeta(1, 2, 1);
-        s.c[2][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_4 = s.get_with_zeta(4, 2, 1);
-        let ax_2 = s.get_with_zeta(2, 2, 1);
-        let ax_0 = s.get_with_zeta(0, 2, 0);
-        let ax_3 = s.get_with_zeta(3, 2, 0);
-        let ax_1 = s.get_with_zeta(1, 2, 0);
-        s.c[2][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_1 = s.get_with_zeta(1, 3, 0);
-        let ax_4 = s.get_with_zeta(4, 3, 1);
-        let ax_2 = s.get_with_zeta(2, 3, 1);
-        let ax_0 = s.get_with_zeta(0, 3, 1);
-        let ax_3 = s.get_with_zeta(3, 3, 0);
-        s.c[3][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_1 = s.get_with_zeta(1, 3, 1);
-        let ax_4 = s.get_with_zeta(4, 3, 0);
-        let ax_2 = s.get_with_zeta(2, 3, 0);
-        let ax_0 = s.get_with_zeta(0, 3, 0);
-        let ax_3 = s.get_with_zeta(3, 3, 1);
-        s.c[3][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_3 = s.get_with_zeta(3, 4, 1);
-        let ax_1 = s.get_with_zeta(1, 4, 0);
-        let ax_4 = s.get_with_zeta(4, 4, 1);
-        let ax_2 = s.get_with_zeta(2, 4, 0);
-        let ax_0 = s.get_with_zeta(0, 4, 0);
-        s.c[4][0] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let ax_3 = s.get_with_zeta(3, 4, 0);
-        let ax_1 = s.get_with_zeta(1, 4, 1);
-        let ax_4 = s.get_with_zeta(4, 4, 0);
-        let ax_2 = s.get_with_zeta(2, 4, 1);
-        let ax_0 = s.get_with_zeta(0, 4, 1);
-        s.c[4][1] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;
-    }
-    {
-        let c_x4_zeta0 = s.c[4][0];
-        let c_x1_zeta1 = s.c[1][1];
-        let c_x3_zeta0 = s.c[3][0];
-        let c_x0_zeta1 = s.c[0][1];
-        let c_x2_zeta0 = s.c[2][0];
-        let c_x4_zeta1 = s.c[4][1];
-        let d_x0_zeta0 = c_x4_zeta0 ^ c_x1_zeta1.rotate_left(1);
-        s.d[0][0] = d_x0_zeta0;
-        let d_x2_zeta1 = c_x1_zeta1 ^ c_x3_zeta0;
-        s.d[2][1] = d_x2_zeta1;
-        let d_x4_zeta0 = c_x3_zeta0 ^ c_x0_zeta1.rotate_left(1);
-        s.d[4][0] = d_x4_zeta0;
-        let d_x1_zeta1 = c_x0_zeta1 ^ c_x2_zeta0;
-        s.d[1][1] = d_x1_zeta1;
-        let d_x3_zeta0 = c_x2_zeta0 ^ c_x4_zeta1.rotate_left(1);
-        s.d[3][0] = d_x3_zeta0;
-        let c_x1_zeta0 = s.c[1][0];
-        let c_x3_zeta1 = s.c[3][1];
-        let c_x2_zeta1 = s.c[2][1];
-        let c_x0_zeta0 = s.c[0][0];
-        let d_x0_zeta1 = c_x4_zeta1 ^ c_x1_zeta0;
-        s.d[0][1] = d_x0_zeta1;
-        let d_x2_zeta0 = c_x1_zeta0 ^ c_x3_zeta1.rotate_left(1);
-        s.d[2][0] = d_x2_zeta0;
-        let d_x4_zeta1 = c_x3_zeta1 ^ c_x0_zeta0;
-        s.d[4][1] = d_x4_zeta1;
-        let d_x1_zeta0 = c_x0_zeta0 ^ c_x2_zeta1.rotate_left(1);
-        s.d[1][0] = d_x1_zeta0;
-        let d_x3_zeta1 = c_x2_zeta1 ^ c_x4_zeta0;
-        s.d[3][1] = d_x3_zeta1;
-    }
+#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
+pub(crate) fn keccakf1600_round3_theta_c_x0_z0(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 0, 0);
+    let ax_3 = s.get_with_zeta(3, 0, 0);
+    let ax_1 = s.get_with_zeta(1, 0, 1);
+    let ax_4 = s.get_with_zeta(4, 0, 1);
+    let ax_2 = s.get_with_zeta(2, 0, 0);
+    s.set_lane_value(0, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round3_theta_c_x0_z1(s: &mut KeccakState) {
+    let ax_0 = s.get_with_zeta(0, 0, 1);
+    let ax_3 = s.get_with_zeta(3, 0, 1);
+    let ax_1 = s.get_with_zeta(1, 0, 0);
+    let ax_4 = s.get_with_zeta(4, 0, 0);
+    let ax_2 = s.get_with_zeta(2, 0, 1);
+    s.set_lane_value(0, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round3_theta_c_x1_z0(s: &mut KeccakState) {
+    let ax_2 = s.get_with_zeta(2, 1, 1);
+    let ax_0 = s.get_with_zeta(0, 1, 0);
+    let ax_3 = s.get_with_zeta(3, 1, 0);
+    let ax_1 = s.get_with_zeta(1, 1, 1);
+    let ax_4 = s.get_with_zeta(4, 1, 0);
+    s.set_lane_value(1, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round3_theta_c_x1_z1(s: &mut KeccakState) {
+    let ax_2 = s.get_with_zeta(2, 1, 0);
+    let ax_0 = s.get_with_zeta(0, 1, 1);
+    let ax_3 = s.get_with_zeta(3, 1, 1);
+    let ax_1 = s.get_with_zeta(1, 1, 0);
+    let ax_4 = s.get_with_zeta(4, 1, 1);
+    s.set_lane_value(1, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round3_theta_c_x2_z0(s: &mut KeccakState) {
+    let ax_4 = s.get_with_zeta(4, 2, 0);
+    let ax_2 = s.get_with_zeta(2, 2, 0);
+    let ax_0 = s.get_with_zeta(0, 2, 1);
+    let ax_3 = s.get_with_zeta(3, 2, 1);
+    let ax_1 = s.get_with_zeta(1, 2, 1);
+    s.set_lane_value(2, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round3_theta_c_x2_z1(s: &mut KeccakState) {
+    let ax_4 = s.get_with_zeta(4, 2, 1);
+    let ax_2 = s.get_with_zeta(2, 2, 1);
+    let ax_0 = s.get_with_zeta(0, 2, 0);
+    let ax_3 = s.get_with_zeta(3, 2, 0);
+    let ax_1 = s.get_with_zeta(1, 2, 0);
+    s.set_lane_value(2, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round3_theta_c_x3_z0(s: &mut KeccakState) {
+    let ax_1 = s.get_with_zeta(1, 3, 0);
+    let ax_4 = s.get_with_zeta(4, 3, 1);
+    let ax_2 = s.get_with_zeta(2, 3, 1);
+    let ax_0 = s.get_with_zeta(0, 3, 1);
+    let ax_3 = s.get_with_zeta(3, 3, 0);
+    s.set_lane_value(3, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round3_theta_c_x3_z1(s: &mut KeccakState) {
+    let ax_1 = s.get_with_zeta(1, 3, 1);
+    let ax_4 = s.get_with_zeta(4, 3, 0);
+    let ax_2 = s.get_with_zeta(2, 3, 0);
+    let ax_0 = s.get_with_zeta(0, 3, 0);
+    let ax_3 = s.get_with_zeta(3, 3, 1);
+    s.set_lane_value(3, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round3_theta_c_x4_z0(s: &mut KeccakState) {
+    let ax_3 = s.get_with_zeta(3, 4, 1);
+    let ax_1 = s.get_with_zeta(1, 4, 0);
+    let ax_4 = s.get_with_zeta(4, 4, 1);
+    let ax_2 = s.get_with_zeta(2, 4, 0);
+    let ax_0 = s.get_with_zeta(0, 4, 0);
+    s.set_lane_value(4, 0, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round3_theta_c_x4_z1(s: &mut KeccakState) {
+    let ax_3 = s.get_with_zeta(3, 4, 0);
+    let ax_1 = s.get_with_zeta(1, 4, 1);
+    let ax_4 = s.get_with_zeta(4, 4, 0);
+    let ax_2 = s.get_with_zeta(2, 4, 1);
+    let ax_0 = s.get_with_zeta(0, 4, 1);
+    s.set_lane_value(4, 1, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round3_theta_d(s: &mut KeccakState) {
+    let c_x4_zeta0 = s.c[4][0];
+    let c_x1_zeta1 = s.c[1][1];
+    let c_x3_zeta0 = s.c[3][0];
+    let c_x0_zeta1 = s.c[0][1];
+    let c_x2_zeta0 = s.c[2][0];
+    let c_x4_zeta1 = s.c[4][1];
+    let d_x0_zeta0 = c_x4_zeta0 ^ c_x1_zeta1.rotate_left(1);
+    s.d[0].0[0] = d_x0_zeta0;
+    let d_x2_zeta1 = c_x1_zeta1 ^ c_x3_zeta0;
+    s.d[2].0[1] = d_x2_zeta1;
+    let d_x4_zeta0 = c_x3_zeta0 ^ c_x0_zeta1.rotate_left(1);
+    s.d[4].0[0] = d_x4_zeta0;
+    let d_x1_zeta1 = c_x0_zeta1 ^ c_x2_zeta0;
+    s.d[1].0[1] = d_x1_zeta1;
+    let d_x3_zeta0 = c_x2_zeta0 ^ c_x4_zeta1.rotate_left(1);
+    s.d[3].0[0] = d_x3_zeta0;
+    let c_x1_zeta0 = s.c[1][0];
+    let c_x3_zeta1 = s.c[3][1];
+    let c_x2_zeta1 = s.c[2][1];
+    let c_x0_zeta0 = s.c[0][0];
+    let d_x0_zeta1 = c_x4_zeta1 ^ c_x1_zeta0;
+    s.d[0].0[1] = d_x0_zeta1;
+    let d_x2_zeta0 = c_x1_zeta0 ^ c_x3_zeta1.rotate_left(1);
+    s.d[2].0[0] = d_x2_zeta0;
+    let d_x4_zeta1 = c_x3_zeta1 ^ c_x0_zeta0;
+    s.d[4].0[1] = d_x4_zeta1;
+    let d_x1_zeta0 = c_x0_zeta0 ^ c_x2_zeta1.rotate_left(1);
+    s.d[1].0[0] = d_x1_zeta0;
+    let d_x3_zeta1 = c_x2_zeta1 ^ c_x4_zeta0;
+    s.d[3].0[1] = d_x3_zeta1;
+}
+
+#[inline(always)]
+pub(crate) fn keccakf1600_round3_theta(s: &mut KeccakState) {
+    keccakf1600_round3_theta_c_x0_z0(s);
+    keccakf1600_round3_theta_c_x0_z1(s);
+    keccakf1600_round3_theta_c_x1_z0(s);
+    keccakf1600_round3_theta_c_x1_z1(s);
+    keccakf1600_round3_theta_c_x2_z0(s);
+    keccakf1600_round3_theta_c_x2_z1(s);
+    keccakf1600_round3_theta_c_x3_z0(s);
+    keccakf1600_round3_theta_c_x3_z1(s);
+    keccakf1600_round3_theta_c_x4_z0(s);
+    keccakf1600_round3_theta_c_x4_z1(s);
+    keccakf1600_round3_theta_d(s);
+}
+
+#[inline(always)]
+#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
+pub(crate) fn keccakf1600_round3_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
     #[cfg(not(feature = "full-unroll"))]
     let i = s.i;
     {
@@ -1765,7 +1955,10 @@ pub(crate) fn keccakf1600_round3<const BASE_ROUND: usize>(s: &mut KeccakState) {
                 (a4 ^ d4).rotate_left(7),
             )
         };
-        let ax0;
+
+        // [hax] uninitialized variables are note supported yet in lean.
+        #[allow(unused_assignments)]
+        let mut ax0 = 0;
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 3];
@@ -1805,7 +1998,10 @@ pub(crate) fn keccakf1600_round3<const BASE_ROUND: usize>(s: &mut KeccakState) {
                 (a4 ^ d4).rotate_left(7),
             )
         };
-        let ax0;
+
+        // [hax] uninitialized variables are note supported yet in lean.
+        #[allow(unused_assignments)]
+        let mut ax0 = 0;
         #[cfg(feature = "full-unroll")]
         {
             ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 3];
@@ -1889,6 +2085,11 @@ pub(crate) fn keccakf1600_round3<const BASE_ROUND: usize>(s: &mut KeccakState) {
         let ax4 = bx4 ^ ((!bx0) & bx1);
         s.set_with_zeta(1, 4, 1, ax4);
     }
+}
+
+#[inline(always)]
+#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1500 in"))]
+pub(crate) fn keccakf1600_round3_pi_rho_chi_2(s: &mut KeccakState) {
     {
         let (bx4, bx0) = {
             let a0 = s.get_with_zeta(2, 0, 0);
@@ -2091,10 +2292,18 @@ pub(crate) fn keccakf1600_round3<const BASE_ROUND: usize>(s: &mut KeccakState) {
 //   [CYCLE_MEASUREMENT libcrux SHAKE256 (PRF_ETA1_RANDOMNESS_1024)] : + 19139 cycles
 #[inline(always)]
 pub(crate) fn keccakf1600_4rounds<const BASE_ROUND: usize>(s: &mut KeccakState) {
-    keccakf1600_round0::<BASE_ROUND>(s);
-    keccakf1600_round1::<BASE_ROUND>(s);
-    keccakf1600_round2::<BASE_ROUND>(s);
-    keccakf1600_round3::<BASE_ROUND>(s);
+    keccakf1600_round0_theta(s);
+    keccakf1600_round0_pi_rho_chi_1::<BASE_ROUND>(s);
+    keccakf1600_round0_pi_rho_chi_2(s);
+    keccakf1600_round1_theta(s);
+    keccakf1600_round1_pi_rho_chi_1::<BASE_ROUND>(s);
+    keccakf1600_round1_pi_rho_chi_2(s);
+    keccakf1600_round2_theta(s);
+    keccakf1600_round2_pi_rho_chi_1::<BASE_ROUND>(s);
+    keccakf1600_round2_pi_rho_chi_2(s);
+    keccakf1600_round3_theta(s);
+    keccakf1600_round3_pi_rho_chi_1::<BASE_ROUND>(s);
+    keccakf1600_round3_pi_rho_chi_2(s);
 }
 
 #[inline(never)]
@@ -2155,27 +2364,18 @@ pub(crate) fn squeeze_next_block<const RATE: usize>(s: &mut KeccakState, out: &m
 
 #[inline(always)]
 pub(crate) fn squeeze_first_three_blocks<const RATE: usize>(s: &mut KeccakState, out: &mut [U8]) {
-    let (mut o0, o1) = Lane2U32::split_at_mut_n(out, RATE);
-    squeeze_first_block::<RATE>(s, &mut o0);
-    let (mut o1, mut o2) = Lane2U32::split_at_mut_n(o1, RATE);
-    squeeze_next_block::<RATE>(s, &mut o1);
-    squeeze_next_block::<RATE>(s, &mut o2);
+    squeeze_first_block::<RATE>(s, out);
+    squeeze_next_block::<RATE>(s, &mut out[RATE..]);
+    squeeze_next_block::<RATE>(s, &mut out[2 * RATE..]);
 }
 
 #[inline(always)]
 pub(crate) fn squeeze_first_five_blocks<const RATE: usize>(s: &mut KeccakState, out: &mut [U8]) {
-    let (mut o0, o1) = Lane2U32::split_at_mut_n(out, RATE);
-    squeeze_first_block::<RATE>(s, &mut o0);
-    let (mut o1, o2) = Lane2U32::split_at_mut_n(o1, RATE);
-
-    squeeze_next_block::<RATE>(s, &mut o1);
-    let (mut o2, o3) = Lane2U32::split_at_mut_n(o2, RATE);
-
-    squeeze_next_block::<RATE>(s, &mut o2);
-    let (mut o3, mut o4) = Lane2U32::split_at_mut_n(o3, RATE);
-
-    squeeze_next_block::<RATE>(s, &mut o3);
-    squeeze_next_block::<RATE>(s, &mut o4);
+    squeeze_first_block::<RATE>(s, out);
+    squeeze_next_block::<RATE>(s, &mut out[RATE..]);
+    squeeze_next_block::<RATE>(s, &mut out[2 * RATE..]);
+    squeeze_next_block::<RATE>(s, &mut out[3 * RATE..]);
+    squeeze_next_block::<RATE>(s, &mut out[4 * RATE..]);
 }
 
 #[inline(always)]
@@ -2216,15 +2416,14 @@ pub(crate) fn keccak<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut 
     if blocks == 0 {
         squeeze_first_and_last::<RATE>(&s, out)
     } else {
-        let (mut o0, mut o1) = Lane2U32::split_at_mut_n(out, RATE);
-        squeeze_first_block::<RATE>(&s, &mut o0);
+        squeeze_first_block::<RATE>(&s, out);
+        let mut offset = RATE;
         for _i in 1..blocks {
-            let (mut o, orest) = Lane2U32::split_at_mut_n(o1, RATE);
-            squeeze_next_block::<RATE>(&mut s, &mut o);
-            o1 = orest;
+            squeeze_next_block::<RATE>(&mut s, &mut out[offset..]);
+            offset += RATE;
         }
         if last < outlen {
-            squeeze_last::<RATE>(s, o1)
+            squeeze_last::<RATE>(s, &mut out[offset..])
         }
     }
 }

--- a/libcrux-iot/sha3/src/lane.rs
+++ b/libcrux-iot/sha3/src/lane.rs
@@ -1,10 +1,10 @@
-use core::ops::{Index, IndexMut};
+use core::ops::Index;
 
 use libcrux_secrets::{CastOps, Classify as _, U32};
 
 /// A lane of the Keccak state,
 #[derive(Clone, Copy)]
-pub struct Lane2U32([U32; 2]);
+pub struct Lane2U32(pub(crate) [U32; 2]);
 
 impl Lane2U32 {
     #[inline(always)]
@@ -15,11 +15,6 @@ impl Lane2U32 {
     #[inline(always)]
     pub(crate) fn zero() -> Self {
         Self::from_ints([0, 0].classify())
-    }
-
-    #[inline(always)]
-    pub(crate) fn split_at_mut_n<T>(a: &mut [T], mid: usize) -> (&mut [T], &mut [T]) {
-        split_at_mut_1(a, mid)
     }
 
     // NOTE: it would be a bit nicer if we used separate types for the interleaved and
@@ -46,7 +41,8 @@ impl Lane2U32 {
 
     #[inline(always)]
     pub(crate) fn deinterleave(self) -> Lane2U32 {
-        let Lane2U32([even_bits, odd_bits]) = self;
+        let even_bits = self.0[0];
+        let odd_bits = self.0[1];
         let mut even_spaced_lo = even_bits & 0xffff;
         even_spaced_lo = (even_spaced_lo ^ (even_spaced_lo << 16)) & 0x0000_ffff;
         even_spaced_lo = (even_spaced_lo ^ (even_spaced_lo << 8)) & 0x00ff_00ff;
@@ -91,13 +87,6 @@ impl Index<usize> for Lane2U32 {
     }
 }
 
-impl IndexMut<usize> for Lane2U32 {
-    #[inline(always)]
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.0[index]
-    }
-}
-
 impl From<[U32; 2]> for Lane2U32 {
     #[inline(always)]
     fn from(value: [U32; 2]) -> Self {
@@ -108,6 +97,7 @@ impl From<[U32; 2]> for Lane2U32 {
 // XXX: This impl will panic Charon at rev 667d2fc98984ff7f3df989c2367e6c1fa4a000e7, so the derivations of
 //      `Debug` which build on it have to be switched off for Eurydice.
 #[cfg(not(eurydice))]
+#[cfg_attr(hax, hax_lib::opaque)]
 impl core::fmt::Debug for Lane2U32 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use libcrux_secrets::Declassify;
@@ -115,11 +105,6 @@ impl core::fmt::Debug for Lane2U32 {
             .field(&self.0.declassify())
             .finish()
     }
-}
-
-#[inline(always)]
-fn split_at_mut_1<T>(out: &mut [T], mid: usize) -> (&mut [T], &mut [T]) {
-    out.split_at_mut(mid)
 }
 
 #[cfg(all(not(eurydice), test))]

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -2,6 +2,9 @@
 //!
 //! A SHA3 implementation with optional simd optimisations.
 
+// Below, some arrays are explicitly converted into slices by writing `out[..]`
+// instead of `out` as a workaround for https://github.com/cryspen/hax/issues/1983
+
 #![no_std]
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
@@ -77,6 +80,14 @@ pub fn hash<const LEN: usize>(algorithm: Algorithm, payload: &[U8]) -> [U8; LEN]
     debug_assert!(payload.len() <= u32::MAX as usize);
 
     let mut out = [0u8; LEN].classify();
+    #[cfg(hax)]
+    match algorithm {
+        Algorithm::Sha224 => portable::sha224(&mut out[..], payload),
+        Algorithm::Sha256 => portable::sha256(&mut out[..], payload),
+        Algorithm::Sha384 => portable::sha384(&mut out[..], payload),
+        Algorithm::Sha512 => portable::sha512(&mut out[..], payload),
+    }
+    #[cfg(not(hax))]
     match algorithm {
         Algorithm::Sha224 => portable::sha224(&mut out, payload),
         Algorithm::Sha256 => portable::sha256(&mut out, payload),
@@ -92,6 +103,9 @@ pub use hash as sha3;
 /// SHA3 224
 pub fn sha224(data: &[U8]) -> [U8; SHA3_224_DIGEST_SIZE] {
     let mut out = [0u8; 28].classify();
+    #[cfg(hax)]
+    sha224_ema(&mut out[..], data);
+    #[cfg(not(hax))]
     sha224_ema(&mut out, data);
     out
 }
@@ -112,6 +126,9 @@ pub fn sha224_ema(digest: &mut [U8], payload: &[U8]) {
 /// SHA3 256
 pub fn sha256(data: &[U8]) -> [U8; SHA3_256_DIGEST_SIZE] {
     let mut out = [0u8; 32].classify();
+    #[cfg(hax)]
+    sha256_ema(&mut out[..], data);
+    #[cfg(not(hax))]
     sha256_ema(&mut out, data);
     out
 }
@@ -129,6 +146,9 @@ pub fn sha256_ema(digest: &mut [U8], payload: &[U8]) {
 /// SHA3 384
 pub fn sha384(data: &[U8]) -> [U8; SHA3_384_DIGEST_SIZE] {
     let mut out = [0u8; 48].classify();
+    #[cfg(hax)]
+    sha384_ema(&mut out[..], data);
+    #[cfg(not(hax))]
     sha384_ema(&mut out, data);
     out
 }
@@ -146,6 +166,9 @@ pub fn sha384_ema(digest: &mut [U8], payload: &[U8]) {
 /// SHA3 512
 pub fn sha512(data: &[U8]) -> [U8; SHA3_512_DIGEST_SIZE] {
     let mut out = [0u8; 64].classify();
+    #[cfg(hax)]
+    sha512_ema(&mut out[..], data);
+    #[cfg(not(hax))]
     sha512_ema(&mut out, data);
     out
 }
@@ -166,6 +189,9 @@ pub fn sha512_ema(digest: &mut [U8], payload: &[U8]) {
 /// the output will only return `u32::MAX` bytes.
 pub fn shake128<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     let mut out = [0u8; BYTES].classify();
+    #[cfg(hax)]
+    portable::keccakx1::<168, 0x1fu8>(data, &mut out[..]);
+    #[cfg(not(hax))]
     portable::keccakx1::<168, 0x1fu8>(data, &mut out);
     out
 }
@@ -183,6 +209,9 @@ pub fn shake128_ema(out: &mut [U8], data: &[U8]) {
 /// the output will only return `u32::MAX` bytes.
 pub fn shake256<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     let mut out = [0u8; BYTES].classify();
+    #[cfg(hax)]
+    portable::keccakx1::<136, 0x1fu8>(data, &mut out[..]);
+    #[cfg(not(hax))]
     portable::keccakx1::<136, 0x1fu8>(data, &mut out);
     out
 }

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -2,6 +2,9 @@
 //!
 //! A SHA3 implementation with optional simd optimisations.
 
+// Below, some arrays are explicitly converted into slices by writing `out[..]`
+// instead of `out` as a workaround for https://github.com/cryspen/hax/issues/1983
+
 #![no_std]
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
@@ -78,10 +81,10 @@ pub fn hash<const LEN: usize>(algorithm: Algorithm, payload: &[U8]) -> [U8; LEN]
 
     let mut out = [0u8; LEN].classify();
     match algorithm {
-        Algorithm::Sha224 => portable::sha224(&mut out, payload),
-        Algorithm::Sha256 => portable::sha256(&mut out, payload),
-        Algorithm::Sha384 => portable::sha384(&mut out, payload),
-        Algorithm::Sha512 => portable::sha512(&mut out, payload),
+        Algorithm::Sha224 => portable::sha224(&mut out[..], payload),
+        Algorithm::Sha256 => portable::sha256(&mut out[..], payload),
+        Algorithm::Sha384 => portable::sha384(&mut out[..], payload),
+        Algorithm::Sha512 => portable::sha512(&mut out[..], payload),
     }
     out
 }
@@ -92,7 +95,7 @@ pub use hash as sha3;
 /// SHA3 224
 pub fn sha224(data: &[U8]) -> [U8; SHA3_224_DIGEST_SIZE] {
     let mut out = [0u8; 28].classify();
-    sha224_ema(&mut out, data);
+    sha224_ema(&mut out[..], data);
     out
 }
 
@@ -112,7 +115,7 @@ pub fn sha224_ema(digest: &mut [U8], payload: &[U8]) {
 /// SHA3 256
 pub fn sha256(data: &[U8]) -> [U8; SHA3_256_DIGEST_SIZE] {
     let mut out = [0u8; 32].classify();
-    sha256_ema(&mut out, data);
+    sha256_ema(&mut out[..], data);
     out
 }
 
@@ -129,7 +132,7 @@ pub fn sha256_ema(digest: &mut [U8], payload: &[U8]) {
 /// SHA3 384
 pub fn sha384(data: &[U8]) -> [U8; SHA3_384_DIGEST_SIZE] {
     let mut out = [0u8; 48].classify();
-    sha384_ema(&mut out, data);
+    sha384_ema(&mut out[..], data);
     out
 }
 
@@ -146,7 +149,7 @@ pub fn sha384_ema(digest: &mut [U8], payload: &[U8]) {
 /// SHA3 512
 pub fn sha512(data: &[U8]) -> [U8; SHA3_512_DIGEST_SIZE] {
     let mut out = [0u8; 64].classify();
-    sha512_ema(&mut out, data);
+    sha512_ema(&mut out[..], data);
     out
 }
 
@@ -166,7 +169,7 @@ pub fn sha512_ema(digest: &mut [U8], payload: &[U8]) {
 /// the output will only return `u32::MAX` bytes.
 pub fn shake128<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     let mut out = [0u8; BYTES].classify();
-    portable::keccakx1::<168, 0x1fu8>(data, &mut out);
+    portable::keccakx1::<168, 0x1fu8>(data, &mut out[..]);
     out
 }
 
@@ -183,7 +186,7 @@ pub fn shake128_ema(out: &mut [U8], data: &[U8]) {
 /// the output will only return `u32::MAX` bytes.
 pub fn shake256<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     let mut out = [0u8; BYTES].classify();
-    portable::keccakx1::<136, 0x1fu8>(data, &mut out);
+    portable::keccakx1::<136, 0x1fu8>(data, &mut out[..]);
     out
 }
 

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -377,7 +377,7 @@ pub mod portable {
 
         /// Squeeze the first SHAKE-256 block
         pub fn shake256_squeeze_first_block(s: &mut KeccakState, out: &mut [U8]) {
-            squeeze_first_block::<136>(&mut s.state, out)
+            squeeze_first_block::<136>(&s.state, out)
         }
 
         /// Squeeze the next SHAKE-256 block

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -2,9 +2,6 @@
 //!
 //! A SHA3 implementation with optional simd optimisations.
 
-// Below, some arrays are explicitly converted into slices by writing `out[..]`
-// instead of `out` as a workaround for https://github.com/cryspen/hax/issues/1983
-
 #![no_std]
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
@@ -81,10 +78,10 @@ pub fn hash<const LEN: usize>(algorithm: Algorithm, payload: &[U8]) -> [U8; LEN]
 
     let mut out = [0u8; LEN].classify();
     match algorithm {
-        Algorithm::Sha224 => portable::sha224(&mut out[..], payload),
-        Algorithm::Sha256 => portable::sha256(&mut out[..], payload),
-        Algorithm::Sha384 => portable::sha384(&mut out[..], payload),
-        Algorithm::Sha512 => portable::sha512(&mut out[..], payload),
+        Algorithm::Sha224 => portable::sha224(&mut out, payload),
+        Algorithm::Sha256 => portable::sha256(&mut out, payload),
+        Algorithm::Sha384 => portable::sha384(&mut out, payload),
+        Algorithm::Sha512 => portable::sha512(&mut out, payload),
     }
     out
 }
@@ -95,7 +92,7 @@ pub use hash as sha3;
 /// SHA3 224
 pub fn sha224(data: &[U8]) -> [U8; SHA3_224_DIGEST_SIZE] {
     let mut out = [0u8; 28].classify();
-    sha224_ema(&mut out[..], data);
+    sha224_ema(&mut out, data);
     out
 }
 
@@ -115,7 +112,7 @@ pub fn sha224_ema(digest: &mut [U8], payload: &[U8]) {
 /// SHA3 256
 pub fn sha256(data: &[U8]) -> [U8; SHA3_256_DIGEST_SIZE] {
     let mut out = [0u8; 32].classify();
-    sha256_ema(&mut out[..], data);
+    sha256_ema(&mut out, data);
     out
 }
 
@@ -132,7 +129,7 @@ pub fn sha256_ema(digest: &mut [U8], payload: &[U8]) {
 /// SHA3 384
 pub fn sha384(data: &[U8]) -> [U8; SHA3_384_DIGEST_SIZE] {
     let mut out = [0u8; 48].classify();
-    sha384_ema(&mut out[..], data);
+    sha384_ema(&mut out, data);
     out
 }
 
@@ -149,7 +146,7 @@ pub fn sha384_ema(digest: &mut [U8], payload: &[U8]) {
 /// SHA3 512
 pub fn sha512(data: &[U8]) -> [U8; SHA3_512_DIGEST_SIZE] {
     let mut out = [0u8; 64].classify();
-    sha512_ema(&mut out[..], data);
+    sha512_ema(&mut out, data);
     out
 }
 
@@ -169,7 +166,7 @@ pub fn sha512_ema(digest: &mut [U8], payload: &[U8]) {
 /// the output will only return `u32::MAX` bytes.
 pub fn shake128<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     let mut out = [0u8; BYTES].classify();
-    portable::keccakx1::<168, 0x1fu8>(data, &mut out[..]);
+    portable::keccakx1::<168, 0x1fu8>(data, &mut out);
     out
 }
 
@@ -186,7 +183,7 @@ pub fn shake128_ema(out: &mut [U8], data: &[U8]) {
 /// the output will only return `u32::MAX` bytes.
 pub fn shake256<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     let mut out = [0u8; BYTES].classify();
-    portable::keccakx1::<136, 0x1fu8>(data, &mut out[..]);
+    portable::keccakx1::<136, 0x1fu8>(data, &mut out);
     out
 }
 

--- a/libcrux-iot/sha3/src/state.rs
+++ b/libcrux-iot/sha3/src/state.rs
@@ -150,7 +150,8 @@ fn store_block_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
 
 #[inline(always)]
 fn store_block_full_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8; 200]) {
-    store_block_2u32::<RATE>(s, out);
+    // `out[..]` is a workaround for https://github.com/cryspen/hax/issues/1983
+    store_block_2u32::<RATE>(s, &mut out[..]);
 }
 
 #[cfg(feature = "check-secret-independence")]

--- a/libcrux-iot/sha3/src/state.rs
+++ b/libcrux-iot/sha3/src/state.rs
@@ -47,7 +47,7 @@ impl KeccakState {
     }
 
     #[inline(always)]
-    pub(crate) fn set_lane_value(&mut self, i: usize, j: usize, value: u32) {
+    pub(crate) fn set_lane_value(&mut self, i: usize, j: usize, value: U32) {
         // XXX: We can't implement IndexMut for `Lane2U32` because of hax
         self.c[i].0[j] = value
     }

--- a/libcrux-iot/sha3/src/state.rs
+++ b/libcrux-iot/sha3/src/state.rs
@@ -72,7 +72,8 @@ impl KeccakState {
         store_block_full_2u32::<RATE>(self, out);
     }
 
-    /// `out` has the exact size we want here. It must be less than or equal to `RATE`.
+    /// `out` has the exact size we want here. It must be less than or equal to
+    /// `RATE`.
     #[inline(always)]
     pub(crate) fn store<const RATE: usize>(self, out: &mut [U8]) {
         #[cfg(not(any(eurydice, hax)))]
@@ -150,6 +151,10 @@ fn store_block_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
 
 #[inline(always)]
 fn store_block_full_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8; 200]) {
+    // `out[..]` is a workaround for https://github.com/cryspen/hax/issues/1983
+    #[cfg(hax)]
+    store_block_2u32::<RATE>(s, &mut out[..]);
+    #[cfg(not(hax))]
     store_block_2u32::<RATE>(s, out);
 }
 

--- a/libcrux-iot/sha3/src/state.rs
+++ b/libcrux-iot/sha3/src/state.rs
@@ -6,7 +6,6 @@ use crate::lane::Lane2U32;
 #[cfg(feature = "check-secret-independence")]
 use crate::{FromLeBytes, ToLeBytes};
 
-#[cfg_attr(hax, hax_lib::opaque)]
 #[derive(Clone, Copy)]
 #[cfg_attr(not(eurydice), derive(Debug))]
 pub(crate) struct KeccakState {
@@ -34,7 +33,7 @@ impl KeccakState {
 
     #[inline(always)]
     pub(crate) fn set_with_zeta(&mut self, i: usize, j: usize, zeta: usize, v: U32) {
-        self.st[5 * j + i][zeta] = v
+        self.st[5 * j + i].0[zeta] = v
     }
 
     #[inline(always)]
@@ -45,6 +44,12 @@ impl KeccakState {
     #[inline(always)]
     pub(crate) fn set_lane(&mut self, i: usize, j: usize, lane: Lane2U32) {
         self.st[5 * j + i] = lane
+    }
+
+    #[inline(always)]
+    pub(crate) fn set_lane_value(&mut self, i: usize, j: usize, value: u32) {
+        // XXX: We can't implement IndexMut for `Lane2U32` because of hax
+        self.c[i].0[j] = value
     }
 
     #[inline(always)]
@@ -70,7 +75,7 @@ impl KeccakState {
     /// `out` has the exact size we want here. It must be less than or equal to `RATE`.
     #[inline(always)]
     pub(crate) fn store<const RATE: usize>(self, out: &mut [U8]) {
-        #[cfg(not(eurydice))]
+        #[cfg(not(any(eurydice, hax)))]
         debug_assert!(out.len() <= RATE, "{} > {}", out.len(), RATE);
 
         let num_full_blocks = out.len() / 8;
@@ -110,6 +115,7 @@ fn load_block_2u32<const RATE: usize>(state: &mut KeccakState, blocks: &[U8], st
     let mut state_flat = [Lane2U32::zero(); 25];
     for i in 0..RATE / 8 {
         let offset = start + 8 * i;
+        // u64::from_le_bytes
         let a = U32::from_le_bytes(blocks[offset..offset + 4].try_into().unwrap());
         let b = U32::from_le_bytes(blocks[offset + 4..offset + 8].try_into().unwrap());
         state_flat[i] = Lane2U32::from([a, b]).interleave();

--- a/libcrux-iot/sha3/src/state.rs
+++ b/libcrux-iot/sha3/src/state.rs
@@ -115,7 +115,7 @@ fn load_block_2u32<const RATE: usize>(state: &mut KeccakState, blocks: &[U8], st
     let mut state_flat = [Lane2U32::zero(); 25];
     for i in 0..RATE / 8 {
         let offset = start + 8 * i;
-        // u64::from_le_bytes
+        // Perform `u64::from_le_bytes` on our 32-bit representation:
         let a = U32::from_le_bytes(blocks[offset..offset + 4].try_into().unwrap());
         let b = U32::from_le_bytes(blocks[offset + 4..offset + 8].try_into().unwrap());
         state_flat[i] = Lane2U32::from([a, b]).interleave();

--- a/libcrux-iot/sha3/src/state.rs
+++ b/libcrux-iot/sha3/src/state.rs
@@ -150,8 +150,7 @@ fn store_block_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
 
 #[inline(always)]
 fn store_block_full_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8; 200]) {
-    // `out[..]` is a workaround for https://github.com/cryspen/hax/issues/1983
-    store_block_2u32::<RATE>(s, &mut out[..]);
+    store_block_2u32::<RATE>(s, out);
 }
 
 #[cfg(feature = "check-secret-independence")]


### PR DESCRIPTION
This PR makes changes to SHA3 that are currently necessary to extract the code using Hax/Lean.
* `split_at_mut` has a mutable return type, which is not supported. We use slices instead.
* For some definitions we need to increase Lean's `maxRecDepth` to allow it to parse them.
* The `keccakf1600_` functions are too large for Lean to handle. I had Claude split them into smaller ones, using `#[inline(always)]` so that the compiled code should be identical.
* Hax does not support uninitialized variables, so I initialize them with 0.
* Hax does not support pattern matching on arrays
* The `IndexMut` instance is not supported because it contains mutable return types. Instead we add a setter function `set_lane_value` to `Lane2U32`.
* In `lib.rs` there was one unnecessary `mut` annotation in a function argument.
* Finally, changing adding `last > 0` to `if last < out_len` in `keccak.rs` line 180 is a bug fix by @franziskuskiefer 

* Late addition: We write `out[..]` instead of `out` in some places due to https://github.com/cryspen/hax/issues/1983