### PR TITLE
Update benchmarks data

### DIFF
--- a/benchmarks.md
+++ b/benchmarks.md
@@ -1,114 +1,136 @@
 # Benchmark Results
 
-All numbers reported here refer to cycle counts.
+Results captured on the reference board.
 
-| Device                          | Clock speed                   |
-|---------------------------------|-------------------------------|
-| [ESP32-S3] [^1] [^2]            | 240 MHz                       |
-| [STM32-L4R5xx] (our Nucleo-144) | 4 MHz (default, up to 120MHz) |
-| [ESP32-C6] [^3]                 | 160 MHz                       |
-| [nRF52840-DK]                   | 64 MHz                        |
-| [nRF5340-DK]                    | 128 MHz                       |
-| [nRF52-DK]                      |                               |
-| - nRF52832                      | 64 MHz                        |
-| - nRF52810                      | 64 MHz                        |
+## Available Devices
 
-## ML-KEM
-
-### ML-KEM 512
-
-| Device                          | KeyGen[Debug] | KeyGen[Release] | Encaps[Debug] | Encaps[Release] | Decaps[Debug] | Decaps[Release] |
-|---------------------------------|---------------|-----------------|---------------|-----------------|---------------|-----------------|
-| Raspberry Pi 3                  |               |                 |               |                 |               |                 |
-| Raspberry Pi 4                  |               |                 |               |                 |               |                 |
-| [ESP32-S3] [^1] [^2]            |               |                 |               |                 |               |                 |
-| [STM32-L4R5xx] (our Nucleo-144) | 4445020       | 771501          | 5044052       | 839800          | 6134089       | 839800          |
-| [ESP32-C6] [^3]                 |               |                 |               |                 |               |                 |
-| [nRF52840-DK]                   | 5968523       | 764636          | 6806307       | 839812          | 8316331       | 1011669         |
-| [nRF5340-DK]                    |               |                 |               |                 |               |                 |
-| [nRF52-DK]                      |               |                 |               |                 |               |                 |
-| - nRF52832                      | 5789064       | 762595          | 6579357       | 838838          | 7998480       | 1010106         |
-| - nRF52810                      | ❌ [^5]       | ❌ [^4]         | ❌ [^5]       | ❌ [^4]         | ❌ [^5]       | ❌ [^4]         |
+| Device                                          | Clock speed                   |
+|-------------------------------------------------|-------------------------------|
+| [STM32-L4R5xx] (our Nucleo-144 reference board) | 4 MHz (default, up to 120MHz) |
+| [ESP32-S3] [^1] [^2]                            | 240 MHz                       |
+| [ESP32-C6] [^3]                                 | 160 MHz                       |
+| [nRF52840-DK]                                   | 64 MHz                        |
+| [nRF5340-DK]                                    | 128 MHz                       |
+| [nRF52-DK]                                      |                               |
+| - nRF52832                                      | 64 MHz                        |
+| - nRF52810                                      | 64 MHz                        |
 
 
-### ML-KEM 768
-
-| Device                          | KeyGen[Debug] | KeyGen[Release] | Encaps[Debug] | Encaps[Release] | Decaps[Debug] | Decaps[Release] |
-|---------------------------------|---------------|-----------------|---------------|-----------------|---------------|-----------------|
-| Raspberry Pi 3                  |               |                 |               |                 |               |                 |
-| Raspberry Pi 4                  |               |                 |               |                 |               |                 |
-| [ESP32-S3] [^1] [^2]            |               |                 |               |                 |               |                 |
-| [STM32-L4R5xx] (our Nucleo-144) | 7085443       | 1273471         | 7996675       | 1395000         | 9421249       | 1591459         |
-| [ESP32-C6] [^3]                 |               |                 |               |                 |               |                 |
-| [nRF52840-DK]                   | 9315152       | 1257679         | 10418524      | 1381088         | 12319554      | 1607698         |
-| [nRF5340-DK]                    |               |                 |               |                 |               |                 |
-| [nRF52-DK]                      |               |                 |               |                 |               |                 |
-| - nRF52832                      | 9434994       | 1276466         | 10691113      | 1401091         | 12626256      | 1630202         |
-| - nRF52810                      | ❌ [^5]       | ❌ [^4]         | ❌ [^5]       | ❌ [^4]         | ❌ [^5]       | ❌ [^4]         |
-
+## Cycle Measurements
 
 ### ML-KEM 1024
 
