### PR TITLE
[ML-DSA] iNTT input reduction

### DIFF
--- a/libcrux-iot/ml-dsa/src/matrix.rs
+++ b/libcrux-iot/ml-dsa/src/matrix.rs
@@ -4,7 +4,7 @@ use crate::{
     arithmetic::shift_left_then_reduce,
     constants::BITS_IN_LOWER_PART_OF_T,
     hash_functions::shake128,
-    ntt::{invert_ntt_montgomery, ntt, ntt_multiply_montgomery},
+    ntt::{invert_ntt_montgomery, ntt, ntt_multiply_montgomery, reduce},
     polynomial::PolynomialRingElement,
     sample::sample_ring_element,
     simd::traits::Operations,
@@ -28,6 +28,11 @@ pub(crate) fn compute_as1_plus_s2<SIMDUnit: Operations>(
     }
 
     for i in 0..result.len() {
+        // We do a Barrett reduction here, since the absolute value of
+        // `columns_in_a` additions might be as large as `columns_in_a
+        // * FIELD_MODULUS`, and `invert_ntt_montgomery` expects
+        // coefficients of size at most `FIELD_MODULUS`.
+        reduce(&mut result[i]);
         invert_ntt_montgomery::<SIMDUnit>(&mut result[i]);
         PolynomialRingElement::add(&mut result[i], &s1_s2[columns_in_a + i]);
     }
@@ -48,6 +53,11 @@ pub(crate) fn compute_matrix_x_mask<SIMDUnit: Operations>(
             ntt_multiply_montgomery(&mut product, &matrix[i * columns_in_a + j]);
             PolynomialRingElement::<SIMDUnit>::add(&mut result[i], &product);
         }
+        // We do a Barrett reduction here, since the absolute value of
+        // `columns_in_a` additions might be as large as `columns_in_a
+        // * FIELD_MODULUS`, and `invert_ntt_montgomery` expects
+        // coefficients of size at most `FIELD_MODULUS`.
+        reduce(&mut result[i]);
         invert_ntt_montgomery(&mut result[i]);
     }
 }
@@ -120,6 +130,11 @@ pub(crate) fn compute_w_approx<SIMDUnit: Operations>(
         ntt_multiply_montgomery(&mut t1[i], verifier_challenge_as_ntt);
         PolynomialRingElement::<SIMDUnit>::subtract(&mut inner_result, &t1[i]);
         t1[i] = inner_result;
+        // We do a Barrett reduction here, since the absolute value of
+        // `columns_in_a` additions might be as large as `columns_in_a
+        // * FIELD_MODULUS`, and `invert_ntt_montgomery` expects
+        // coefficients of size at most `FIELD_MODULUS`.
+        reduce(&mut t1[i]);
         invert_ntt_montgomery(&mut t1[i]);
     }
 }
