### PR TITLE
SHA3 Cleanup and Documentation

### DIFF
--- a/libcrux-iot/ml-dsa/Cargo.toml
+++ b/libcrux-iot/ml-dsa/Cargo.toml
@@ -17,7 +17,7 @@ bench = false # so libtest doesn't eat the arguments to criterion
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libcrux-iot-sha3 = { path = "../sha3" }
+libcrux-iot-sha3 = { path = "../sha3", features = ["unbuffered-xof"] }
 libcrux-macros.workspace = true
 hax-lib.workspace = true
 libcrux-secrets.workspace = true

--- a/libcrux-iot/ml-dsa/src/hash_functions.rs
+++ b/libcrux-iot/ml-dsa/src/hash_functions.rs
@@ -98,7 +98,7 @@ pub(crate) mod shake128 {
 
 /// A portable implementation of [`shake128::Xof`] and [`shake256::Xof`].
 pub(crate) mod portable {
-    use libcrux_iot_sha3::incremental::{self, KeccakState, Xof};
+    use libcrux_iot_sha3::incremental::{self, UnbufferedXofState, Xof};
     use libcrux_secrets::{Classify as _, U8};
 
     use super::{shake128, shake256};
@@ -108,10 +108,10 @@ pub(crate) mod portable {
     /// We're using a portable implementation so this is actually sequential.
     #[cfg_attr(hax, hax_lib::opaque)]
     pub(crate) struct Shake128X4 {
-        state0: KeccakState,
-        state1: KeccakState,
-        state2: KeccakState,
-        state3: KeccakState,
+        state0: UnbufferedXofState,
+        state1: UnbufferedXofState,
+        state2: UnbufferedXofState,
+        state3: UnbufferedXofState,
     }
 
     #[inline(always)]
@@ -232,7 +232,7 @@ pub(crate) mod portable {
     /// Portable SHAKE 128 state
     #[cfg_attr(hax, hax_lib::opaque)]
     pub(crate) struct Shake128 {
-        state: KeccakState,
+        state: UnbufferedXofState,
     }
 
     #[inline(always)]
@@ -250,7 +250,7 @@ pub(crate) mod portable {
     /// Portable SHAKE 256 state
     #[cfg_attr(hax, hax_lib::opaque)]
     pub(crate) struct Shake256 {
-        state: KeccakState,
+        state: UnbufferedXofState,
     }
 
     #[inline(always)]
@@ -306,10 +306,10 @@ pub(crate) mod portable {
     /// We're using a portable implementation so this is actually sequential.
     #[cfg_attr(hax, hax_lib::opaque)]
     pub(crate) struct Shake256X4 {
-        state0: libcrux_iot_sha3::incremental::KeccakState,
-        state1: libcrux_iot_sha3::incremental::KeccakState,
-        state2: libcrux_iot_sha3::incremental::KeccakState,
-        state3: libcrux_iot_sha3::incremental::KeccakState,
+        state0: incremental::UnbufferedXofState,
+        state1: incremental::UnbufferedXofState,
+        state2: incremental::UnbufferedXofState,
+        state3: incremental::UnbufferedXofState,
     }
 
     #[inline(always)]

--- a/libcrux-iot/ml-dsa/src/hash_functions.rs
+++ b/libcrux-iot/ml-dsa/src/hash_functions.rs
@@ -98,12 +98,10 @@ pub(crate) mod shake128 {
 
 /// A portable implementation of [`shake128::Xof`] and [`shake256::Xof`].
 pub(crate) mod portable {
-    use super::{shake128, shake256};
-    use libcrux_iot_sha3::portable::{
-        incremental::{self, Xof},
-        KeccakState,
-    };
+    use libcrux_iot_sha3::incremental::{self, KeccakState, Xof};
     use libcrux_secrets::{Classify as _, U8};
+
+    use super::{shake128, shake256};
 
     /// Portable SHAKE 128 x4 state.
     ///
@@ -239,7 +237,7 @@ pub(crate) mod portable {
 
     #[inline(always)]
     fn shake128(input: &[U8], out: &mut [U8]) {
-        libcrux_iot_sha3::portable::shake128(out, input);
+        libcrux_iot_sha3::shake128_ema(out, input);
     }
 
     impl shake128::Xof for Shake128 {
@@ -257,7 +255,7 @@ pub(crate) mod portable {
 
     #[inline(always)]
     fn shake256<const OUTPUT_LENGTH: usize>(input: &[U8], out: &mut [U8; OUTPUT_LENGTH]) {
-        libcrux_iot_sha3::portable::shake256(out, input);
+        libcrux_iot_sha3::shake256_ema(out, input);
     }
 
     #[inline(always)]
@@ -308,10 +306,10 @@ pub(crate) mod portable {
     /// We're using a portable implementation so this is actually sequential.
     #[cfg_attr(hax, hax_lib::opaque)]
     pub(crate) struct Shake256X4 {
-        state0: libcrux_iot_sha3::portable::KeccakState,
-        state1: libcrux_iot_sha3::portable::KeccakState,
-        state2: libcrux_iot_sha3::portable::KeccakState,
-        state3: libcrux_iot_sha3::portable::KeccakState,
+        state0: libcrux_iot_sha3::incremental::KeccakState,
+        state1: libcrux_iot_sha3::incremental::KeccakState,
+        state2: libcrux_iot_sha3::incremental::KeccakState,
+        state3: libcrux_iot_sha3::incremental::KeccakState,
     }
 
     #[inline(always)]

--- a/libcrux-iot/ml-kem/Cargo.toml
+++ b/libcrux-iot/ml-kem/Cargo.toml
@@ -28,6 +28,7 @@ bench = false # so libtest doesn't eat the arguments to criterion
 rand = { version = "0.9", optional = true }
 libcrux-iot-sha3 = { path = "../sha3" , features = [
     "full-unroll",
+    "unbuffered-xof"
 ] }
 hax-lib.workspace = true
 libcrux-secrets.workspace = true

--- a/libcrux-iot/ml-kem/src/hash_functions.rs
+++ b/libcrux-iot/ml-kem/src/hash_functions.rs
@@ -72,7 +72,7 @@ pub(crate) trait Hash {
 pub(crate) mod portable {
     use libcrux_iot_sha3::{
         self,
-        incremental::{self, KeccakState},
+        incremental::{self, UnbufferedXofState},
         sha256_ema, sha512_ema, shake256_ema,
     };
     use libcrux_secrets::Classify as _;
@@ -87,7 +87,7 @@ pub(crate) mod portable {
     /// All other functions don't actually use any members.
     #[cfg_attr(hax, hax_lib::opaque)]
     pub(crate) struct PortableHash {
-        shake128_state: [KeccakState; 4],
+        shake128_state: [UnbufferedXofState; 4],
     }
 
     #[hax_lib::requires(output.len() == 64)]

--- a/libcrux-iot/ml-kem/src/hash_functions.rs
+++ b/libcrux-iot/ml-kem/src/hash_functions.rs
@@ -70,11 +70,16 @@ pub(crate) trait Hash {
 
 /// A portable implementation of [`Hash`]
 pub(crate) mod portable {
-    use super::*;
-    use libcrux_iot_sha3::portable::{self, incremental, KeccakState};
+    use libcrux_iot_sha3::{
+        self,
+        incremental::{self, KeccakState},
+        sha256_ema, sha512_ema, shake256_ema,
+    };
     use libcrux_secrets::Classify as _;
     #[cfg(not(hax))]
     use libcrux_secrets::ClassifyRefMut as _;
+
+    use super::*;
 
     /// The state.
     ///
@@ -90,7 +95,7 @@ pub(crate) mod portable {
     #[hax_lib::opaque]
     #[inline(always)]
     fn G(input: &[U8], output: &mut [U8]) {
-        portable::sha512(output, input);
+        sha512_ema(output, input);
     }
 
     #[hax_lib::requires(output.len() == 32)]
@@ -98,7 +103,7 @@ pub(crate) mod portable {
     #[hax_lib::opaque]
     #[inline(always)]
     fn H(input: &[U8], output: &mut [U8]) {
-        portable::sha256(output, input);
+        sha256_ema(output, input);
     }
 
     #[hax_lib::requires(LEN <= u32::MAX as usize && out.len() == LEN)]
@@ -108,7 +113,7 @@ pub(crate) mod portable {
     fn PRF<const LEN: usize>(input: &[U8], out: &mut [U8]) {
         #[cfg(not(eurydice))]
         debug_assert!(out.len() == LEN);
-        portable::shake256(out, input);
+        shake256_ema(out, input);
     }
 
     #[hax_lib::requires(
@@ -122,7 +127,7 @@ pub(crate) mod portable {
     fn PRFxN(input: &[[U8; 33]], outputs: &mut [U8], out_len: usize) {
         for i in 0..input.len() {
             hax_lib::loop_invariant!(|_: usize| outputs.len() == input.len() * out_len);
-            portable::shake256(
+            shake256_ema(
                 &mut outputs[i * out_len..(i + 1) * out_len],
                 input[i].as_slice(),
             );

--- a/libcrux-iot/sha3/Cargo.toml
+++ b/libcrux-iot/sha3/Cargo.toml
@@ -25,6 +25,12 @@ hax-lib.workspace = true
 
 [features]
 full-unroll = []
+
+# Expose unbuffered XOF functionality for cases where the exact
+# absorbtion and squeeze lengths are known, e.g. ML-KEM or ML-DSA.
+unbuffered-xof = []
+
+# Turn on secret-independence checking via `libcrux-secrets`
 check-secret-independence = ["libcrux-secrets/check-secret-independence"]
 
 [dev-dependencies]

--- a/libcrux-iot/sha3/Cargo.toml
+++ b/libcrux-iot/sha3/Cargo.toml
@@ -27,7 +27,7 @@ hax-lib.workspace = true
 full-unroll = []
 
 # Expose unbuffered XOF functionality for cases where the exact
-# absorbtion and squeeze lengths are known, e.g. ML-KEM or ML-DSA.
+# absorption and squeeze lengths are known, e.g. ML-KEM or ML-DSA.
 unbuffered-xof = []
 
 # Turn on secret-independence checking via `libcrux-secrets`

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -2363,6 +2363,7 @@ pub(crate) fn squeeze_next_block<const RATE: usize>(s: &mut KeccakState, out: &m
 }
 
 #[inline(always)]
+#[cfg(feature = "unbuffered-xof")]
 pub(crate) fn squeeze_first_three_blocks<const RATE: usize>(s: &mut KeccakState, out: &mut [U8]) {
     squeeze_first_block::<RATE>(s, out);
     squeeze_next_block::<RATE>(s, &mut out[RATE..]);
@@ -2370,6 +2371,7 @@ pub(crate) fn squeeze_first_three_blocks<const RATE: usize>(s: &mut KeccakState,
 }
 
 #[inline(always)]
+#[cfg(feature = "unbuffered-xof")]
 pub(crate) fn squeeze_first_five_blocks<const RATE: usize>(s: &mut KeccakState, out: &mut [U8]) {
     squeeze_first_block::<RATE>(s, out);
     squeeze_next_block::<RATE>(s, &mut out[RATE..]);

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -82,17 +82,17 @@ pub fn hash<const LEN: usize>(algorithm: Algorithm, payload: &[U8]) -> [U8; LEN]
     let mut out = [0u8; LEN].classify();
     #[cfg(hax)]
     match algorithm {
-        Algorithm::Sha224 => portable::sha224(&mut out[..], payload),
-        Algorithm::Sha256 => portable::sha256(&mut out[..], payload),
-        Algorithm::Sha384 => portable::sha384(&mut out[..], payload),
-        Algorithm::Sha512 => portable::sha512(&mut out[..], payload),
+        Algorithm::Sha224 => sha224_ema(&mut out[..], payload),
+        Algorithm::Sha256 => sha256_ema(&mut out[..], payload),
+        Algorithm::Sha384 => sha384_ema(&mut out[..], payload),
+        Algorithm::Sha512 => sha512_ema(&mut out[..], payload),
     }
     #[cfg(not(hax))]
     match algorithm {
-        Algorithm::Sha224 => portable::sha224(&mut out, payload),
-        Algorithm::Sha256 => portable::sha256(&mut out, payload),
-        Algorithm::Sha384 => portable::sha384(&mut out, payload),
-        Algorithm::Sha512 => portable::sha512(&mut out, payload),
+        Algorithm::Sha224 => sha224_ema(&mut out, payload),
+        Algorithm::Sha256 => sha256_ema(&mut out, payload),
+        Algorithm::Sha384 => sha384_ema(&mut out, payload),
+        Algorithm::Sha512 => sha512_ema(&mut out, payload),
     }
     out
 }
@@ -120,7 +120,7 @@ pub fn sha224_ema(digest: &mut [U8], payload: &[U8]) {
     #[cfg(not(eurydice))]
     debug_assert!(digest.len() == 28);
 
-    portable::keccakx1::<144, 0x06u8>(payload, digest);
+    keccakx1::<144, 0x06u8>(payload, digest);
 }
 
 /// SHA3 256
@@ -140,7 +140,7 @@ pub fn sha256_ema(digest: &mut [U8], payload: &[U8]) {
     #[cfg(not(eurydice))]
     debug_assert!(digest.len() == 32);
 
-    portable::keccakx1::<136, 0x06u8>(payload, digest);
+    keccakx1::<136, 0x06u8>(payload, digest);
 }
 
 /// SHA3 384
@@ -160,7 +160,7 @@ pub fn sha384_ema(digest: &mut [U8], payload: &[U8]) {
     #[cfg(not(eurydice))]
     debug_assert!(digest.len() == 48);
 
-    portable::keccakx1::<104, 0x06u8>(payload, digest);
+    keccakx1::<104, 0x06u8>(payload, digest);
 }
 
 /// SHA3 512
@@ -180,7 +180,7 @@ pub fn sha512_ema(digest: &mut [U8], payload: &[U8]) {
     #[cfg(not(eurydice))]
     debug_assert!(digest.len() == 64);
 
-    portable::keccakx1::<72, 0x06u8>(payload, digest);
+    keccakx1::<72, 0x06u8>(payload, digest);
 }
 
 /// SHAKE 128
@@ -190,9 +190,9 @@ pub fn sha512_ema(digest: &mut [U8], payload: &[U8]) {
 pub fn shake128<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     let mut out = [0u8; BYTES].classify();
     #[cfg(hax)]
-    portable::keccakx1::<168, 0x1fu8>(data, &mut out[..]);
+    keccakx1::<168, 0x1fu8>(data, &mut out[..]);
     #[cfg(not(hax))]
-    portable::keccakx1::<168, 0x1fu8>(data, &mut out);
+    keccakx1::<168, 0x1fu8>(data, &mut out);
     out
 }
 
@@ -200,7 +200,7 @@ pub fn shake128<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
 ///
 /// Writes `out.len()` bytes.
 pub fn shake128_ema(out: &mut [U8], data: &[U8]) {
-    portable::keccakx1::<168, 0x1fu8>(data, out);
+    keccakx1::<168, 0x1fu8>(data, out);
 }
 
 /// SHAKE 256
@@ -210,9 +210,9 @@ pub fn shake128_ema(out: &mut [U8], data: &[U8]) {
 pub fn shake256<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     let mut out = [0u8; BYTES].classify();
     #[cfg(hax)]
-    portable::keccakx1::<136, 0x1fu8>(data, &mut out[..]);
+    keccakx1::<136, 0x1fu8>(data, &mut out[..]);
     #[cfg(not(hax))]
-    portable::keccakx1::<136, 0x1fu8>(data, &mut out);
+    keccakx1::<136, 0x1fu8>(data, &mut out);
     out
 }
 
@@ -220,201 +220,163 @@ pub fn shake256<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
 ///
 /// Writes `out.len()` bytes.
 pub fn shake256_ema(out: &mut [U8], data: &[U8]) {
-    portable::keccakx1::<136, 0x1fu8>(data, out);
+    keccakx1::<136, 0x1fu8>(data, out);
 }
 
-//  === The portable instantiation === //
-
-/// A portable SHA3 implementation
-pub mod portable {
+/// An incremental API for SHAKE
+pub mod incremental {
     use libcrux_secrets::U8;
 
-    use super::*;
-
-    /// The Keccak state for the incremental API.
+    /// An Keccak permutation state.
     #[derive(Clone, Copy)]
     #[cfg_attr(not(eurydice), derive(Debug))]
     pub struct KeccakState {
-        state: state::KeccakState,
+        pub(crate) state: crate::state::KeccakState,
     }
 
-    pub(crate) fn keccakx1<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut [U8]) {
-        keccak::keccak::<RATE, DELIM>(data, out)
+    use crate::keccak::{
+        absorb_final, squeeze_first_block, squeeze_first_five_blocks, squeeze_first_three_blocks,
+        squeeze_next_block, KeccakXofState,
+    };
+    mod private {
+        pub trait Sealed {}
+
+        impl Sealed for super::Shake128Xof {}
+        impl Sealed for super::Shake256Xof {}
     }
 
-    /// A portable SHA3 224 implementation.
-    pub fn sha224(digest: &mut [U8], data: &[U8]) {
-        keccakx1::<144, 0x06u8>(data, digest);
+    /// SHAKE128 Xof state
+    pub struct Shake128Xof {
+        state: KeccakXofState<168>,
     }
 
-    /// A portable SHA3 256 implementation.
-    pub fn sha256(digest: &mut [U8], data: &[U8]) {
-        keccakx1::<136, 0x06u8>(data, digest);
+    /// SHAKE256 Xof state
+    pub struct Shake256Xof {
+        state: KeccakXofState<136>,
     }
 
-    /// A portable SHA3 384 implementation.
-    pub fn sha384(digest: &mut [U8], data: &[U8]) {
-        keccakx1::<104, 0x06u8>(data, digest);
+    /// An XOF
+    pub trait Xof<const RATE: usize>: private::Sealed {
+        /// Create new absorb state
+        fn new() -> Self;
+
+        /// Absorb input
+        fn absorb(&mut self, input: &[U8]);
+
+        /// Absorb final input (may be empty)
+        fn absorb_final(&mut self, input: &[U8]);
+
+        /// Squeeze output bytes
+        fn squeeze(&mut self, out: &mut [U8]);
     }
 
-    /// A portable SHA3 512 implementation.
-    pub fn sha512(digest: &mut [U8], data: &[U8]) {
-        keccakx1::<72, 0x06u8>(data, digest);
+    impl Xof<168> for Shake128Xof {
+        fn new() -> Self {
+            Self {
+                state: KeccakXofState::<168>::new(),
+            }
+        }
+
+        fn absorb(&mut self, input: &[U8]) {
+            self.state.absorb(input);
+        }
+
+        fn absorb_final(&mut self, input: &[U8]) {
+            self.state.absorb_final::<0x1fu8>(input);
+        }
+
+        /// Shake128 squeeze
+        fn squeeze(&mut self, out: &mut [U8]) {
+            self.state.squeeze(out);
+        }
     }
 
-    /// A portable SHAKE128 implementation.
-    pub fn shake128(digest: &mut [U8], data: &[U8]) {
-        keccakx1::<168, 0x1fu8>(data, digest);
+    /// Shake256 XOF in absorb state
+    impl Xof<136> for Shake256Xof {
+        /// Shake256 new state
+        fn new() -> Self {
+            Self {
+                state: KeccakXofState::<136>::new(),
+            }
+        }
+
+        /// Shake256 absorb
+        fn absorb(&mut self, input: &[U8]) {
+            self.state.absorb(input);
+        }
+
+        /// Shake256 absorb final
+        fn absorb_final(&mut self, input: &[U8]) {
+            self.state.absorb_final::<0x1fu8>(input);
+        }
+
+        /// Shake256 squeeze
+        fn squeeze(&mut self, out: &mut [U8]) {
+            self.state.squeeze(out);
+        }
     }
 
-    /// A portable SHAKE256 implementation.
-    pub fn shake256(digest: &mut [U8], data: &[U8]) {
-        keccakx1::<136, 0x1fu8>(data, digest);
+    /// Create a new SHAKE-128 state object.
+    #[inline(always)]
+    pub fn shake128_init() -> KeccakState {
+        KeccakState {
+            state: crate::state::KeccakState::new(),
+        }
     }
 
-    /// An incremental API for SHAKE
-    pub mod incremental {
-        use keccak::{
-            absorb_final, squeeze_first_block, squeeze_first_five_blocks,
-            squeeze_first_three_blocks, squeeze_next_block, KeccakXofState,
-        };
-        use libcrux_secrets::U8;
-        mod private {
-            pub trait Sealed {}
+    /// Absorb
+    pub fn shake128_absorb_final(s: &mut KeccakState, data0: &[U8]) {
+        absorb_final::<168, 0x1fu8>(&mut s.state, data0, 0, data0.len());
+    }
 
-            impl Sealed for super::Shake128Xof {}
-            impl Sealed for super::Shake256Xof {}
+    /// Perform four rounds of the keccak permutation functions
+    pub fn keccakf1660_4rounds(s: &mut KeccakState) {
+        crate::keccak::keccakf1600_4rounds::<0>(&mut s.state);
+    }
+
+    /// Squeeze three blocks
+    pub fn shake128_squeeze_first_three_blocks(s: &mut KeccakState, out0: &mut [U8]) {
+        squeeze_first_three_blocks::<168>(&mut s.state, out0)
+    }
+
+    /// Squeeze five blocks
+    pub fn shake128_squeeze_first_five_blocks(s: &mut KeccakState, out0: &mut [U8]) {
+        squeeze_first_five_blocks::<168>(&mut s.state, out0)
+    }
+
+    /// Squeeze another block
+    pub fn shake128_squeeze_next_block(s: &mut KeccakState, out0: &mut [U8]) {
+        squeeze_next_block::<168>(&mut s.state, out0)
+    }
+
+    /// Create a new SHAKE-256 state object.
+    #[inline(always)]
+    pub fn shake256_init() -> KeccakState {
+        KeccakState {
+            state: crate::state::KeccakState::new(),
         }
-        use super::*;
+    }
 
-        /// SHAKE128 Xof state
-        pub struct Shake128Xof {
-            state: KeccakXofState<168>,
-        }
+    /// Absorb some data for SHAKE-256 for the last time
+    pub fn shake256_absorb_final(s: &mut KeccakState, data: &[U8]) {
+        absorb_final::<136, 0x1fu8>(&mut s.state, data, 0, data.len());
+    }
 
-        /// SHAKE256 Xof state
-        pub struct Shake256Xof {
-            state: KeccakXofState<136>,
-        }
+    /// Squeeze the first SHAKE-256 block
+    pub fn shake256_squeeze_first_block(s: &mut KeccakState, out: &mut [U8]) {
+        squeeze_first_block::<136>(&s.state, out)
+    }
 
-        /// An XOF
-        pub trait Xof<const RATE: usize>: private::Sealed {
-            /// Create new absorb state
-            fn new() -> Self;
-
-            /// Absorb input
-            fn absorb(&mut self, input: &[U8]);
-
-            /// Absorb final input (may be empty)
-            fn absorb_final(&mut self, input: &[U8]);
-
-            /// Squeeze output bytes
-            fn squeeze(&mut self, out: &mut [U8]);
-        }
-
-        impl Xof<168> for Shake128Xof {
-            fn new() -> Self {
-                Self {
-                    state: KeccakXofState::<168>::new(),
-                }
-            }
-
-            fn absorb(&mut self, input: &[U8]) {
-                self.state.absorb(input);
-            }
-
-            fn absorb_final(&mut self, input: &[U8]) {
-                self.state.absorb_final::<0x1fu8>(input);
-            }
-
-            /// Shake128 squeeze
-            fn squeeze(&mut self, out: &mut [U8]) {
-                self.state.squeeze(out);
-            }
-        }
-
-        /// Shake256 XOF in absorb state
-        impl Xof<136> for Shake256Xof {
-            /// Shake256 new state
-            fn new() -> Self {
-                Self {
-                    state: KeccakXofState::<136>::new(),
-                }
-            }
-
-            /// Shake256 absorb
-            fn absorb(&mut self, input: &[U8]) {
-                self.state.absorb(input);
-            }
-
-            /// Shake256 absorb final
-            fn absorb_final(&mut self, input: &[U8]) {
-                self.state.absorb_final::<0x1fu8>(input);
-            }
-
-            /// Shake256 squeeze
-            fn squeeze(&mut self, out: &mut [U8]) {
-                self.state.squeeze(out);
-            }
-        }
-
-        /// Create a new SHAKE-128 state object.
-        #[inline(always)]
-        pub fn shake128_init() -> KeccakState {
-            KeccakState {
-                state: state::KeccakState::new(),
-            }
-        }
-
-        /// Absorb
-        pub fn shake128_absorb_final(s: &mut KeccakState, data0: &[U8]) {
-            absorb_final::<168, 0x1fu8>(&mut s.state, data0, 0, data0.len());
-        }
-
-        /// Perform four rounds of the keccak permutation functions
-        pub fn keccakf1660_4rounds(s: &mut KeccakState) {
-            keccak::keccakf1600_4rounds::<0>(&mut s.state);
-        }
-
-        /// Squeeze three blocks
-        pub fn shake128_squeeze_first_three_blocks(s: &mut KeccakState, out0: &mut [U8]) {
-            squeeze_first_three_blocks::<168>(&mut s.state, out0)
-        }
-
-        /// Squeeze five blocks
-        pub fn shake128_squeeze_first_five_blocks(s: &mut KeccakState, out0: &mut [U8]) {
-            squeeze_first_five_blocks::<168>(&mut s.state, out0)
-        }
-
-        /// Squeeze another block
-        pub fn shake128_squeeze_next_block(s: &mut KeccakState, out0: &mut [U8]) {
-            squeeze_next_block::<168>(&mut s.state, out0)
-        }
-
-        /// Create a new SHAKE-256 state object.
-        #[inline(always)]
-        pub fn shake256_init() -> KeccakState {
-            KeccakState {
-                state: state::KeccakState::new(),
-            }
-        }
-
-        /// Absorb some data for SHAKE-256 for the last time
-        pub fn shake256_absorb_final(s: &mut KeccakState, data: &[U8]) {
-            absorb_final::<136, 0x1fu8>(&mut s.state, data, 0, data.len());
-        }
-
-        /// Squeeze the first SHAKE-256 block
-        pub fn shake256_squeeze_first_block(s: &mut KeccakState, out: &mut [U8]) {
-            squeeze_first_block::<136>(&s.state, out)
-        }
-
-        /// Squeeze the next SHAKE-256 block
-        pub fn shake256_squeeze_next_block(s: &mut KeccakState, out: &mut [U8]) {
-            squeeze_next_block::<136>(&mut s.state, out)
-        }
+    /// Squeeze the next SHAKE-256 block
+    pub fn shake256_squeeze_next_block(s: &mut KeccakState, out: &mut [U8]) {
+        squeeze_next_block::<136>(&mut s.state, out)
     }
 }
+
+pub(crate) fn keccakx1<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut [U8]) {
+    keccak::keccak::<RATE, DELIM>(data, out)
+}
+//  === The portable instantiation === //
 
 #[cfg(feature = "check-secret-independence")]
 trait FromLeBytes<const N: usize>: Sized {

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -28,10 +28,9 @@
 //! ### `unbuffered-xof`
 //!
 //! This exposes an additional, unbuffered interface to the SHAKE
-//! APIs. This is useful for reducing memory usage in applications where
-//! inputs are always fully absorbed immediately and only outputs of
-//! lengths that are multiples of `RATE` are squeezed, e.g. in ML-KEM or
-//! ML-DSA.
+//! APIs. This is useful for reducing memory usage in ML-KEM and ML-DSA
+//! applications where inputs are always fully absorbed immediately and
+//! only outputs of lengths that are multiples of `RATE` are squeezed.
 //!
 //! ### `check-secret-independence`
 //!
@@ -165,7 +164,7 @@ pub fn sha224(payload: &[U8]) -> [U8; SHA3_224_DIGEST_SIZE] {
 
 /// Writes SHA3-224 digest of input payload to externally allocated buffer.
 ///
-/// Preconditions
+/// Preconditions:
 /// - `payload` is at most `u32::MAX` bytes long
 /// - `digest` is exactly [`SHA3_224_DIGEST_SIZE`] bytes long
 pub fn sha224_ema(digest: &mut [U8], payload: &[U8]) {
@@ -179,7 +178,7 @@ pub fn sha224_ema(digest: &mut [U8], payload: &[U8]) {
 
 /// Returns SHA3-256 digest of input payload.
 ///
-/// Preconditions
+/// Preconditions:
 /// - `payload` is at most `u32::MAX` bytes long
 pub fn sha256(data: &[U8]) -> [U8; SHA3_256_DIGEST_SIZE] {
     let mut out = [0u8; 32].classify();
@@ -192,7 +191,7 @@ pub fn sha256(data: &[U8]) -> [U8; SHA3_256_DIGEST_SIZE] {
 
 /// Writes SHA3-256 digest of input payload to externally allocated buffer.
 ///
-/// Preconditions
+/// Preconditions:
 /// - `payload` is at most `u32::MAX` bytes long
 /// - `digest` is exactly [`SHA3_256_DIGEST_SIZE`] bytes long
 pub fn sha256_ema(digest: &mut [U8], payload: &[U8]) {
@@ -206,7 +205,7 @@ pub fn sha256_ema(digest: &mut [U8], payload: &[U8]) {
 
 /// Returns SHA3-384 digest of input payload.
 ///
-/// Preconditions
+/// Preconditions:
 /// - `payload` is at most `u32::MAX` bytes long
 pub fn sha384(data: &[U8]) -> [U8; SHA3_384_DIGEST_SIZE] {
     let mut out = [0u8; 48].classify();
@@ -281,7 +280,7 @@ pub fn shake128_ema(out: &mut [U8], data: &[U8]) {
     keccakx1::<168, 0x1fu8>(data, out);
 }
 
-/// Returns SHA3-256 digest of input payload.
+/// Returns SHAKE256 digest of input payload.
 ///
 /// Preconditions:
 /// - `BYTES` is at most `u32::MAX as usize`
@@ -294,7 +293,7 @@ pub fn shake256<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     out
 }
 
-/// Writes SHA3-256 digest of input payload to externally allocated buffer.
+/// Writes SHAKE256 digest of input payload to externally allocated buffer.
 ///
 /// Writes `out.len()` bytes.
 ///
@@ -313,7 +312,7 @@ pub mod incremental {
     #[cfg_attr(not(eurydice), derive(Debug))]
     #[cfg(feature = "unbuffered-xof")]
     pub struct UnbufferedXofState {
-        pub(crate) state: crate::state::KeccakState,
+        state: crate::state::KeccakState,
     }
 
     use crate::keccak::KeccakXofState;

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -119,8 +119,8 @@ pub const fn digest_size(mode: Algorithm) -> usize {
 /// Hashes using a particular [`Algorithm`] of the SHA3 family.
 ///
 /// # Examples
-///
-/// ```rust
+#[cfg_attr(not(feature = "check-secret-independence"), doc = r#"```rust"#)]
+#[cfg_attr(feature = "check-secret-independence", doc = r#"```rust,ignore"#)]
 /// use libcrux_iot_sha3::{digest_size, hash, Algorithm};
 ///
 /// let payload = b"Kecak is a Balinese dance.";

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -329,11 +329,6 @@ pub mod incremental {
         absorb_final::<168, 0x1fu8>(&mut s.state, data0, 0, data0.len());
     }
 
-    /// Perform four rounds of the keccak permutation functions
-    pub fn keccakf1660_4rounds(s: &mut KeccakState) {
-        crate::keccak::keccakf1600_4rounds::<0>(&mut s.state);
-    }
-
     /// Squeeze three blocks
     pub fn shake128_squeeze_first_three_blocks(s: &mut KeccakState, out0: &mut [U8]) {
         squeeze_first_three_blocks::<168>(&mut s.state, out0)

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -1,6 +1,48 @@
 //! # SHA3
 //!
-//! A SHA3 implementation with optional simd optimisations.
+//! This crate implements the SHA3 family of hash functions as well as
+//! the SHAKE-128 and SHAKE-256 extendable output functions (XOFs).
+//!
+//! The crate provides "one-shot" functions for computing digests, which
+//! either return freshly allocated buffers or write to externally
+//! provided digest buffers (`*_ema` variants, short for External Memory
+//! Allocation).
+//!
+//! In addition, an incremental, input-buffering interface (i.e. `init`,
+//! `absorb`, `absorb_final` and `squeeze` functions) is provided for the
+//! SHAKE functions.
+//!
+//! ## Cargo Features
+//!
+//! The crate provides cargo features for different, application-specific
+//! uses.
+//!
+//! ### `full-unroll`
+//!
+//! This feature fully unrolls some parts of the computation of the Keccak
+//! permutation, whereas without this feature these computations are broken
+//! into smaller pieces. Our measurements suggest that full unrolling is
+//! beneficial for reducing cycles spent on the Keccak permutation, but
+//! comes at the cost of increased stack usage.
+//!
+//! ### `unbuffered-xof`
+//!
+//! This exposes an additional, unbuffered interface to the SHAKE
+//! APIs. This is useful for reducing memory usage in applications where
+//! inputs are always fully absorbed immediately and only outputs of
+//! lengths that are multiples of `RATE` are squeezed, e.g. in ML-KEM or
+//! ML-DSA.
+//!
+//! ### `check-secret-independence`
+//!
+//! This feature enables compile-time checking of secret-independence of
+//! arithmetic operations using the `libcrux-secrets` crate.
+//!
+//! *Note*: `libcrux-secrets` provides Rust source level assurance of
+//! secret-independence on common architectures, but does not give hard
+//! guarantees. In particular there are platforms where `libcrux-secrets`
+//! assumptions about the safety of operations like multiplication do not
+//! apply, such as e.g. ARM Cortex-M3.
 
 // Below, some arrays are explicitly converted into slices by writing `out[..]`
 // instead of `out` as a workaround for https://github.com/cryspen/hax/issues/1983
@@ -15,16 +57,16 @@ mod keccak;
 mod lane;
 mod state;
 
-/// Size in bytes of a SHA3 244 digest.
+/// Size in bytes of a SHA3 244 digest
 pub const SHA3_224_DIGEST_SIZE: usize = 28;
-/// Size in bytes of a SHA3 256 digest.
+/// Size in bytes of a SHA3 256 digest
 pub const SHA3_256_DIGEST_SIZE: usize = 32;
-/// Size in bytes of a SHA3 2384 digest.
+/// Size in bytes of a SHA3 384 digest
 pub const SHA3_384_DIGEST_SIZE: usize = 48;
-/// Size in bytes of a SHA3 512 digest.
+/// Size in bytes of a SHA3 512 digest
 pub const SHA3_512_DIGEST_SIZE: usize = 64;
 
-/// The Digest Algorithm.
+/// The Digest Algorithm
 #[cfg_attr(not(eurydice), derive(Copy, Clone, Debug, PartialEq))]
 #[repr(u32)]
 pub enum Algorithm {
@@ -64,7 +106,7 @@ impl From<Algorithm> for u32 {
     }
 }
 
-/// Returns the output size of a digest.
+/// Returns the size of a digest in bytes for a given [`Algorithm`].
 pub const fn digest_size(mode: Algorithm) -> usize {
     match mode {
         Algorithm::Sha224 => SHA3_224_DIGEST_SIZE,
@@ -74,7 +116,16 @@ pub const fn digest_size(mode: Algorithm) -> usize {
     }
 }
 
-/// SHA3
+/// Hashes using a particular [`Algorithm`] of the SHA3 family.
+///
+/// # Examples
+///
+/// ```rust
+/// use libcrux_iot_sha3::{digest_size, hash, Algorithm};
+///
+/// let payload = b"Kecak is a Balinese dance.";
+/// let digest: [u8; digest_size(Algorithm::Sha256)] = hash(Algorithm::Sha256, payload);
+/// ```
 pub fn hash<const LEN: usize>(algorithm: Algorithm, payload: &[U8]) -> [U8; LEN] {
     #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
@@ -97,33 +148,39 @@ pub fn hash<const LEN: usize>(algorithm: Algorithm, payload: &[U8]) -> [U8; LEN]
     out
 }
 
-/// SHA3
 pub use hash as sha3;
 
-/// SHA3 224
-pub fn sha224(data: &[U8]) -> [U8; SHA3_224_DIGEST_SIZE] {
+/// Returns SHA3-224 digest of input payload.
+///
+/// Preconditions:
+/// - `payload` is at most `u32::MAX` bytes long
+pub fn sha224(payload: &[U8]) -> [U8; SHA3_224_DIGEST_SIZE] {
     let mut out = [0u8; 28].classify();
     #[cfg(hax)]
-    sha224_ema(&mut out[..], data);
+    sha224_ema(&mut out[..], payload);
     #[cfg(not(hax))]
-    sha224_ema(&mut out, data);
+    sha224_ema(&mut out, payload);
     out
 }
 
-/// SHA3 224
+/// Writes SHA3-224 digest of input payload to externally allocated buffer.
 ///
-/// Preconditions:
-/// - `digest.len() == 28`
+/// Preconditions
+/// - `payload` is at most `u32::MAX` bytes long
+/// - `digest` is exactly [`SHA3_224_DIGEST_SIZE`] bytes long
 pub fn sha224_ema(digest: &mut [U8], payload: &[U8]) {
     #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
     #[cfg(not(eurydice))]
-    debug_assert!(digest.len() == 28);
+    debug_assert!(digest.len() == SHA3_224_DIGEST_SIZE);
 
     keccakx1::<144, 0x06u8>(payload, digest);
 }
 
-/// SHA3 256
+/// Returns SHA3-256 digest of input payload.
+///
+/// Preconditions
+/// - `payload` is at most `u32::MAX` bytes long
 pub fn sha256(data: &[U8]) -> [U8; SHA3_256_DIGEST_SIZE] {
     let mut out = [0u8; 32].classify();
     #[cfg(hax)]
@@ -133,17 +190,24 @@ pub fn sha256(data: &[U8]) -> [U8; SHA3_256_DIGEST_SIZE] {
     out
 }
 
-/// SHA3 256
+/// Writes SHA3-256 digest of input payload to externally allocated buffer.
+///
+/// Preconditions
+/// - `payload` is at most `u32::MAX` bytes long
+/// - `digest` is exactly [`SHA3_256_DIGEST_SIZE`] bytes long
 pub fn sha256_ema(digest: &mut [U8], payload: &[U8]) {
     #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
     #[cfg(not(eurydice))]
-    debug_assert!(digest.len() == 32);
+    debug_assert!(digest.len() == SHA3_256_DIGEST_SIZE);
 
     keccakx1::<136, 0x06u8>(payload, digest);
 }
 
-/// SHA3 384
+/// Returns SHA3-384 digest of input payload.
+///
+/// Preconditions
+/// - `payload` is at most `u32::MAX` bytes long
 pub fn sha384(data: &[U8]) -> [U8; SHA3_384_DIGEST_SIZE] {
     let mut out = [0u8; 48].classify();
     #[cfg(hax)]
@@ -153,17 +217,24 @@ pub fn sha384(data: &[U8]) -> [U8; SHA3_384_DIGEST_SIZE] {
     out
 }
 
-/// SHA3 384
+/// Writes SHA3-384 digest of input payload to externally allocated buffer.
+///
+/// Preconditions:
+/// - `payload` is at most `u32::MAX` bytes long
+/// - `digest` is exactly [`SHA3_384_DIGEST_SIZE`] bytes long
 pub fn sha384_ema(digest: &mut [U8], payload: &[U8]) {
     #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
     #[cfg(not(eurydice))]
-    debug_assert!(digest.len() == 48);
+    debug_assert!(digest.len() == SHA3_384_DIGEST_SIZE);
 
     keccakx1::<104, 0x06u8>(payload, digest);
 }
 
-/// SHA3 512
+/// Returns SHA3-512 digest of input payload.
+///
+/// Preconditions:
+/// - `payload` is at most `u32::MAX` bytes long
 pub fn sha512(data: &[U8]) -> [U8; SHA3_512_DIGEST_SIZE] {
     let mut out = [0u8; 64].classify();
     #[cfg(hax)]
@@ -173,20 +244,24 @@ pub fn sha512(data: &[U8]) -> [U8; SHA3_512_DIGEST_SIZE] {
     out
 }
 
-/// SHA3 512
+/// Writes SHA3-512 digest of input payload to externally allocated buffer.
+///
+/// Preconditions:
+/// - `payload` is at most `u32::MAX` bytes long
+/// - `digest` is exactly [`SHA3_512_DIGEST_SIZE`] bytes long
 pub fn sha512_ema(digest: &mut [U8], payload: &[U8]) {
     #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
     #[cfg(not(eurydice))]
-    debug_assert!(digest.len() == 64);
+    debug_assert!(digest.len() == SHA3_512_DIGEST_SIZE);
 
     keccakx1::<72, 0x06u8>(payload, digest);
 }
 
-/// SHAKE 128
+/// Returns SHAKE-128 digest of input payload.
 ///
-/// Note that the output length `BYTES` must fit into 32 bit. If it is longer,
-/// the output will only return `u32::MAX` bytes.
+/// Preconditions:
+/// - `BYTES` is at most `u32::MAX as usize`
 pub fn shake128<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     let mut out = [0u8; BYTES].classify();
     #[cfg(hax)]
@@ -196,17 +271,20 @@ pub fn shake128<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     out
 }
 
-/// SHAKE 128
+/// Writes SHAKE-128 digest of input payload to externally allocated buffer.
 ///
-/// Writes `out.len()` bytes.
+/// Writes `out.len()` bytes
+///
+/// Preconditions:
+/// - `out` is at most `u32::MAX` bytes long
 pub fn shake128_ema(out: &mut [U8], data: &[U8]) {
     keccakx1::<168, 0x1fu8>(data, out);
 }
 
-/// SHAKE 256
+/// Returns SHA3-256 digest of input payload.
 ///
-/// Note that the output length `BYTES` must fit into 32 bit. If it is longer,
-/// the output will only return `u32::MAX` bytes.
+/// Preconditions:
+/// - `BYTES` is at most `u32::MAX as usize`
 pub fn shake256<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     let mut out = [0u8; BYTES].classify();
     #[cfg(hax)]
@@ -216,27 +294,33 @@ pub fn shake256<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     out
 }
 
-/// SHAKE 256
+/// Writes SHA3-256 digest of input payload to externally allocated buffer.
 ///
 /// Writes `out.len()` bytes.
+///
+/// Preconditions:
+/// - `out` is at most `u32::MAX` bytes long
 pub fn shake256_ema(out: &mut [U8], data: &[U8]) {
     keccakx1::<136, 0x1fu8>(data, out);
 }
 
-/// An incremental API for SHAKE
+/// Incremental API for SHAKE XOFs
 pub mod incremental {
     use libcrux_secrets::U8;
 
-    /// An Keccak permutation state.
+    /// An unbuffered XOF state.
     #[derive(Clone, Copy)]
     #[cfg_attr(not(eurydice), derive(Debug))]
-    pub struct KeccakState {
+    #[cfg(feature = "unbuffered-xof")]
+    pub struct UnbufferedXofState {
         pub(crate) state: crate::state::KeccakState,
     }
 
+    use crate::keccak::KeccakXofState;
+    #[cfg(feature = "unbuffered-xof")]
     use crate::keccak::{
         absorb_final, squeeze_first_block, squeeze_first_five_blocks, squeeze_first_three_blocks,
-        squeeze_next_block, KeccakXofState,
+        squeeze_next_block,
     };
     mod private {
         pub trait Sealed {}
@@ -245,28 +329,56 @@ pub mod incremental {
         impl Sealed for super::Shake256Xof {}
     }
 
-    /// SHAKE128 Xof state
+    /// Input-buffering SHAKE128 state
     pub struct Shake128Xof {
         state: KeccakXofState<168>,
     }
 
-    /// SHAKE256 Xof state
+    /// Input-buffering SHAKE256 state
     pub struct Shake256Xof {
         state: KeccakXofState<136>,
     }
 
-    /// An XOF
+    /// Interface for an input-buffering Extendable Output Function
+    /// (XOF)
     pub trait Xof<const RATE: usize>: private::Sealed {
-        /// Create new absorb state
+        /// Create new buffered XOF state.
+        ///
+        /// The internal buffer is initialized as empty.
         fn new() -> Self;
 
-        /// Absorb input
+        /// Absorb bytes from `input` into the buffered XOF state.
+        ///
+        /// The bytes from `input` are appended to the contents of the
+        /// internal buffer and the internal XOF state is then updated
+        /// with `RATE` bytes from this combined input at a time. If
+        /// the length of the combined input is not a multiple of
+        /// `RATE`, the remainder of length `< RATE` bytes is stored
+        /// in the internal buffer.
         fn absorb(&mut self, input: &[U8]);
 
-        /// Absorb final input (may be empty)
+        /// Absorb bytes from `input` into the buffered XOF state and
+        /// finalize for squeezing.
+        ///
+        /// The bytes from `input` are appended to the contents of the
+        /// internal buffer and the internal XOF state is then updated
+        /// with `RATE` bytes from this combined input at a time. If
+        /// the length of the combined input is not a multiple of
+        /// `RATE`, the remainder of length `< RATE` bytes is appended
+        /// with the appropriate delimiter and padded into a
+        /// `RATE`-size block before updating the internal XOF state
+        /// with this final input block.
         fn absorb_final(&mut self, input: &[U8]);
 
-        /// Squeeze output bytes
+        /// Squeeze bytes from a finalized XOF state into `out`.
+        ///
+        /// *Caution*: Output bytes are not buffered, meaning if a
+        /// first call to `squeeze` provides a number of output bytes
+        /// that is not evenly divided by `RATE`, a subsequent call to
+        /// `squeeze` will return bytes starting from the next block
+        /// of outputs generated by the internal permutation, **not**
+        /// from the remainder of bytes that were not part of the
+        /// output of the previous call.
         fn squeeze(&mut self, out: &mut [U8]);
     }
 
@@ -285,27 +397,22 @@ pub mod incremental {
             self.state.absorb_final::<0x1fu8>(input);
         }
 
-        /// Shake128 squeeze
         fn squeeze(&mut self, out: &mut [U8]) {
             self.state.squeeze(out);
         }
     }
 
-    /// Shake256 XOF in absorb state
     impl Xof<136> for Shake256Xof {
-        /// Shake256 new state
         fn new() -> Self {
             Self {
                 state: KeccakXofState::<136>::new(),
             }
         }
 
-        /// Shake256 absorb
         fn absorb(&mut self, input: &[U8]) {
             self.state.absorb(input);
         }
 
-        /// Shake256 absorb final
         fn absorb_final(&mut self, input: &[U8]) {
             self.state.absorb_final::<0x1fu8>(input);
         }
@@ -318,52 +425,61 @@ pub mod incremental {
 
     /// Create a new SHAKE-128 state object.
     #[inline(always)]
-    pub fn shake128_init() -> KeccakState {
-        KeccakState {
+    #[cfg(feature = "unbuffered-xof")]
+    pub fn shake128_init() -> UnbufferedXofState {
+        UnbufferedXofState {
             state: crate::state::KeccakState::new(),
         }
     }
 
     /// Absorb
-    pub fn shake128_absorb_final(s: &mut KeccakState, data0: &[U8]) {
+    #[cfg(feature = "unbuffered-xof")]
+    pub fn shake128_absorb_final(s: &mut UnbufferedXofState, data0: &[U8]) {
         absorb_final::<168, 0x1fu8>(&mut s.state, data0, 0, data0.len());
     }
 
     /// Squeeze three blocks
-    pub fn shake128_squeeze_first_three_blocks(s: &mut KeccakState, out0: &mut [U8]) {
+    #[cfg(feature = "unbuffered-xof")]
+    pub fn shake128_squeeze_first_three_blocks(s: &mut UnbufferedXofState, out0: &mut [U8]) {
         squeeze_first_three_blocks::<168>(&mut s.state, out0)
     }
 
     /// Squeeze five blocks
-    pub fn shake128_squeeze_first_five_blocks(s: &mut KeccakState, out0: &mut [U8]) {
+    #[cfg(feature = "unbuffered-xof")]
+    pub fn shake128_squeeze_first_five_blocks(s: &mut UnbufferedXofState, out0: &mut [U8]) {
         squeeze_first_five_blocks::<168>(&mut s.state, out0)
     }
 
     /// Squeeze another block
-    pub fn shake128_squeeze_next_block(s: &mut KeccakState, out0: &mut [U8]) {
+    #[cfg(feature = "unbuffered-xof")]
+    pub fn shake128_squeeze_next_block(s: &mut UnbufferedXofState, out0: &mut [U8]) {
         squeeze_next_block::<168>(&mut s.state, out0)
     }
 
     /// Create a new SHAKE-256 state object.
     #[inline(always)]
-    pub fn shake256_init() -> KeccakState {
-        KeccakState {
+    #[cfg(feature = "unbuffered-xof")]
+    pub fn shake256_init() -> UnbufferedXofState {
+        UnbufferedXofState {
             state: crate::state::KeccakState::new(),
         }
     }
 
     /// Absorb some data for SHAKE-256 for the last time
-    pub fn shake256_absorb_final(s: &mut KeccakState, data: &[U8]) {
+    #[cfg(feature = "unbuffered-xof")]
+    pub fn shake256_absorb_final(s: &mut UnbufferedXofState, data: &[U8]) {
         absorb_final::<136, 0x1fu8>(&mut s.state, data, 0, data.len());
     }
 
     /// Squeeze the first SHAKE-256 block
-    pub fn shake256_squeeze_first_block(s: &mut KeccakState, out: &mut [U8]) {
+    #[cfg(feature = "unbuffered-xof")]
+    pub fn shake256_squeeze_first_block(s: &mut UnbufferedXofState, out: &mut [U8]) {
         squeeze_first_block::<136>(&s.state, out)
     }
 
     /// Squeeze the next SHAKE-256 block
-    pub fn shake256_squeeze_next_block(s: &mut KeccakState, out: &mut [U8]) {
+    #[cfg(feature = "unbuffered-xof")]
+    pub fn shake256_squeeze_next_block(s: &mut UnbufferedXofState, out: &mut [U8]) {
         squeeze_next_block::<136>(&mut s.state, out)
     }
 }
@@ -371,7 +487,6 @@ pub mod incremental {
 pub(crate) fn keccakx1<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut [U8]) {
     keccak::keccak::<RATE, DELIM>(data, out)
 }
-//  === The portable instantiation === //
 
 #[cfg(feature = "check-secret-independence")]
 trait FromLeBytes<const N: usize>: Sized {


### PR DESCRIPTION
This PR simplifies the module structure of SHA3 and provides more documentation for the default public API.

I want to add more documentation for the specialized unbuffered XOFs ML-KEM and ML-DSA as well. For now, I've sequestered them behind an `unbuffered-xof` feature, since they are not for general use.

Writing the documentation I also noticed that the general-purpose `squeeze` does not look like you can call it several times, without observing that you only squeeze multiples of `RATE` bytes for the all but the last call. Something we might want to fix, as well.