-| Device                          | KeyGen[Debug] | KeyGen[Release] | Encaps[Debug] | Encaps[Release] | Decaps[Debug] | Decaps[Release] |
-|---------------------------------|---------------|-----------------|---------------|-----------------|---------------|-----------------|
-| Raspberry Pi 3                  |               |                 |               |                 |               |                 |
-| Raspberry Pi 4                  |               |                 |               |                 |               |                 |
-| [ESP32-S3] [^1] [^2]            |               |                 |               |                 |               |                 |
-| [STM32-L4R5xx] (our Nucleo-144) | 10981246      | 1991691         | 11988292      | 2129442         | 13756274      | 2371826         |
-| [ESP32-C6] [^3]                 |               |                 |               |                 |               |                 |
-| [nRF52840-DK]                   | 14_910_284    | 1_959_916       | 16_318_665    | 2_103_371       | 18_830_628    | 2_391_463       |
-| [nRF5340-DK]                    |               |                 |               |                 |               |                 |
-| [nRF52-DK]                      |               |                 |               |                 |               |                 |
-| - nRF52832                      | 14886756      | 1951395         | 16021505      | 2094650         | 18385162      | 2381655         |
-| - nRF52810                      | ❌ [^5]       | ❌ [^4]         | ❌ [^5]       | ❌ [^4]         | ❌ [^5]       | ❌ [^4]         |
+Run `DEFMT_LOG=infor cargo rrb mlkem` in `libcrux-nucleo-l4r5zi` to reproduce:
 
-
-## ML-DSA
-### ML-DSA 44
-
-| Device                          | KeyGen[Debug] | KeyGen[Release] | Sign[Debug] | Sign[Release] | Verify[Debug] | Verify[Release] |
-|---------------------------------|---------------|-----------------|-------------|---------------|---------------|-----------------|
-| Raspberry Pi 3                  |               |                 |             |               |               |                 |
-| Raspberry Pi 4                  |               |                 |             |               |               |                 |
-| [ESP32-S3] [^1] [^2]            |               |                 |             |               |               |                 |
-| [STM32-L4R5xx] (our Nucleo-144) | 19524681      | 3476142         | 28743483    | 4825636       | 20929483      | 3695919         |
-| [ESP32-C6] [^3]                 |               |                 |             |               |               |                 |
-| [nRF52840-DK]                   | 25565997      | 3565042         | 37809350    | 4987219       | 27441288      | 3788007         |
-| [nRF5340-DK]                    |               |                 |             |               |               |                 |
-| [nRF52-DK]                      |               |                 |             |               |               |                 |
-| - nRF52832                      | ❌ [^5]       | ❌ [^4]         | ❌ [^5]     | ❌ [^4]       | ❌ [^5]       | ❌ [^4]         |
-| - nRF52810                      |               |                 |             |               |               |                 |
-
-### ML-DSA 65
-
-| Device                          | KeyGen[Debug] | KeyGen[Release] | Sign[Debug] | Sign[Release] | Verify[Debug] | Verify[Release] |
-|---------------------------------|---------------|-----------------|-------------|---------------|---------------|-----------------|
-| Raspberry Pi 3                  |               |                 |             |               |               |                 |
-| Raspberry Pi 4                  |               |                 |             |               |               |                 |
-| [ESP32-S3] [^1] [^2]            |               |                 |             |               |               |                 |
-| [STM32-L4R5xx] (our Nucleo-144) | 36271715      | 6382246         | 47606417    | 7981373       | 37005196      | 6501876         |
-| [ESP32-C6] [^3]                 |               |                 |             |               |               |                 |
-| [nRF52840-DK]                   | 47073665      | 6638977         | 62247859    | 8364565       | 48188918      | 6767475         |
-| [nRF5340-DK]                    |               |                 |             |               |               |                 |
-| [nRF52-DK]                      |               |                 |             |               |               |                 |
-| - nRF52832                      | ❌ [^5]       | ❌ [^6]         | ❌ [^5]     | ❌ [^6]       | ❌ [^5]       | ❌ [^6]         |
-| - nRF52810                      |               |                 |             |               |               |                 |
+```
+l,0,16000000,ML-KEM Benchmark
+b,r,bench_keygen,0
+b,d,bench_keygen,0,1704770
+b,r,bench_keygen,1
+b,d,bench_keygen,1,1704773
+b,r,bench_keygen,2
+b,d,bench_keygen,2,1704774
+b,r,bench_keygen,3
+b,d,bench_keygen,3,1704773
+b,r,bench_keygen,4
+b,d,bench_keygen,4,1704772
+b,r,bench_encaps,0
+b,d,bench_encaps,0,1825446
+b,r,bench_encaps,1
+b,d,bench_encaps,1,1825442
+b,r,bench_encaps,2
+b,d,bench_encaps,2,1825440
+b,r,bench_encaps,3
+b,d,bench_encaps,3,1825442
+b,r,bench_encaps,4
+b,d,bench_encaps,4,1825447
+b,r,bench_decaps,0
+b,d,bench_decaps,0,2020988
+b,r,bench_decaps,1
+b,d,bench_decaps,1,2020988
+b,r,bench_decaps,2
+b,d,bench_decaps,2,2020990
+b,r,bench_decaps,3
+b,d,bench_decaps,3,2020985
+b,r,bench_decaps,4
+b,d,bench_decaps,4,2020989
+Firmware exited successfully
+```
 
 
 ### ML-DSA 87
 