@@ -185,6 +200,12 @@ pub(crate) fn compute_w_approx_i<SIMDUnit: Operations>(
     ntt(poly_slot_a);
     ntt_multiply_montgomery(poly_slot_a, verifier_challenge_as_ntt);
     PolynomialRingElement::<SIMDUnit>::subtract(poly_slot_c, poly_slot_a);
+
+    // We do a Barrett reduction here, since the absolute value of
+    // `columns_in_a` additions might be as large as `columns_in_a
+    // * FIELD_MODULUS`, and `invert_ntt_montgomery` expects
+    // coefficients of size at most `FIELD_MODULUS`.
+    reduce(poly_slot_c);
     invert_ntt_montgomery(poly_slot_c);
 
     Ok(())

--- a/libcrux-iot/ml-dsa/src/ntt.rs
+++ b/libcrux-iot/ml-dsa/src/ntt.rs
@@ -24,12 +24,17 @@ pub(crate) fn ntt_multiply_montgomery<SIMDUnit: Operations>(
     ()
 }
 
+#[inline(always)]
+// Barrett reduce all coefficients.
+pub(crate) fn reduce<SIMDUnit: Operations>(re: &mut PolynomialRingElement<SIMDUnit>) {
+    SIMDUnit::reduce(&mut re.simd_units);
+}
+
 #[cfg(test)]
 mod tests {
     use libcrux_secrets::ClassifyRef as _;
 
     use super::*;
-
     use crate::{polynomial::PolynomialRingElement, simd::traits::Operations};
 
     fn test_ntt_generic<SIMDUnit: Operations>() {

--- a/libcrux-iot/ml-dsa/src/simd/portable.rs
+++ b/libcrux-iot/ml-dsa/src/simd/portable.rs
@@ -126,4 +126,10 @@ impl Operations for Coefficients {
     fn invert_ntt_montgomery(simd_units: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
         invntt::invert_ntt_montgomery(simd_units)
     }
+
+    fn reduce(simd_units: &mut [Self; SIMD_UNITS_IN_RING_ELEMENT]) {
+        for i in 0..simd_units.len() {
+            Self::shift_left_then_reduce::<0>(&mut simd_units[i]);
+        }
+    }
 }

--- a/libcrux-iot/ml-dsa/src/simd/portable/invntt.rs
+++ b/libcrux-iot/ml-dsa/src/simd/portable/invntt.rs
@@ -1,7 +1,9 @@
 use libcrux_secrets::Classify as _;
 
-use super::arithmetic::{self, montgomery_multiply_fe_by_fer};
-use super::vector_type::Coefficients;
+use super::{
+    arithmetic::{self, montgomery_multiply_fe_by_fer},
+    vector_type::Coefficients,
+};
 use crate::simd::traits::{COEFFICIENTS_IN_SIMD_UNIT, SIMD_UNITS_IN_RING_ELEMENT};
 
 #[inline(always)]
@@ -306,4 +308,101 @@ pub(crate) fn invert_ntt_montgomery(re: &mut [Coefficients; SIMD_UNITS_IN_RING_E
 
     // [hax] https://github.com/hacspec/hax/issues/720
     ()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        polynomial::PolynomialRingElement,
+        simd::traits::{Operations, FIELD_MODULUS, SIMD_UNITS_IN_RING_ELEMENT},
+    };
+
+    fn poly_reduce_from_value<SIMDUnit: Operations>(
+        value: i32,
+        reduce: bool,
+    ) -> PolynomialRingElement<SIMDUnit> {
+        let mut re = PolynomialRingElement::<SIMDUnit>::zero();
+
+        PolynomialRingElement::<SIMDUnit>::from_i32_array(
+            &[value.classify(); SIMD_UNITS_IN_RING_ELEMENT * COEFFICIENTS_IN_SIMD_UNIT],
+            &mut re,
+        );
+
+        if reduce {
+            SIMDUnit::reduce(&mut re.simd_units);
+        }
+
+        let _ = core::hint::black_box(SIMDUnit::invert_ntt_montgomery(&mut re.simd_units));
+
+        re
+    }
+
+    #[test]
+    fn inv_ntt_unreduced_max() {
+        let value = FIELD_MODULUS + (FIELD_MODULUS / 1024) + 6;
+        let _re_portable =
+            poly_reduce_from_value::<crate::simd::portable::PortableSIMDUnit>(value, true);
+    }
+
+    #[test]
+    fn inv_ntt_reduced() {
+        let value = FIELD_MODULUS + (FIELD_MODULUS / 1024) + 7;
+        let _re_portable =
+            poly_reduce_from_value::<crate::simd::portable::PortableSIMDUnit>(value, true);
+    }
+
+    #[test]
+    #[should_panic]
+    fn inv_ntt_reduced_panic() {
+        let value = FIELD_MODULUS + (FIELD_MODULUS / 1024) + 7;
+        // iNTT without reduction: In debug mode this will panic.
+        let re1 = poly_reduce_from_value::<crate::simd::portable::PortableSIMDUnit>(value, false);
+
+        let re2 = poly_reduce_from_value::<crate::simd::portable::PortableSIMDUnit>(value, true);
+
+        // In release mode, one of the checks below will panic, since
+        // the intermediate values silently overflowed, producing an
+        // incorrect result.
+        assert_eq!(re1.to_i32_array(), re2.to_i32_array());
+    }
+
+    #[test]
+    fn inv_ntt_reduced_large() {
+        let value = FIELD_MODULUS * 8;
+        let _re_portable =
+            poly_reduce_from_value::<crate::simd::portable::PortableSIMDUnit>(value, true);
+    }
+
+    #[test]
+    #[should_panic]
+    fn inv_ntt_reduced_large_panic() {
+        let value = FIELD_MODULUS * 8;
+
+        // iNTT without reduction: In debug mode this will panic.
+        let re1 = poly_reduce_from_value::<crate::simd::portable::PortableSIMDUnit>(value, false);
+
+        let re2 = poly_reduce_from_value::<crate::simd::portable::PortableSIMDUnit>(value, true);
+
+        // In release mode, one of the checks below will panic, since
+        // the intermediate values silently overflowed, producing an
+        // incorrect result.
+        assert_eq!(re1.to_i32_array(), re2.to_i32_array());
+    }
+
+    #[test]
+    #[should_panic]
+    fn inv_ntt_unreduced_panic() {
+        let value = FIELD_MODULUS + (FIELD_MODULUS / 1024) + 7;
+
+        // iNTT without reduction: In debug mode this will panic.
+        let re1 = poly_reduce_from_value::<crate::simd::portable::PortableSIMDUnit>(value, false);
+
+        let re2 = poly_reduce_from_value::<crate::simd::portable::PortableSIMDUnit>(value, true);
+
+        // In release mode, one of the checks below will panic, since
+        // the intermediate values silently overflowed, producing an
+        // incorrect result.
+        assert_eq!(re1.to_i32_array(), re2.to_i32_array());
+    }
 }

--- a/libcrux-iot/ml-dsa/src/simd/traits.rs
+++ b/libcrux-iot/ml-dsa/src/simd/traits.rs
@@ -79,4 +79,7 @@ pub(crate) trait Operations: Copy + Clone {
 
     // invert NTT and convert to standard domain
     fn invert_ntt_montgomery(simd_units: &mut [Self; SIMD_UNITS_IN_RING_ELEMENT]);
+
+    // Barrett reduce all coefficients
+    fn reduce(simd_units: &mut [Self; SIMD_UNITS_IN_RING_ELEMENT]);
 }


### PR DESCRIPTION
This is a port of the iNTT input reductions we introduced in mainline ML-DSA in https://github.com/cryspen/libcrux/pull/1006.