### PR TITLE
[nucleo]: fix potential UB in stack measurement

### DIFF
--- a/libcrux-nucleo-l4r5zi/src/bin/mldsa_stack_keygen.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/mldsa_stack_keygen.rs
@@ -27,8 +27,8 @@ extern "C" {
 fn main() -> ! {
     let _pair = core::hint::black_box(mldsa::generate_key_pair(assets::KEYGEN_SEED));
 
-    let stack_start = core::hint::black_box(unsafe { &_stack_start as *const u32 });
-    let stack_end = core::hint::black_box(unsafe { &_stack_end as *const u32 });
+    let stack_start = core::hint::black_box(&raw const _stack_start);
+    let stack_end = core::hint::black_box(&raw const _stack_end);
 
     board::stack::measure(
         assets::STR_KEYGEN,

--- a/libcrux-nucleo-l4r5zi/src/bin/mldsa_stack_sign.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/mldsa_stack_sign.rs
@@ -32,8 +32,8 @@ fn main() -> ! {
         assets::SIGNING_SEED,
     ));
 
-    let stack_start = core::hint::black_box(unsafe { &_stack_start as *const u32 });
-    let stack_end = core::hint::black_box(unsafe { &_stack_end as *const u32 });
+    let stack_start = core::hint::black_box(&raw const _stack_start);
+    let stack_end = core::hint::black_box(&raw const _stack_end);
 
     board::stack::measure(
         assets::STR_SIGN,

--- a/libcrux-nucleo-l4r5zi/src/bin/mldsa_stack_verify.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/mldsa_stack_verify.rs
@@ -38,8 +38,8 @@ fn main() -> ! {
         defmt::trace!("NO");
     }
 
-    let stack_start = core::hint::black_box(unsafe { &_stack_start as *const u32 });
-    let stack_end = core::hint::black_box(unsafe { &_stack_end as *const u32 });
+    let stack_start = core::hint::black_box(&raw const _stack_start);
+    let stack_end = core::hint::black_box(&raw const _stack_end);
 
     core::hint::black_box(board::stack::measure(
         assets::STR_VERIFY,

--- a/libcrux-nucleo-l4r5zi/src/bin/mlkem_stack_decaps.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/mlkem_stack_decaps.rs
@@ -30,8 +30,8 @@ fn main() -> ! {
         &libcrux_iot_ml_kem::MlKemCiphertext::from(assets::CT),
     ));
 
-    let stack_start = core::hint::black_box(unsafe { &_stack_start as *const u32 });
-    let stack_end = core::hint::black_box(unsafe { &_stack_end as *const u32 });
+    let stack_start = core::hint::black_box(&raw const _stack_start);
+    let stack_end = core::hint::black_box(&raw const _stack_end);
 
     board::stack::measure(
         assets::STR_DECAPS,

--- a/libcrux-nucleo-l4r5zi/src/bin/mlkem_stack_encaps.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/mlkem_stack_encaps.rs
@@ -30,8 +30,8 @@ fn main() -> ! {
         assets::ENCAPS_SEED,
     ));
 
-    let stack_start = core::hint::black_box(unsafe { &_stack_start as *const u32 });
-    let stack_end = core::hint::black_box(unsafe { &_stack_end as *const u32 });
+    let stack_start = core::hint::black_box(&raw const _stack_start);
+    let stack_end = core::hint::black_box(&raw const _stack_end);
 
     board::stack::measure(
         assets::STR_ENCAPS,

--- a/libcrux-nucleo-l4r5zi/src/bin/mlkem_stack_keygen.rs
+++ b/libcrux-nucleo-l4r5zi/src/bin/mlkem_stack_keygen.rs
@@ -27,8 +27,8 @@ extern "C" {
 fn main() -> ! {
     let _pair = core::hint::black_box(mlkem::generate_key_pair(assets::KEYGEN_SEED));
 
-    let stack_start = core::hint::black_box(unsafe { &_stack_start as *const u32 });
-    let stack_end = core::hint::black_box(unsafe { &_stack_end as *const u32 });
+    let stack_start = core::hint::black_box(&raw const _stack_start);
+    let stack_end = core::hint::black_box(&raw const _stack_end);
 
     board::stack::measure(
         assets::STR_KEYGEN,


### PR DESCRIPTION
Use &raw const place expression instead of casting invalid reference.

See the [addr_of](https://doc.rust-lang.org/std/ptr/macro.addr_of.html) docs why the previous was UB.