-| Device                          | KeyGen[Debug] | KeyGen[Release] | Sign[Debug] | Sign[Release] | Verify[Debug] | Verify[Release] |
-|---------------------------------|---------------|-----------------|-------------|---------------|---------------|-----------------|
-| Raspberry Pi 3                  |               |                 |             |               |               |                 |
-| Raspberry Pi 4                  |               |                 |             |               |               |                 |
-| [ESP32-S3] [^1] [^2]            |               |                 |             |               |               |                 |
-| [STM32-L4R5xx] (our Nucleo-144) | 60053867      | 10633875        | 137335754   | 21909905      | 61676143      | 10794553        |
-| [ESP32-C6] [^3]                 |               |                 |             |               |               |                 |
-| [nRF52840-DK]                   | ❌ [^5]       | ❌ [^4]         | ❌ [^5]     | ❌ [^4]       | ❌ [^5]       | ❌ [^4]         |
-| [nRF5340-DK]                    |               |                 |             |               |               |                 |
-| [nRF52-DK]                      |               |                 |             |               |               |                 |
-| - nRF52832                      | ❌ [^5]       | ❌ [^6]         | ❌ [^5]     | ❌ [^6]       | ❌ [^5]       | ❌ [^6]         |
-| - nRF52810                      |               |                 |             |               |               |                 |
+Run `DEFMT_LOG=infor cargo rrb mldsa` in `libcrux-nucleo-l4r5zi` to reproduce:
+
+```
+l,0,16000000,ML-DSA Benchmark
+b,r,bench_keygen,0
+b,d,bench_keygen,0,7786306
+b,r,bench_keygen,1
+b,d,bench_keygen,1,7786306
+b,r,bench_keygen,2
+b,d,bench_keygen,2,7786307
+b,r,bench_keygen,3
+b,d,bench_keygen,3,7786307
+b,r,bench_keygen,4
+b,d,bench_keygen,4,7786305
+b,r,bench_sign,0
+b,d,bench_sign,0,13558239
+b,r,bench_sign,1
+b,d,bench_sign,1,13558234
+b,r,bench_sign,2
+b,d,bench_sign,2,13558236
+b,r,bench_sign,3
+b,d,bench_sign,3,13558238
+b,r,bench_sign,4
+b,d,bench_sign,4,13558244
+b,r,bench_verify,0
+b,d,bench_verify,0,7210660
+b,r,bench_verify,1
+b,d,bench_verify,1,7210654
+b,r,bench_verify,2
+b,d,bench_verify,2,7210654
+b,r,bench_verify,3
+b,d,bench_verify,3,7210659
+b,r,bench_verify,4
+b,d,bench_verify,4,7210655
+Firmware exited successfully
+```
+
+
+## Stack usage
+
+Results in bytes on the reference board.
+Run `./measure-stacks.sh` in `libcrux-nucleo-l4r5zi` to reproduce.
+
+```
+Repository at commit: 9218c076a08d4fb9697e4e615c049a576ea78c4f
+l,0,0,ML-KEM 1024 Key Generation
+b,r,stack,0
+b,d,stack,0,34016
+Firmware exited successfully
+l,0,0,ML-KEM 1024 Encapsulation
+b,r,stack,0
+b,d,stack,0,20104
+Firmware exited successfully
+l,0,0,ML-KEM 1024 Decapsulation
+b,r,stack,0
+b,d,stack,0,23400
+Firmware exited successfully
+l,0,0,ML-DSA 87 Key Generation
+b,r,stack,0
+b,d,stack,0,109464
+Firmware exited successfully
+l,0,0,ML-DSA 87 Signing
+b,r,stack,0
+b,d,stack,0,168192
+Firmware exited successfully
+l,0,0,ML-DSA 87 Verification
+b,r,stack,0
+b,d,stack,0,9760
+Firmware exited successfully
+```
+
 
 
 [STM32-L4R5xx]: https://www.st.com/en/microcontrollers-microprocessors/stm32l4r5zi.html?rt=db&id=DB3171


### PR DESCRIPTION
This PR provides a snapshot of some benchmarks on the reference board. The setup for measuring cycles of the other variants is broken unfortunately, and we should discuss how we could fix it, but the ML-KEM 1024 and ML-DSA 87 measurements should give a good worst-case estimation for the other paramter sets as well.