### PR TITLE
[SHA3] Panic Freedom modulo Keccak in F*

### DIFF
--- a/.github/workflows/sha3-hax.yml
+++ b/.github/workflows/sha3-hax.yml
@@ -1,0 +1,107 @@
+name: SHA3 - hax
+
+permissions: {}
+
+on:
+  merge_group:
+  push:
+    branches: ["main"]
+
+  pull_request:
+    branches: ["main"]
+
+  schedule:
+    - cron: "0 0 * * *"
+
+  workflow_dispatch:
+    inputs:
+      hax_ref:
+        description: "The hax revision you want this job to use"
+        required: false
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # NOTE: This always runs, even if the `hax_ref` workflow input is provided.
+  # TODO: Move this reusable workflow to a standalone action
+  get-hax-ref:
+    uses: ./.github/workflows/get-hax-ref.yml
+
+  extract:
+    runs-on: ubuntu-latest
+    needs:
+      - get-hax-ref
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: hacspec/hax-actions@main
+        with:
+          hax_reference: ${{ github.event.inputs.hax_ref || needs.get-hax-ref.outputs.hax_ref }}
+          fstar: v2025.10.06
+
+      - name: 🏃 Extract SHA3 crate
+        working-directory: libcrux-iot/sha3
+        run: ./hax.py extract
+
+      - name: ↑ Upload F* extraction
+        uses: actions/upload-artifact@v7
+        with:
+          name: fstar-extractions
+          path: "**/proofs/fstar"
+          include-hidden-files: true
+          if-no-files-found: error
+
+  panic-freedom:
+    runs-on: ubuntu-latest
+    needs:
+      - get-hax-ref
+      - extract
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: hacspec/hax-actions@main
+        with:
+          hax_reference: ${{ github.event.inputs.hax_ref || needs.get-hax-ref.outputs.hax_ref }}
+          fstar: v2025.10.06
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: fstar-extractions
+          path: .
+
+      - name: 🏃 Panic Freedom in SHA3
+        working-directory: libcrux-iot/sha3
+        run: ./hax.py prove 
+  
+  sha3-extract-hax-status:
+    if: ${{ always() }}
+    needs: [get-hax-ref, extract]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Successful
+        if: ${{ !(contains(needs.*.result, 'failure')) }} 
+        run: exit 0 
+      - name: Failing
+        if: ${{ (contains(needs.*.result, 'failure')) }} 
+        run: exit 1 
+  
+  sha3-panic-freedom-status:
+    if: ${{ always() }}
+    needs: [get-hax-ref, panic-freedom]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Successful
+        if: ${{ !(contains(needs.*.result, 'failure')) }} 
+        run: exit 0 
+      - name: Failing
+        if: ${{ (contains(needs.*.result, 'failure')) }} 
+        run: exit 1 

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ kyber-crate/
 *.lock
 /.fstar-cache/
 /c/combined/generated/build/
-
 !flake.lock
+/libcrux-iot/sha3/proofs/fstar/extraction/.depend

--- a/c/combined/generated/code_gen.txt
+++ b/c/combined/generated/code_gen.txt
@@ -3,4 +3,4 @@ Charon: e656e17bff6ca5efac8ab6919b9b74cb9a8dd8ad
 Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
 Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
 F*: unset
-Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+Libcrux: dirty

--- a/c/combined/generated/code_gen.txt
+++ b/c/combined/generated/code_gen.txt
@@ -3,4 +3,4 @@ Charon: e656e17bff6ca5efac8ab6919b9b74cb9a8dd8ad
 Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
 Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
 F*: unset
-Libcrux: dirty
+Libcrux: 2c7414ac3af3bdb176aef9a3abc1b1e5cf4d8892

--- a/c/combined/generated/internal/libcrux_iot_sha3.h
+++ b/c/combined/generated/internal/libcrux_iot_sha3.h
@@ -120,7 +120,7 @@ libcrux_iot_sha3_keccak_fill_buffer_f0_60(
   size_t consumed = (size_t)0U;
   if (self->buf_len > (size_t)0U)
   {
-    if (self->buf_len + input_len >= (size_t)168U)
+    if (input_len >= (size_t)168U - self->buf_len)
     {
       consumed = (size_t)168U - self->buf_len;
       Eurydice_slice_copy(Eurydice_array_to_subslice_from_mut_5f0(&self->buf, self->buf_len),
@@ -368,7 +368,7 @@ libcrux_iot_sha3_state_store_18_60(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(&self,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -383,7 +383,8 @@ libcrux_iot_sha3_state_store_18_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -396,13 +397,14 @@ libcrux_iot_sha3_state_store_18_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
   if (last_block_len > (size_t)4U)
   {
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(&self,
           num_full_blocks / (size_t)5U,
           num_full_blocks % (size_t)5U));
@@ -418,7 +420,8 @@ libcrux_iot_sha3_state_store_18_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____2, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____3 =
@@ -431,7 +434,8 @@ libcrux_iot_sha3_state_store_18_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____3,
       Eurydice_array_to_subslice_shared_d41(&lvalue,
         (KRML_CLITERAL(core_ops_range_Range_87){ .start = (size_t)0U, .end = last_half_block_len })),
@@ -440,7 +444,7 @@ libcrux_iot_sha3_state_store_18_60(
   else if (last_block_len > (size_t)0U)
   {
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(&self,
           num_full_blocks / (size_t)5U,
           num_full_blocks % (size_t)5U));
@@ -455,12 +459,62 @@ libcrux_iot_sha3_state_store_18_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____4,
       Eurydice_array_to_subslice_shared_d41(&lvalue,
         (KRML_CLITERAL(core_ops_range_Range_87){ .start = (size_t)0U, .end = last_block_len })),
       uint8_t);
   }
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak._squeeze
+with const generics
+- RATE= 168
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak__squeeze_60(
+  libcrux_iot_sha3_keccak_KeccakXofState_31 *state,
+  Eurydice_mut_borrow_slice_u8 out
+)
+{
+  if (state->sponge)
+  {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+  }
+  size_t out_len = out.meta;
+  size_t blocks = out_len / (size_t)168U;
+  size_t last = out_len - out_len % (size_t)168U;
+  size_t mid;
+  if ((size_t)168U >= out_len)
+  {
+    mid = out_len;
+  }
+  else
+  {
+    mid = (size_t)168U;
+  }
+  libcrux_iot_sha3_state_store_18_60(state->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
+  size_t offset = mid;
+  for (size_t i = (size_t)1U; i < blocks; i++)
+  {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+    libcrux_iot_sha3_state_store_18_60(state->inner,
+      Eurydice_slice_subslice_mut_c8(out,
+        (KRML_CLITERAL(core_ops_range_Range_87){ .start = offset, .end = offset + (size_t)168U })));
+    offset += (size_t)168U;
+  }
+  if (last > (size_t)0U)
+  {
+    if (last < out_len)
+    {
+      libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+      libcrux_iot_sha3_state_store_18_60(state->inner,
+        Eurydice_slice_subslice_from_mut_6d(out, offset));
+    }
+  }
+  state->sponge = true;
 }
 
 /**
@@ -480,42 +534,7 @@ libcrux_iot_sha3_keccak_squeeze_f0_60(
   Eurydice_mut_borrow_slice_u8 out
 )
 {
-  if (self->sponge)
-  {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-  }
-  size_t out_len = out.meta;
-  size_t blocks = out_len / (size_t)168U;
-  size_t last = out_len - out_len % (size_t)168U;
-  size_t mid;
-  if ((size_t)168U >= out_len)
-  {
-    mid = out_len;
-  }
-  else
-  {
-    mid = (size_t)168U;
-  }
-  libcrux_iot_sha3_state_store_18_60(self->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
-  size_t offset = mid;
-  for (size_t i = (size_t)1U; i < blocks; i++)
-  {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-    libcrux_iot_sha3_state_store_18_60(self->inner,
-      Eurydice_slice_subslice_mut_c8(out,
-        (KRML_CLITERAL(core_ops_range_Range_87){ .start = offset, .end = offset + (size_t)168U })));
-    offset += (size_t)168U;
-  }
-  if (last > (size_t)0U)
-  {
-    if (last < out_len)
-    {
-      libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-      libcrux_iot_sha3_state_store_18_60(self->inner,
-        Eurydice_slice_subslice_from_mut_6d(out, offset));
-    }
-  }
-  self->sponge = true;
+  libcrux_iot_sha3_keccak__squeeze_60(self, out);
 }
 
 /**
@@ -582,9 +601,21 @@ static inline uint32_t libcrux_iot_sha3_from_c3(libcrux_iot_sha3_Algorithm v)
 }
 
 /**
-This function found in impl {core::convert::From<u32> for libcrux_iot_sha3::Algorithm}
+A monomorphic instance of core.result.Result
+with types libcrux_iot_sha3_Algorithm, ()
+
 */
-static inline libcrux_iot_sha3_Algorithm libcrux_iot_sha3_from_c2(uint32_t v)
+typedef struct core_result_Result_20_s
+{
+  core_result_Result_8e_tags tag;
+  libcrux_iot_sha3_Algorithm f0;
+}
+core_result_Result_20;
+
+/**
+This function found in impl {core::convert::TryFrom<u32, libcrux_iot_sha3::UnknownAlgorithm> for libcrux_iot_sha3::Algorithm}
+*/
+static inline core_result_Result_20 libcrux_iot_sha3_try_from_72(uint32_t v)
 {
   switch (v)
   {
@@ -594,23 +625,46 @@ static inline libcrux_iot_sha3_Algorithm libcrux_iot_sha3_from_c2(uint32_t v)
       }
     case 2U:
       {
-        return libcrux_iot_sha3_Algorithm_Sha256;
+        return
+          (
+            KRML_CLITERAL(core_result_Result_20){
+              .tag = core_result_Ok,
+              .f0 = libcrux_iot_sha3_Algorithm_Sha256
+            }
+          );
       }
     case 3U:
       {
-        return libcrux_iot_sha3_Algorithm_Sha384;
+        return
+          (
+            KRML_CLITERAL(core_result_Result_20){
+              .tag = core_result_Ok,
+              .f0 = libcrux_iot_sha3_Algorithm_Sha384
+            }
+          );
       }
     case 4U:
       {
-        return libcrux_iot_sha3_Algorithm_Sha512;
+        return
+          (
+            KRML_CLITERAL(core_result_Result_20){
+              .tag = core_result_Ok,
+              .f0 = libcrux_iot_sha3_Algorithm_Sha512
+            }
+          );
       }
     default:
       {
-        KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__, "panic!");
-        KRML_HOST_EXIT(255U);
+        return (KRML_CLITERAL(core_result_Result_20){ .tag = core_result_Err });
       }
   }
-  return libcrux_iot_sha3_Algorithm_Sha224;
+  return
+    (
+      KRML_CLITERAL(core_result_Result_20){
+        .tag = core_result_Ok,
+        .f0 = libcrux_iot_sha3_Algorithm_Sha224
+      }
+    );
 }
 
 #if defined(__cplusplus)

--- a/c/combined/generated/libcrux_iot_mldsa87_portable.h
+++ b/c/combined/generated/libcrux_iot_mldsa87_portable.h
@@ -51,7 +51,7 @@ libcrux_iot_ml_dsa_ml_dsa_87_portable_generate_key_pair(Eurydice_arr_ec randomne
  and is a byte string of length at most 255 bytes. It
  may also be empty.
 */
-static inline core_result_Result_20
+static inline core_result_Result_200
 libcrux_iot_ml_dsa_ml_dsa_87_portable_sign(
   const Eurydice_arr_e2 *signing_key,
   Eurydice_borrow_slice_u8 message,
@@ -97,7 +97,7 @@ libcrux_iot_ml_dsa_ml_dsa_87_portable_sign_mut(
  and is a byte string of length at most 255 bytes. It
  may also be empty.
 */
-static inline core_result_Result_20
+static inline core_result_Result_200
 libcrux_iot_ml_dsa_ml_dsa_87_portable_sign_pre_hashed_shake128(
   const Eurydice_arr_e2 *signing_key,
   Eurydice_borrow_slice_u8 message,

--- a/c/combined/generated/libcrux_iot_mldsa_portable.h
+++ b/c/combined/generated/libcrux_iot_mldsa_portable.h
@@ -10888,7 +10888,7 @@ A monomorphic instance of core.result.Result
 with types libcrux_iot_ml_dsa_types_MLDSASignature_06, libcrux_iot_ml_dsa_types_SigningError
 
 */
-typedef struct core_result_Result_20_s
+typedef struct core_result_Result_200_s
 {
   core_result_Result_8e_tags tag;
   union {
@@ -10897,7 +10897,7 @@ typedef struct core_result_Result_20_s
   }
   val;
 }
-core_result_Result_20;
+core_result_Result_200;
 
 /**
  Init with zero
@@ -11347,7 +11347,7 @@ with types libcrux_iot_ml_dsa_simd_portable_vector_type_Coefficients, libcrux_io
 with const generics
 
 */
-static KRML_MUSTINLINE core_result_Result_20
+static KRML_MUSTINLINE core_result_Result_200
 libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_c4(
   Eurydice_borrow_slice_u8 signing_key,
   Eurydice_borrow_slice_u8 message,
@@ -11363,12 +11363,12 @@ libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_c4(
       context,
       randomness,
       &signature);
-  core_result_Result_20 uu____1;
+  core_result_Result_200 uu____1;
   if (uu____0.tag == core_result_Ok)
   {
     uu____1 =
       (
-        KRML_CLITERAL(core_result_Result_20){
+        KRML_CLITERAL(core_result_Result_200){
           .tag = core_result_Ok,
           .val = { .case_Ok = signature }
         }
@@ -11378,7 +11378,7 @@ libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_c4(
   {
     libcrux_iot_ml_dsa_types_SigningError e = uu____0.f0;
     uu____1 =
-      (KRML_CLITERAL(core_result_Result_20){ .tag = core_result_Err, .val = { .case_Err = e } });
+      (KRML_CLITERAL(core_result_Result_200){ .tag = core_result_Err, .val = { .case_Err = e } });
   }
   return uu____1;
 }
@@ -11386,7 +11386,7 @@ libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_c4(
 /**
  Sign.
 */
-static inline core_result_Result_20
+static inline core_result_Result_200
 libcrux_iot_ml_dsa_ml_dsa_generic_instantiations_portable_ml_dsa_87_sign(
   const Eurydice_arr_e2 *signing_key,
   Eurydice_borrow_slice_u8 message,
@@ -11494,7 +11494,7 @@ with types libcrux_iot_ml_dsa_simd_portable_vector_type_Coefficients, libcrux_io
 with const generics
 
 */
-static KRML_MUSTINLINE core_result_Result_20
+static KRML_MUSTINLINE core_result_Result_200
 libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_pre_hashed_36(
   Eurydice_borrow_slice_u8 signing_key,
   Eurydice_borrow_slice_u8 message,
@@ -11512,12 +11512,12 @@ libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_pre_hashed_36(
       pre_hash_buffer,
       randomness,
       &signature);
-  core_result_Result_20 uu____1;
+  core_result_Result_200 uu____1;
   if (uu____0.tag == core_result_Ok)
   {
     uu____1 =
       (
-        KRML_CLITERAL(core_result_Result_20){
+        KRML_CLITERAL(core_result_Result_200){
           .tag = core_result_Ok,
           .val = { .case_Ok = signature }
         }
@@ -11527,7 +11527,7 @@ libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_pre_hashed_36(
   {
     libcrux_iot_ml_dsa_types_SigningError e = uu____0.f0;
     uu____1 =
-      (KRML_CLITERAL(core_result_Result_20){ .tag = core_result_Err, .val = { .case_Err = e } });
+      (KRML_CLITERAL(core_result_Result_200){ .tag = core_result_Err, .val = { .case_Err = e } });
   }
   return uu____1;
 }
@@ -11535,7 +11535,7 @@ libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_pre_hashed_36(
 /**
  Sign (pre-hashed).
 */
-static inline core_result_Result_20
+static inline core_result_Result_200
 libcrux_iot_ml_dsa_ml_dsa_generic_instantiations_portable_ml_dsa_87_sign_pre_hashed_shake128(
   const Eurydice_arr_e2 *signing_key,
   Eurydice_borrow_slice_u8 message,

--- a/c/combined/generated/libcrux_iot_mlkem768_portable.h
+++ b/c/combined/generated/libcrux_iot_mlkem768_portable.h
@@ -6275,16 +6275,18 @@ libcrux_iot_ml_kem_serialize_deserialize_ring_elements_reduced_51(
   Eurydice_dst_ref_mut_2f deserialized_pk
 )
 {
+  Eurydice_borrow_slice_u8
+  public_key0 = libcrux_secrets_int_classify_public_classify_ref_6d_90(public_key);
   for
   (size_t
     i = (size_t)0U;
-    i < public_key.meta / LIBCRUX_IOT_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT;
+    i < public_key0.meta / LIBCRUX_IOT_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT;
     i++)
   {
     size_t i0 = i;
     Eurydice_borrow_slice_u8
     ring_element =
-      Eurydice_slice_subslice_shared_c8(public_key,
+      Eurydice_slice_subslice_shared_c8(public_key0,
         (
           KRML_CLITERAL(core_ops_range_Range_87){
             .start = i0 * LIBCRUX_IOT_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
@@ -6292,7 +6294,7 @@ libcrux_iot_ml_kem_serialize_deserialize_ring_elements_reduced_51(
               LIBCRUX_IOT_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT
           }
         ));
-    libcrux_iot_ml_kem_serialize_deserialize_to_reduced_ring_element_a7(libcrux_secrets_int_classify_public_classify_ref_6d_90(ring_element),
+    libcrux_iot_ml_kem_serialize_deserialize_to_reduced_ring_element_a7(ring_element,
       &deserialized_pk.ptr[i0]);
   }
 }

--- a/c/combined/generated/libcrux_iot_sha3.h
+++ b/c/combined/generated/libcrux_iot_sha3.h
@@ -441,210 +441,337 @@ libcrux_iot_sha3_state_set_with_zeta_18(
 #define LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1 ((KRML_CLITERAL(Eurydice_arr_030){ .data = { 0U, 137U, 2147483787U, 2147516544U, 139U, 32768U, 2147516552U, 2147483778U, 11U, 10U, 32898U, 32771U, 32907U, 2147483659U, 2147483786U, 2147483777U, 2147483777U, 2147483656U, 131U, 2147516419U, 2147516552U, 2147483784U, 32768U, 2147516546U, 2147516553U, 2147516547U, 2147483649U, 2147516418U, 2147483785U, 130U, 2147483656U, 137U, 2147483656U, 0U, 131U, 2147516544U, 8U, 2147483776U, 2147516544U, 2U, 2147516555U, 8U, 2147483657U, 32779U, 2147516546U, 2147516416U, 32776U, 32897U, 2147516553U, 2147516553U, 2147516426U, 138U, 130U, 2147483650U, 32898U, 32896U, 2147483659U, 2147483651U, 10U, 32769U, 2147483779U, 32899U, 139U, 32778U, 2147483779U, 32778U, 2147483648U, 2147483786U, 2147483656U, 10U, 32904U, 8U, 2147483651U, 0U, 10U, 32779U, 2147516552U, 2147483659U, 2147483776U, 2147516554U, 32777U, 3U, 2147483651U, 137U, 2147483777U, 2147483787U, 2147516419U, 2147516427U, 32776U, 32776U, 32770U, 9U, 2147516545U, 32906U, 2147516426U, 128U, 32905U, 32906U, 2147516553U, 2147516416U, 32897U, 2147516426U, 9U, 2147516418U, 2147483658U, 2147516418U, 2147483648U, 2147483657U, 32904U, 2U, 2147516424U, 2147516552U, 2147483649U, 2147516555U, 2U, 2147516418U, 2147483779U, 32905U, 32896U, 2147483778U, 136U, 2147516554U, 32906U, 2147516547U, 2147483659U, 2147483657U, 32769U, 2147483785U, 136U, 2147516419U, 2147516417U, 3U, 2147483776U, 2147516425U, 2147483785U, 11U, 131U, 2147516425U, 2147483779U, 32768U, 2147516427U, 32770U, 3U, 2147483786U, 2147483650U, 32769U, 2147483648U, 2147483651U, 131U, 2147516554U, 32771U, 32776U, 32907U, 2147483778U, 1U, 32769U, 2147483658U, 2147516424U, 2147516427U, 32897U, 2147516547U, 2147483778U, 130U, 2147483777U, 2147483650U, 32904U, 139U, 32899U, 8U, 2147483786U, 2147483787U, 2147516554U, 32896U, 2147483784U, 32899U, 2U, 2147516545U, 32771U, 32897U, 2147516416U, 32770U, 138U, 1U, 32898U, 32906U, 2147516416U, 32907U, 2147483649U, 2147516545U, 32777U, 138U, 136U, 2147516425U, 2147483658U, 2147516555U, 139U, 32905U, 32771U, 32770U, 128U, 32778U, 2147483658U, 2147516545U, 32896U, 2147483649U, 2147516424U, 2147516546U, 2147516426U, 3U, 2147483657U, 32898U, 32777U, 128U, 32899U, 129U, 1U, 32779U, 2147516417U, 128U, 32768U, 2147516417U, 9U, 2147516555U, 129U, 130U, 2147483787U, 2147516425U, 2147483648U, 2147483776U, 2147516419U, 2147516546U, 2147516547U, 2147483784U, 32905U, 32777U, 9U, 2147516424U, 2147516417U, 138U, 11U, 137U, 2147483650U, 32779U, 2147516427U, 32907U, 2147483784U, 32778U, 2147483785U, 1U, 32904U, 129U, 136U, 2147516544U, 129U, 11U } }))
 
 static KRML_MUSTINLINE void
-libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
 {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)
     };
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
     };
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
+    };
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+    };
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
+    };
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
+    };
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____2 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)
     };
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____3 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
     };
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____4 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____5 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)
     };
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-      .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-      .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-      .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)
     };
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____8 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-      .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____9 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-      .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-      .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)
     };
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____10 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
   uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
@@ -652,25 +779,36 @@ libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(libcrux_iot_sha3_state_K
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____11 =
+  uu____1 =
     {
       .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
       .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
       .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)
     };
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax44);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+{
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(s);
 }
 
 static KRML_MUSTINLINE void
@@ -865,210 +1003,337 @@ libcrux_iot_sha3_keccak_keccakf1600_round1_theta(libcrux_iot_sha3_state_KeccakSt
 }
 
 static KRML_MUSTINLINE void
-libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
 {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)
     };
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
     };
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
+    };
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+    };
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
+    };
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
+    };
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____2 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)
     };
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____3 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
     };
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____4 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____5 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)
     };
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-      .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-      .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-      .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)
     };
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____8 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-      .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____9 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-      .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-      .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)
     };
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____10 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
   uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
@@ -1076,25 +1341,36 @@ libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(libcrux_iot_sha3_state_K
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____11 =
+  uu____1 =
     {
       .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
       .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
       .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)
     };
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax44);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+{
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(s);
 }
 
 static KRML_MUSTINLINE void
@@ -1289,210 +1565,337 @@ libcrux_iot_sha3_keccak_keccakf1600_round2_theta(libcrux_iot_sha3_state_KeccakSt
 }
 
 static KRML_MUSTINLINE void
-libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
 {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)
     };
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
     };
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
+    };
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+    };
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
+    };
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
+    };
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____2 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)
     };
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____3 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
     };
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____4 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____5 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)
     };
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-      .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-      .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-      .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)
     };
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____8 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-      .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____9 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-      .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-      .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)
     };
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____10 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
   uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
@@ -1500,25 +1903,36 @@ libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(libcrux_iot_sha3_state_K
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____11 =
+  uu____1 =
     {
       .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
       .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
       .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)
     };
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax44);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+{
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(s);
 }
 
 static KRML_MUSTINLINE void
@@ -1713,210 +2127,337 @@ libcrux_iot_sha3_keccak_keccakf1600_round3_theta(libcrux_iot_sha3_state_KeccakSt
 }
 
 static KRML_MUSTINLINE void
-libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
 {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)
     };
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
     };
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
+    };
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+    };
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
+    };
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
+    };
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____2 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)
     };
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____3 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
     };
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____4 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____5 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)
     };
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-      .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-      .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-      .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)
     };
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____8 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-      .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____9 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-      .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-      .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)
     };
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____10 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
   uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
@@ -1924,25 +2465,137 @@ libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(libcrux_iot_sha3_state_K
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____11 =
+  uu____1 =
     {
       .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
       .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
       .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)
     };
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax44);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+{
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(s);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
+    };
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
+    };
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax4);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
+    };
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
+    };
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax4);
 }
 
 /**
@@ -1955,162 +2608,111 @@ libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_56(
   libcrux_iot_sha3_state_KeccakState *s
 )
 {
-  size_t i = s->i;
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
     };
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
     };
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____2 =
-    {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)
-    };
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3
-  uu____3 =
-    {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)
-    };
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____4 =
-    {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)
-    };
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3
-  uu____5 =
-    {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)
-    };
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax4);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
     };
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
     };
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax42);
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax4);
 }
 
 /**
@@ -2123,162 +2725,111 @@ libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_56(
   libcrux_iot_sha3_state_KeccakState *s
 )
 {
-  size_t i = s->i;
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
     };
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
     };
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____2 =
-    {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)
-    };
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3
-  uu____3 =
-    {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)
-    };
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____4 =
-    {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)
-    };
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3
-  uu____5 =
-    {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)
-    };
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax4);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
     };
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
     };
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax42);
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax4);
 }
 
 /**
@@ -2291,162 +2842,111 @@ libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_56(
   libcrux_iot_sha3_state_KeccakState *s
 )
 {
-  size_t i = s->i;
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
     };
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
     };
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____2 =
-    {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)
-    };
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3
-  uu____3 =
-    {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)
-    };
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____4 =
-    {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)
-    };
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3
-  uu____5 =
-    {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)
-    };
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax4);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
     };
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
     };
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax42);
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax4);
 }
 
 /**
@@ -2459,162 +2959,10 @@ libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_56(
   libcrux_iot_sha3_state_KeccakState *s
 )
 {
-  size_t i = s->i;
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2
-  uu____0 =
-    {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)
-    };
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3
-  uu____1 =
-    {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)
-    };
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____2 =
-    {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)
-    };
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3
-  uu____3 =
-    {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)
-    };
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____4 =
-    {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)
-    };
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3
-  uu____5 =
-    {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)
-    };
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2
-  uu____6 =
-    {
-      .fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
-    };
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3
-  uu____7 =
-    {
-      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
-    };
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax42);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(s);
 }
 
 /**
@@ -2656,7 +3004,7 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_2u32_b2(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   Eurydice_borrow_slice_u8 blocks,
   size_t start
 )
@@ -2711,8 +3059,8 @@ libcrux_iot_sha3_state_load_block_2u32_b2(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    got = libcrux_iot_sha3_state_get_lane_18(state, i0 / (size_t)5U, i0 % (size_t)5U);
-    libcrux_iot_sha3_state_set_lane_18(state,
+    got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(keccak_state,
       i0 / (size_t)5U,
       i0 % (size_t)5U,
       libcrux_iot_sha3_lane_from_ints_8d((
@@ -2737,12 +3085,12 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_full_2u32_b2(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   const Eurydice_arr_5c *blocks,
   size_t start
 )
 {
-  libcrux_iot_sha3_state_load_block_2u32_b2(state,
+  libcrux_iot_sha3_state_load_block_2u32_b2(keccak_state,
     Eurydice_array_to_slice_shared_15(blocks),
     start);
 }
@@ -2858,7 +3206,7 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_2u32_60(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   Eurydice_borrow_slice_u8 blocks,
   size_t start
 )
@@ -2913,8 +3261,8 @@ libcrux_iot_sha3_state_load_block_2u32_60(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    got = libcrux_iot_sha3_state_get_lane_18(state, i0 / (size_t)5U, i0 % (size_t)5U);
-    libcrux_iot_sha3_state_set_lane_18(state,
+    got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(keccak_state,
       i0 / (size_t)5U,
       i0 % (size_t)5U,
       libcrux_iot_sha3_lane_from_ints_8d((
@@ -2973,12 +3321,12 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_full_2u32_60(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   const Eurydice_arr_5c *blocks,
   size_t start
 )
 {
-  libcrux_iot_sha3_state_load_block_2u32_60(state,
+  libcrux_iot_sha3_state_load_block_2u32_60(keccak_state,
     Eurydice_array_to_slice_shared_15(blocks),
     start);
 }
@@ -3050,7 +3398,7 @@ libcrux_iot_sha3_state_store_block_2u32_60(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(s,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -3065,7 +3413,8 @@ libcrux_iot_sha3_state_store_block_2u32_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -3078,7 +3427,8 @@ libcrux_iot_sha3_state_store_block_2u32_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
 }
@@ -3225,10 +3575,11 @@ libcrux_iot_sha3_keccak_keccak_37(
   size_t blocks = outlen / (size_t)168U;
   size_t last = outlen - outlen % (size_t)168U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++)
   {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_60(&s, data, i0 * (size_t)168U);
+    libcrux_iot_sha3_keccak_absorb_block_60(&s, data, start);
+    start += (size_t)168U;
   }
   libcrux_iot_sha3_keccak_absorb_final_37(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U)
@@ -3394,7 +3745,7 @@ libcrux_iot_sha3_state_store_block_2u32_b2(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(s,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -3409,7 +3760,8 @@ libcrux_iot_sha3_state_store_block_2u32_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -3422,7 +3774,8 @@ libcrux_iot_sha3_state_store_block_2u32_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
 }
@@ -3569,10 +3922,11 @@ libcrux_iot_sha3_keccak_keccak_22(
   size_t blocks = outlen / (size_t)136U;
   size_t last = outlen - outlen % (size_t)136U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++)
   {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, i0 * (size_t)136U);
+    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, start);
+    start += (size_t)136U;
   }
   libcrux_iot_sha3_keccak_absorb_final_22(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U)
@@ -3673,7 +4027,7 @@ libcrux_iot_sha3_keccak_fill_buffer_f0_b2(
   size_t consumed = (size_t)0U;
   if (self->buf_len > (size_t)0U)
   {
-    if (self->buf_len + input_len >= (size_t)136U)
+    if (input_len >= (size_t)136U - self->buf_len)
     {
       consumed = (size_t)136U - self->buf_len;
       Eurydice_slice_copy(Eurydice_array_to_subslice_from_mut_5f(&self->buf, self->buf_len),
@@ -3921,7 +4275,7 @@ libcrux_iot_sha3_state_store_18_b2(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(&self,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -3936,7 +4290,8 @@ libcrux_iot_sha3_state_store_18_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -3949,13 +4304,14 @@ libcrux_iot_sha3_state_store_18_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
   if (last_block_len > (size_t)4U)
   {
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(&self,
           num_full_blocks / (size_t)5U,
           num_full_blocks % (size_t)5U));
@@ -3971,7 +4327,8 @@ libcrux_iot_sha3_state_store_18_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____2, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____3 =
@@ -3984,7 +4341,8 @@ libcrux_iot_sha3_state_store_18_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____3,
       Eurydice_array_to_subslice_shared_d41(&lvalue,
         (KRML_CLITERAL(core_ops_range_Range_87){ .start = (size_t)0U, .end = last_half_block_len })),
@@ -3993,7 +4351,7 @@ libcrux_iot_sha3_state_store_18_b2(
   else if (last_block_len > (size_t)0U)
   {
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(&self,
           num_full_blocks / (size_t)5U,
           num_full_blocks % (size_t)5U));
@@ -4008,12 +4366,62 @@ libcrux_iot_sha3_state_store_18_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____4,
       Eurydice_array_to_subslice_shared_d41(&lvalue,
         (KRML_CLITERAL(core_ops_range_Range_87){ .start = (size_t)0U, .end = last_block_len })),
       uint8_t);
   }
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak._squeeze
+with const generics
+- RATE= 136
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak__squeeze_b2(
+  libcrux_iot_sha3_keccak_KeccakXofState_bd *state,
+  Eurydice_mut_borrow_slice_u8 out
+)
+{
+  if (state->sponge)
+  {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+  }
+  size_t out_len = out.meta;
+  size_t blocks = out_len / (size_t)136U;
+  size_t last = out_len - out_len % (size_t)136U;
+  size_t mid;
+  if ((size_t)136U >= out_len)
+  {
+    mid = out_len;
+  }
+  else
+  {
+    mid = (size_t)136U;
+  }
+  libcrux_iot_sha3_state_store_18_b2(state->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
+  size_t offset = mid;
+  for (size_t i = (size_t)1U; i < blocks; i++)
+  {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+    libcrux_iot_sha3_state_store_18_b2(state->inner,
+      Eurydice_slice_subslice_mut_c8(out,
+        (KRML_CLITERAL(core_ops_range_Range_87){ .start = offset, .end = offset + (size_t)136U })));
+    offset += (size_t)136U;
+  }
+  if (last > (size_t)0U)
+  {
+    if (last < out_len)
+    {
+      libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+      libcrux_iot_sha3_state_store_18_b2(state->inner,
+        Eurydice_slice_subslice_from_mut_6d(out, offset));
+    }
+  }
+  state->sponge = true;
 }
 
 /**
@@ -4033,42 +4441,7 @@ libcrux_iot_sha3_keccak_squeeze_f0_b2(
   Eurydice_mut_borrow_slice_u8 out
 )
 {
-  if (self->sponge)
-  {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-  }
-  size_t out_len = out.meta;
-  size_t blocks = out_len / (size_t)136U;
-  size_t last = out_len - out_len % (size_t)136U;
-  size_t mid;
-  if ((size_t)136U >= out_len)
-  {
-    mid = out_len;
-  }
-  else
-  {
-    mid = (size_t)136U;
-  }
-  libcrux_iot_sha3_state_store_18_b2(self->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
-  size_t offset = mid;
-  for (size_t i = (size_t)1U; i < blocks; i++)
-  {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-    libcrux_iot_sha3_state_store_18_b2(self->inner,
-      Eurydice_slice_subslice_mut_c8(out,
-        (KRML_CLITERAL(core_ops_range_Range_87){ .start = offset, .end = offset + (size_t)136U })));
-    offset += (size_t)136U;
-  }
-  if (last > (size_t)0U)
-  {
-    if (last < out_len)
-    {
-      libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-      libcrux_iot_sha3_state_store_18_b2(self->inner,
-        Eurydice_slice_subslice_from_mut_6d(out, offset));
-    }
-  }
-  self->sponge = true;
+  libcrux_iot_sha3_keccak__squeeze_b2(self, out);
 }
 
 /**
@@ -4093,7 +4466,7 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_2u32_c6(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   Eurydice_borrow_slice_u8 blocks,
   size_t start
 )
@@ -4148,8 +4521,8 @@ libcrux_iot_sha3_state_load_block_2u32_c6(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    got = libcrux_iot_sha3_state_get_lane_18(state, i0 / (size_t)5U, i0 % (size_t)5U);
-    libcrux_iot_sha3_state_set_lane_18(state,
+    got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(keccak_state,
       i0 / (size_t)5U,
       i0 % (size_t)5U,
       libcrux_iot_sha3_lane_from_ints_8d((
@@ -4208,12 +4581,12 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_full_2u32_c6(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   const Eurydice_arr_5c *blocks,
   size_t start
 )
 {
-  libcrux_iot_sha3_state_load_block_2u32_c6(state,
+  libcrux_iot_sha3_state_load_block_2u32_c6(keccak_state,
     Eurydice_array_to_slice_shared_15(blocks),
     start);
 }
@@ -4285,7 +4658,7 @@ libcrux_iot_sha3_state_store_block_2u32_c6(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(s,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -4300,7 +4673,8 @@ libcrux_iot_sha3_state_store_block_2u32_c6(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -4313,7 +4687,8 @@ libcrux_iot_sha3_state_store_block_2u32_c6(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
 }
@@ -4460,10 +4835,11 @@ libcrux_iot_sha3_keccak_keccak_dc(
   size_t blocks = outlen / (size_t)72U;
   size_t last = outlen - outlen % (size_t)72U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++)
   {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_c6(&s, data, i0 * (size_t)72U);
+    libcrux_iot_sha3_keccak_absorb_block_c6(&s, data, start);
+    start += (size_t)72U;
   }
   libcrux_iot_sha3_keccak_absorb_final_dc(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U)
@@ -4567,10 +4943,11 @@ libcrux_iot_sha3_keccak_keccak_220(
   size_t blocks = outlen / (size_t)136U;
   size_t last = outlen - outlen % (size_t)136U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++)
   {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, i0 * (size_t)136U);
+    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, start);
+    start += (size_t)136U;
   }
   libcrux_iot_sha3_keccak_absorb_final_220(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U)
@@ -4659,7 +5036,7 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_2u32_9e(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   Eurydice_borrow_slice_u8 blocks,
   size_t start
 )
@@ -4714,8 +5091,8 @@ libcrux_iot_sha3_state_load_block_2u32_9e(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    got = libcrux_iot_sha3_state_get_lane_18(state, i0 / (size_t)5U, i0 % (size_t)5U);
-    libcrux_iot_sha3_state_set_lane_18(state,
+    got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(keccak_state,
       i0 / (size_t)5U,
       i0 % (size_t)5U,
       libcrux_iot_sha3_lane_from_ints_8d((
@@ -4774,12 +5151,12 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_full_2u32_9e(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   const Eurydice_arr_5c *blocks,
   size_t start
 )
 {
-  libcrux_iot_sha3_state_load_block_2u32_9e(state,
+  libcrux_iot_sha3_state_load_block_2u32_9e(keccak_state,
     Eurydice_array_to_slice_shared_15(blocks),
     start);
 }
@@ -4851,7 +5228,7 @@ libcrux_iot_sha3_state_store_block_2u32_9e(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(s,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -4866,7 +5243,8 @@ libcrux_iot_sha3_state_store_block_2u32_9e(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -4879,7 +5257,8 @@ libcrux_iot_sha3_state_store_block_2u32_9e(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
 }
@@ -5026,10 +5405,11 @@ libcrux_iot_sha3_keccak_keccak_3a(
   size_t blocks = outlen / (size_t)144U;
   size_t last = outlen - outlen % (size_t)144U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++)
   {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_9e(&s, data, i0 * (size_t)144U);
+    libcrux_iot_sha3_keccak_absorb_block_9e(&s, data, start);
+    start += (size_t)144U;
   }
   libcrux_iot_sha3_keccak_absorb_final_3a(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U)
@@ -5088,7 +5468,7 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_2u32_53(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   Eurydice_borrow_slice_u8 blocks,
   size_t start
 )
@@ -5143,8 +5523,8 @@ libcrux_iot_sha3_state_load_block_2u32_53(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    got = libcrux_iot_sha3_state_get_lane_18(state, i0 / (size_t)5U, i0 % (size_t)5U);
-    libcrux_iot_sha3_state_set_lane_18(state,
+    got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(keccak_state,
       i0 / (size_t)5U,
       i0 % (size_t)5U,
       libcrux_iot_sha3_lane_from_ints_8d((
@@ -5203,12 +5583,12 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_full_2u32_53(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   const Eurydice_arr_5c *blocks,
   size_t start
 )
 {
-  libcrux_iot_sha3_state_load_block_2u32_53(state,
+  libcrux_iot_sha3_state_load_block_2u32_53(keccak_state,
     Eurydice_array_to_slice_shared_15(blocks),
     start);
 }
@@ -5280,7 +5660,7 @@ libcrux_iot_sha3_state_store_block_2u32_53(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(s,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -5295,7 +5675,8 @@ libcrux_iot_sha3_state_store_block_2u32_53(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -5308,7 +5689,8 @@ libcrux_iot_sha3_state_store_block_2u32_53(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
 }
@@ -5455,10 +5837,11 @@ libcrux_iot_sha3_keccak_keccak_dc0(
   size_t blocks = outlen / (size_t)104U;
   size_t last = outlen - outlen % (size_t)104U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++)
   {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_53(&s, data, i0 * (size_t)104U);
+    libcrux_iot_sha3_keccak_absorb_block_53(&s, data, start);
+    start += (size_t)104U;
   }
   libcrux_iot_sha3_keccak_absorb_final_dc0(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U)
@@ -5533,14 +5916,14 @@ static inline Eurydice_arr_a2 libcrux_iot_sha3_sha224(Eurydice_borrow_slice_u8 p
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-static inline Eurydice_arr_ec libcrux_iot_sha3_sha256(Eurydice_borrow_slice_u8 data)
+static inline Eurydice_arr_ec libcrux_iot_sha3_sha256(Eurydice_borrow_slice_u8 payload)
 {
   Eurydice_arr_ec
   out =
     libcrux_secrets_int_public_integers_classify_27_4b((
         KRML_CLITERAL(Eurydice_arr_ec){ .data = { 0U } }
       ));
-  libcrux_iot_sha3_sha256_ema(Eurydice_array_to_slice_mut_01(&out), data);
+  libcrux_iot_sha3_sha256_ema(Eurydice_array_to_slice_mut_01(&out), payload);
   return out;
 }
 
@@ -5550,14 +5933,14 @@ static inline Eurydice_arr_ec libcrux_iot_sha3_sha256(Eurydice_borrow_slice_u8 d
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-static inline Eurydice_arr_65 libcrux_iot_sha3_sha384(Eurydice_borrow_slice_u8 data)
+static inline Eurydice_arr_65 libcrux_iot_sha3_sha384(Eurydice_borrow_slice_u8 payload)
 {
   Eurydice_arr_65
   out =
     libcrux_secrets_int_public_integers_classify_27_69((
         KRML_CLITERAL(Eurydice_arr_65){ .data = { 0U } }
       ));
-  libcrux_iot_sha3_sha384_ema(Eurydice_array_to_slice_mut_9f(&out), data);
+  libcrux_iot_sha3_sha384_ema(Eurydice_array_to_slice_mut_9f(&out), payload);
   return out;
 }
 
@@ -5567,14 +5950,14 @@ static inline Eurydice_arr_65 libcrux_iot_sha3_sha384(Eurydice_borrow_slice_u8 d
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-static inline Eurydice_arr_c7 libcrux_iot_sha3_sha512(Eurydice_borrow_slice_u8 data)
+static inline Eurydice_arr_c7 libcrux_iot_sha3_sha512(Eurydice_borrow_slice_u8 payload)
 {
   Eurydice_arr_c7
   out =
     libcrux_secrets_int_public_integers_classify_27_56((
         KRML_CLITERAL(Eurydice_arr_c7){ .data = { 0U } }
       ));
-  libcrux_iot_sha3_sha512_ema(Eurydice_array_to_slice_mut_17(&out), data);
+  libcrux_iot_sha3_sha512_ema(Eurydice_array_to_slice_mut_17(&out), payload);
   return out;
 }
 

--- a/c/combined/generated/libcrux_iot_sha3.h
+++ b/c/combined/generated/libcrux_iot_sha3.h
@@ -3009,13 +3009,6 @@ libcrux_iot_sha3_state_load_block_2u32_b2(
   size_t start
 )
 {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++)
-  {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression, (size_t)25U * sizeof (Eurydice_arr_a0));
   for (size_t i = (size_t)0U; i < (size_t)136U / (size_t)8U; i++)
   {
     size_t i0 = i;
@@ -3049,15 +3042,10 @@ libcrux_iot_sha3_state_load_block_2u32_b2(
             KRML_CLITERAL(core_result_Result_c7){ .tag = core_result_Ok, .val = { .case_Ok = arr } }
           )));
     Eurydice_arr_a0
-    uu____0 =
+    lane =
       libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29((
             KRML_CLITERAL(Eurydice_arr_a0){ .data = { a, b } }
           )));
-    state_flat.data[i0] = uu____0;
-  }
-  for (size_t i = (size_t)0U; i < (size_t)136U / (size_t)8U; i++)
-  {
-    size_t i0 = i;
     Eurydice_arr_a0
     got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(keccak_state,
@@ -3067,10 +3055,10 @@ libcrux_iot_sha3_state_load_block_2u32_b2(
           KRML_CLITERAL(Eurydice_arr_a0){
             .data = {
               libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
+                libcrux_iot_sha3_lane_index_cc(&lane,
                   (size_t)0U)[0U],
               libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
+                libcrux_iot_sha3_lane_index_cc(&lane,
                   (size_t)1U)[0U]
             }
           }
@@ -3211,13 +3199,6 @@ libcrux_iot_sha3_state_load_block_2u32_60(
   size_t start
 )
 {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++)
-  {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression, (size_t)25U * sizeof (Eurydice_arr_a0));
   for (size_t i = (size_t)0U; i < (size_t)168U / (size_t)8U; i++)
   {
     size_t i0 = i;
@@ -3251,15 +3232,10 @@ libcrux_iot_sha3_state_load_block_2u32_60(
             KRML_CLITERAL(core_result_Result_c7){ .tag = core_result_Ok, .val = { .case_Ok = arr } }
           )));
     Eurydice_arr_a0
-    uu____0 =
+    lane =
       libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29((
             KRML_CLITERAL(Eurydice_arr_a0){ .data = { a, b } }
           )));
-    state_flat.data[i0] = uu____0;
-  }
-  for (size_t i = (size_t)0U; i < (size_t)168U / (size_t)8U; i++)
-  {
-    size_t i0 = i;
     Eurydice_arr_a0
     got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(keccak_state,
@@ -3269,10 +3245,10 @@ libcrux_iot_sha3_state_load_block_2u32_60(
           KRML_CLITERAL(Eurydice_arr_a0){
             .data = {
               libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
+                libcrux_iot_sha3_lane_index_cc(&lane,
                   (size_t)0U)[0U],
               libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
+                libcrux_iot_sha3_lane_index_cc(&lane,
                   (size_t)1U)[0U]
             }
           }
@@ -4471,13 +4447,6 @@ libcrux_iot_sha3_state_load_block_2u32_c6(
   size_t start
 )
 {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++)
-  {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression, (size_t)25U * sizeof (Eurydice_arr_a0));
   for (size_t i = (size_t)0U; i < (size_t)72U / (size_t)8U; i++)
   {
     size_t i0 = i;
@@ -4511,15 +4480,10 @@ libcrux_iot_sha3_state_load_block_2u32_c6(
             KRML_CLITERAL(core_result_Result_c7){ .tag = core_result_Ok, .val = { .case_Ok = arr } }
           )));
     Eurydice_arr_a0
-    uu____0 =
+    lane =
       libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29((
             KRML_CLITERAL(Eurydice_arr_a0){ .data = { a, b } }
           )));
-    state_flat.data[i0] = uu____0;
-  }
-  for (size_t i = (size_t)0U; i < (size_t)72U / (size_t)8U; i++)
-  {
-    size_t i0 = i;
     Eurydice_arr_a0
     got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(keccak_state,
@@ -4529,10 +4493,10 @@ libcrux_iot_sha3_state_load_block_2u32_c6(
           KRML_CLITERAL(Eurydice_arr_a0){
             .data = {
               libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
+                libcrux_iot_sha3_lane_index_cc(&lane,
                   (size_t)0U)[0U],
               libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
+                libcrux_iot_sha3_lane_index_cc(&lane,
                   (size_t)1U)[0U]
             }
           }
@@ -5041,13 +5005,6 @@ libcrux_iot_sha3_state_load_block_2u32_9e(
   size_t start
 )
 {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++)
-  {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression, (size_t)25U * sizeof (Eurydice_arr_a0));
   for (size_t i = (size_t)0U; i < (size_t)144U / (size_t)8U; i++)
   {
     size_t i0 = i;
@@ -5081,15 +5038,10 @@ libcrux_iot_sha3_state_load_block_2u32_9e(
             KRML_CLITERAL(core_result_Result_c7){ .tag = core_result_Ok, .val = { .case_Ok = arr } }
           )));
     Eurydice_arr_a0
-    uu____0 =
+    lane =
       libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29((
             KRML_CLITERAL(Eurydice_arr_a0){ .data = { a, b } }
           )));
-    state_flat.data[i0] = uu____0;
-  }
-  for (size_t i = (size_t)0U; i < (size_t)144U / (size_t)8U; i++)
-  {
-    size_t i0 = i;
     Eurydice_arr_a0
     got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(keccak_state,
@@ -5099,10 +5051,10 @@ libcrux_iot_sha3_state_load_block_2u32_9e(
           KRML_CLITERAL(Eurydice_arr_a0){
             .data = {
               libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
+                libcrux_iot_sha3_lane_index_cc(&lane,
                   (size_t)0U)[0U],
               libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
+                libcrux_iot_sha3_lane_index_cc(&lane,
                   (size_t)1U)[0U]
             }
           }
@@ -5473,13 +5425,6 @@ libcrux_iot_sha3_state_load_block_2u32_53(
   size_t start
 )
 {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++)
-  {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression, (size_t)25U * sizeof (Eurydice_arr_a0));
   for (size_t i = (size_t)0U; i < (size_t)104U / (size_t)8U; i++)
   {
     size_t i0 = i;
@@ -5513,15 +5458,10 @@ libcrux_iot_sha3_state_load_block_2u32_53(
             KRML_CLITERAL(core_result_Result_c7){ .tag = core_result_Ok, .val = { .case_Ok = arr } }
           )));
     Eurydice_arr_a0
-    uu____0 =
+    lane =
       libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29((
             KRML_CLITERAL(Eurydice_arr_a0){ .data = { a, b } }
           )));
-    state_flat.data[i0] = uu____0;
-  }
-  for (size_t i = (size_t)0U; i < (size_t)104U / (size_t)8U; i++)
-  {
-    size_t i0 = i;
     Eurydice_arr_a0
     got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(keccak_state,
@@ -5531,10 +5471,10 @@ libcrux_iot_sha3_state_load_block_2u32_53(
           KRML_CLITERAL(Eurydice_arr_a0){
             .data = {
               libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
+                libcrux_iot_sha3_lane_index_cc(&lane,
                   (size_t)0U)[0U],
               libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
+                libcrux_iot_sha3_lane_index_cc(&lane,
                   (size_t)1U)[0U]
             }
           }

--- a/c/sha3/extracted/code_gen.txt
+++ b/c/sha3/extracted/code_gen.txt
@@ -3,4 +3,4 @@ Charon: e656e17bff6ca5efac8ab6919b9b74cb9a8dd8ad
 Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
 Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
 F*: unset
-Libcrux: dirty
+Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d

--- a/c/sha3/extracted/code_gen.txt
+++ b/c/sha3/extracted/code_gen.txt
@@ -3,4 +3,4 @@ Charon: e656e17bff6ca5efac8ab6919b9b74cb9a8dd8ad
 Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
 Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
 F*: unset
-Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+Libcrux: dirty

--- a/c/sha3/extracted/code_gen.txt
+++ b/c/sha3/extracted/code_gen.txt
@@ -3,4 +3,4 @@ Charon: e656e17bff6ca5efac8ab6919b9b74cb9a8dd8ad
 Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
 Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
 F*: unset
-Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
+Libcrux: dirty

--- a/c/sha3/extracted/header.txt
+++ b/c/sha3/extracted/header.txt
@@ -8,5 +8,5 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
+ * Libcrux: dirty
  */

--- a/c/sha3/extracted/header.txt
+++ b/c/sha3/extracted/header.txt
@@ -8,5 +8,5 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */

--- a/c/sha3/extracted/header.txt
+++ b/c/sha3/extracted/header.txt
@@ -8,5 +8,5 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */

--- a/c/sha3/extracted/internal/libcrux_iot_core.h
+++ b/c/sha3/extracted/internal/libcrux_iot_core.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */
 
 #ifndef internal_libcrux_iot_core_H

--- a/c/sha3/extracted/internal/libcrux_iot_core.h
+++ b/c/sha3/extracted/internal/libcrux_iot_core.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
+ * Libcrux: dirty
  */
 
 #ifndef internal_libcrux_iot_core_H

--- a/c/sha3/extracted/internal/libcrux_iot_core.h
+++ b/c/sha3/extracted/internal/libcrux_iot_core.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */
 
 #ifndef internal_libcrux_iot_core_H
@@ -42,16 +42,6 @@ typedef struct core_ops_range_Range_87_s {
 This function found in impl {libcrux_secrets::int::CastOps for u32}
 */
 uint64_t libcrux_secrets_int_as_u64_b8(uint32_t self);
-
-/**
-This function found in impl {libcrux_secrets::traits::Classify<T> for T}
-*/
-/**
-A monomorphic instance of libcrux_secrets.int.public_integers.classify_27
-with types uint32_t
-
-*/
-uint32_t libcrux_secrets_int_public_integers_classify_27_df(uint32_t self);
 
 /**
 This function found in impl {libcrux_secrets::int::CastOps for u64}

--- a/c/sha3/extracted/internal/libcrux_iot_sha3.h
+++ b/c/sha3/extracted/internal/libcrux_iot_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */
 
 #ifndef internal_libcrux_iot_sha3_H
@@ -249,6 +249,30 @@ void libcrux_iot_sha3_state_set_with_zeta_18(
           2147483784U, 32778U,      2147483785U, 1U,          32904U,      \
           129U,        136U,        2147516544U, 129U,        11U}}))
 
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
 void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(
     libcrux_iot_sha3_state_KeccakState *s);
 
@@ -286,6 +310,30 @@ void libcrux_iot_sha3_keccak_keccakf1600_round1_theta_d(
     libcrux_iot_sha3_state_KeccakState *s);
 
 void libcrux_iot_sha3_keccak_keccakf1600_round1_theta(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(
     libcrux_iot_sha3_state_KeccakState *s);
 
 void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(
@@ -327,6 +375,30 @@ void libcrux_iot_sha3_keccak_keccakf1600_round2_theta_d(
 void libcrux_iot_sha3_keccak_keccakf1600_round2_theta(
     libcrux_iot_sha3_state_KeccakState *s);
 
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
 void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(
     libcrux_iot_sha3_state_KeccakState *s);
 
@@ -366,7 +438,49 @@ void libcrux_iot_sha3_keccak_keccakf1600_round3_theta_d(
 void libcrux_iot_sha3_keccak_keccakf1600_round3_theta(
     libcrux_iot_sha3_state_KeccakState *s);
 
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
 void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -379,6 +493,24 @@ void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_56(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
 - BASE_ROUND= 0
 */
@@ -387,10 +519,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_56(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 - BASE_ROUND= 0
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -422,8 +590,8 @@ with const generics
 - RATE= 144
 */
 void libcrux_iot_sha3_state_load_block_2u32_9e(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -452,8 +620,8 @@ with const generics
 - RATE= 144
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_9e(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -575,8 +743,8 @@ with const generics
 - RATE= 136
 */
 void libcrux_iot_sha3_state_load_block_2u32_b2(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -605,8 +773,8 @@ with const generics
 - RATE= 136
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_b2(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -728,8 +896,8 @@ with const generics
 - RATE= 104
 */
 void libcrux_iot_sha3_state_load_block_2u32_53(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -758,8 +926,8 @@ with const generics
 - RATE= 104
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_53(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -881,8 +1049,8 @@ with const generics
 - RATE= 72
 */
 void libcrux_iot_sha3_state_load_block_2u32_c6(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -911,8 +1079,8 @@ with const generics
 - RATE= 72
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_c6(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -1034,8 +1202,8 @@ with const generics
 - RATE= 168
 */
 void libcrux_iot_sha3_state_load_block_2u32_60(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -1064,8 +1232,8 @@ with const generics
 - RATE= 168
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_60(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -1381,6 +1549,15 @@ void libcrux_iot_sha3_state_store_18_b2(libcrux_iot_sha3_state_KeccakState self,
                                         Eurydice_mut_borrow_slice_u8 out);
 
 /**
+A monomorphic instance of libcrux_iot_sha3.keccak._squeeze
+with const generics
+- RATE= 136
+*/
+void libcrux_iot_sha3_keccak__squeeze_b2(
+    libcrux_iot_sha3_keccak_KeccakXofState_bd *state,
+    Eurydice_mut_borrow_slice_u8 out);
+
+/**
  Squeeze `N` x `LEN` bytes.
 */
 /**
@@ -1548,6 +1725,15 @@ void libcrux_iot_sha3_state_store_18_60(libcrux_iot_sha3_state_KeccakState self,
                                         Eurydice_mut_borrow_slice_u8 out);
 
 /**
+A monomorphic instance of libcrux_iot_sha3.keccak._squeeze
+with const generics
+- RATE= 168
+*/
+void libcrux_iot_sha3_keccak__squeeze_60(
+    libcrux_iot_sha3_keccak_KeccakXofState_31 *state,
+    Eurydice_mut_borrow_slice_u8 out);
+
+/**
  Squeeze `N` x `LEN` bytes.
 */
 /**
@@ -1592,10 +1778,20 @@ for u32}
 uint32_t from_c3(Algorithm v);
 
 /**
-This function found in impl {core::convert::From<u32> for
-libcrux_iot_sha3::Algorithm}
+A monomorphic instance of core.result.Result
+with types libcrux_iot_sha3_Algorithm, ()
+
 */
-Algorithm from_c2(uint32_t v);
+typedef struct core_result_Result_20_s {
+  core_result_Result_c7_tags tag;
+  Algorithm f0;
+} core_result_Result_20;
+
+/**
+This function found in impl {core::convert::TryFrom<u32,
+libcrux_iot_sha3::UnknownAlgorithm> for libcrux_iot_sha3::Algorithm}
+*/
+core_result_Result_20 try_from_72(uint32_t v);
 
 #if defined(__cplusplus)
 }

--- a/c/sha3/extracted/internal/libcrux_iot_sha3.h
+++ b/c/sha3/extracted/internal/libcrux_iot_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */
 
 #ifndef internal_libcrux_iot_sha3_H

--- a/c/sha3/extracted/internal/libcrux_iot_sha3.h
+++ b/c/sha3/extracted/internal/libcrux_iot_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
+ * Libcrux: dirty
  */
 
 #ifndef internal_libcrux_iot_sha3_H

--- a/c/sha3/extracted/libcrux_iot_core.c
+++ b/c/sha3/extracted/libcrux_iot_core.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */
 
 #include "internal/libcrux_iot_core.h"

--- a/c/sha3/extracted/libcrux_iot_core.c
+++ b/c/sha3/extracted/libcrux_iot_core.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */
 
 #include "internal/libcrux_iot_core.h"
@@ -48,9 +48,7 @@ A monomorphic instance of libcrux_secrets.int.public_integers.classify_27
 with types uint32_t
 
 */
-uint32_t libcrux_secrets_int_public_integers_classify_27_df(uint32_t self) {
-  return self;
-}
+static KRML_MUSTINLINE uint32_t classify_27_df(uint32_t self) { return self; }
 
 /**
 This function found in impl {libcrux_secrets::traits::Declassify<T> for T}
@@ -66,8 +64,7 @@ static KRML_MUSTINLINE uint64_t declassify_d8_49(uint64_t self) { return self; }
 This function found in impl {libcrux_secrets::int::CastOps for u64}
 */
 uint32_t libcrux_secrets_int_as_u32_a3(uint64_t self) {
-  return libcrux_secrets_int_public_integers_classify_27_df(
-      (uint32_t)declassify_d8_49(self));
+  return classify_27_df((uint32_t)declassify_d8_49(self));
 }
 
 /**

--- a/c/sha3/extracted/libcrux_iot_core.c
+++ b/c/sha3/extracted/libcrux_iot_core.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
+ * Libcrux: dirty
  */
 
 #include "internal/libcrux_iot_core.h"

--- a/c/sha3/extracted/libcrux_iot_core.h
+++ b/c/sha3/extracted/libcrux_iot_core.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
+ * Libcrux: dirty
  */
 
 #ifndef libcrux_iot_core_H

--- a/c/sha3/extracted/libcrux_iot_core.h
+++ b/c/sha3/extracted/libcrux_iot_core.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */
 
 #ifndef libcrux_iot_core_H

--- a/c/sha3/extracted/libcrux_iot_core.h
+++ b/c/sha3/extracted/libcrux_iot_core.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */
 
 #ifndef libcrux_iot_core_H

--- a/c/sha3/extracted/libcrux_iot_sha3.c
+++ b/c/sha3/extracted/libcrux_iot_sha3.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
+ * Libcrux: dirty
  */
 
 #include "internal/libcrux_iot_sha3.h"
@@ -3093,13 +3093,6 @@ with const generics
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_9e(
     libcrux_iot_sha3_state_KeccakState *keccak_state,
     Eurydice_borrow_slice_u8 blocks, size_t start) {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression,
-         (size_t)25U * sizeof(Eurydice_arr_a0));
   for (size_t i = (size_t)0U; i < (size_t)144U / (size_t)8U; i++) {
     size_t i0 = i;
     size_t offset = start + (size_t)8U * i0;
@@ -3124,24 +3117,19 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_9e(
     uint32_t b = core_num__u32__from_le_bytes(
         core_result_unwrap_26_cc((KRML_CLITERAL(core_result_Result_c7){
             .tag = core_result_Ok, .val = {.case_Ok = arr}})));
-    Eurydice_arr_a0 uu____0 =
+    Eurydice_arr_a0 lane =
         libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29(
             (KRML_CLITERAL(Eurydice_arr_a0){.data = {a, b}})));
-    state_flat.data[i0] = uu____0;
-  }
-  for (size_t i = (size_t)0U; i < (size_t)144U / (size_t)8U; i++) {
-    size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
         keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
         keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
-            .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                         libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
-                                                        (size_t)0U)[0U],
-                     libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                         libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
-                                                        (size_t)1U)[0U]}})));
+            .data = {
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U],
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]}})));
   }
 }
 
@@ -3422,13 +3410,6 @@ with const generics
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_b2(
     libcrux_iot_sha3_state_KeccakState *keccak_state,
     Eurydice_borrow_slice_u8 blocks, size_t start) {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression,
-         (size_t)25U * sizeof(Eurydice_arr_a0));
   for (size_t i = (size_t)0U; i < (size_t)136U / (size_t)8U; i++) {
     size_t i0 = i;
     size_t offset = start + (size_t)8U * i0;
@@ -3453,24 +3434,19 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_b2(
     uint32_t b = core_num__u32__from_le_bytes(
         core_result_unwrap_26_cc((KRML_CLITERAL(core_result_Result_c7){
             .tag = core_result_Ok, .val = {.case_Ok = arr}})));
-    Eurydice_arr_a0 uu____0 =
+    Eurydice_arr_a0 lane =
         libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29(
             (KRML_CLITERAL(Eurydice_arr_a0){.data = {a, b}})));
-    state_flat.data[i0] = uu____0;
-  }
-  for (size_t i = (size_t)0U; i < (size_t)136U / (size_t)8U; i++) {
-    size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
         keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
         keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
-            .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                         libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
-                                                        (size_t)0U)[0U],
-                     libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                         libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
-                                                        (size_t)1U)[0U]}})));
+            .data = {
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U],
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]}})));
   }
 }
 
@@ -3751,13 +3727,6 @@ with const generics
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_53(
     libcrux_iot_sha3_state_KeccakState *keccak_state,
     Eurydice_borrow_slice_u8 blocks, size_t start) {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression,
-         (size_t)25U * sizeof(Eurydice_arr_a0));
   for (size_t i = (size_t)0U; i < (size_t)104U / (size_t)8U; i++) {
     size_t i0 = i;
     size_t offset = start + (size_t)8U * i0;
@@ -3782,24 +3751,19 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_53(
     uint32_t b = core_num__u32__from_le_bytes(
         core_result_unwrap_26_cc((KRML_CLITERAL(core_result_Result_c7){
             .tag = core_result_Ok, .val = {.case_Ok = arr}})));
-    Eurydice_arr_a0 uu____0 =
+    Eurydice_arr_a0 lane =
         libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29(
             (KRML_CLITERAL(Eurydice_arr_a0){.data = {a, b}})));
-    state_flat.data[i0] = uu____0;
-  }
-  for (size_t i = (size_t)0U; i < (size_t)104U / (size_t)8U; i++) {
-    size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
         keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
         keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
-            .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                         libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
-                                                        (size_t)0U)[0U],
-                     libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                         libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
-                                                        (size_t)1U)[0U]}})));
+            .data = {
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U],
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]}})));
   }
 }
 
@@ -4080,13 +4044,6 @@ with const generics
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_c6(
     libcrux_iot_sha3_state_KeccakState *keccak_state,
     Eurydice_borrow_slice_u8 blocks, size_t start) {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression,
-         (size_t)25U * sizeof(Eurydice_arr_a0));
   for (size_t i = (size_t)0U; i < (size_t)72U / (size_t)8U; i++) {
     size_t i0 = i;
     size_t offset = start + (size_t)8U * i0;
@@ -4111,24 +4068,19 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_c6(
     uint32_t b = core_num__u32__from_le_bytes(
         core_result_unwrap_26_cc((KRML_CLITERAL(core_result_Result_c7){
             .tag = core_result_Ok, .val = {.case_Ok = arr}})));
-    Eurydice_arr_a0 uu____0 =
+    Eurydice_arr_a0 lane =
         libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29(
             (KRML_CLITERAL(Eurydice_arr_a0){.data = {a, b}})));
-    state_flat.data[i0] = uu____0;
-  }
-  for (size_t i = (size_t)0U; i < (size_t)72U / (size_t)8U; i++) {
-    size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
         keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
         keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
-            .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                         libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
-                                                        (size_t)0U)[0U],
-                     libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                         libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
-                                                        (size_t)1U)[0U]}})));
+            .data = {
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U],
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]}})));
   }
 }
 
@@ -4461,13 +4413,6 @@ with const generics
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_60(
     libcrux_iot_sha3_state_KeccakState *keccak_state,
     Eurydice_borrow_slice_u8 blocks, size_t start) {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression,
-         (size_t)25U * sizeof(Eurydice_arr_a0));
   for (size_t i = (size_t)0U; i < (size_t)168U / (size_t)8U; i++) {
     size_t i0 = i;
     size_t offset = start + (size_t)8U * i0;
@@ -4492,24 +4437,19 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_60(
     uint32_t b = core_num__u32__from_le_bytes(
         core_result_unwrap_26_cc((KRML_CLITERAL(core_result_Result_c7){
             .tag = core_result_Ok, .val = {.case_Ok = arr}})));
-    Eurydice_arr_a0 uu____0 =
+    Eurydice_arr_a0 lane =
         libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29(
             (KRML_CLITERAL(Eurydice_arr_a0){.data = {a, b}})));
-    state_flat.data[i0] = uu____0;
-  }
-  for (size_t i = (size_t)0U; i < (size_t)168U / (size_t)8U; i++) {
-    size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
         keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
         keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
-            .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                         libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
-                                                        (size_t)0U)[0U],
-                     libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                         libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
-                                                        (size_t)1U)[0U]}})));
+            .data = {
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U],
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]}})));
   }
 }
 

--- a/c/sha3/extracted/libcrux_iot_sha3.c
+++ b/c/sha3/extracted/libcrux_iot_sha3.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */
 
 #include "internal/libcrux_iot_sha3.h"
@@ -411,218 +411,334 @@ typedef struct uint32_t_x3_s {
   uint32_t thd;
 } uint32_t_x3;
 
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(
     libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)};
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)};
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
                                           ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
                                           ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
                                           ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
                                           ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)};
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)};
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)};
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)};
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-                         .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)};
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-                         .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-                         .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)};
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____8 = {.fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-                         .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)};
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____9 = {.fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-                         .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-                         .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)};
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
-                                          ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
-                                          ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____10 = {.fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
-                          .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
@@ -632,27 +748,37 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
                                                         (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____11 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
-                          .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
-                          .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
-                                          ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax44);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(s);
 }
 
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_theta_c_x0_z0(
@@ -874,218 +1000,334 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_theta(
   libcrux_iot_sha3_keccak_keccakf1600_round1_theta_d(s);
 }
 
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(
     libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
                                                         (size_t)0U, (size_t)1U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)};
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)};
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
                                           ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
                                           ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
                                           ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
                                           ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)};
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)};
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)};
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)};
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-                         .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)};
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-                         .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-                         .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)};
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
-                                          ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____8 = {.fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-                         .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)};
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____9 = {.fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-                         .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-                         .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)};
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
-                                          ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____10 = {.fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
-                          .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
                                                         (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
@@ -1095,27 +1337,37 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
                                                         (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____11 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
-                          .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
-                          .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
-                                          ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax44);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(s);
 }
 
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_theta_c_x0_z0(
@@ -1337,218 +1589,334 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_theta(
   libcrux_iot_sha3_keccak_keccakf1600_round2_theta_d(s);
 }
 
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(
     libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)0U, (size_t)1U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)};
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)};
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
                                           ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
                                           ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
                                           ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
                                           ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)};
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)};
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)};
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)};
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-                         .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)};
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-                         .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-                         .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)};
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
-                                          ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____8 = {.fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-                         .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)};
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____9 = {.fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-                         .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-                         .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)};
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
-                                          ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
-                                          ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____10 = {.fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
-                          .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
@@ -1558,27 +1926,37 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____11 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
-                          .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
-                          .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
                                           ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
-                                          ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax44);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(s);
 }
 
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_theta_c_x0_z0(
@@ -1800,918 +2178,64 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_theta(
   libcrux_iot_sha3_keccak_keccakf1600_round3_theta_d(s);
 }
 
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(
     libcrux_iot_sha3_state_KeccakState *s) {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)};
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)};
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)};
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)};
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)};
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)};
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-                         .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)};
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-                         .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-                         .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)};
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
-                                          ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____8 = {.fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-                         .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)};
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____9 = {.fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-                         .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-                         .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)};
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
-                                          ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
-                                          ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)1U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____10 = {.fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
-                          .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)2U, (size_t)1U);
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)3U, (size_t)1U);
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)4U, (size_t)1U);
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____11 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
-                          .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
-                          .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
-                                          ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax44);
-}
-
-/**
-A monomorphic instance of
-libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
-- BASE_ROUND= 0
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_56(
-    libcrux_iot_sha3_state_KeccakState *s) {
-  size_t i = s->i;
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
-                                                        (size_t)1U, (size_t)0U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)3U, (size_t)1U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
                          .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
                          .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
-}
-
-/**
-A monomorphic instance of
-libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
-- BASE_ROUND= 0
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_56(
-    libcrux_iot_sha3_state_KeccakState *s) {
-  size_t i = s->i;
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)1U, (size_t)0U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
-                                                        (size_t)3U, (size_t)0U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
-}
-
-/**
-A monomorphic instance of
-libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
-- BASE_ROUND= 0
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_56(
-    libcrux_iot_sha3_state_KeccakState *s) {
-  size_t i = s->i;
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)1U, (size_t)1U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)3U, (size_t)0U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
-}
-
-/**
-A monomorphic instance of
-libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_1 with const generics
-- BASE_ROUND= 0
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_56(
-    libcrux_iot_sha3_state_KeccakState *s) {
-  size_t i = s->i;
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
@@ -2721,27 +2245,779 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_56(
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
                          .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
                          .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_1 with const generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(s);
 }
 
 /**
@@ -2815,8 +3091,8 @@ with const generics
 - RATE= 144
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_9e(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
   Eurydice_arr_c0 state_flat;
   Eurydice_arr_a0 repeat_expression[25U];
   for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
@@ -2856,9 +3132,9 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_9e(
   for (size_t i = (size_t)0U; i < (size_t)144U / (size_t)8U; i++) {
     size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U);
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U,
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
             .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
                          libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
@@ -2901,10 +3177,10 @@ with const generics
 - RATE= 144
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_9e(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_9e(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -2958,7 +3234,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_9e(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)144U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -2967,7 +3243,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_9e(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -2976,7 +3252,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_9e(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -3092,9 +3368,10 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_3a(
   size_t blocks = outlen / (size_t)144U;
   size_t last = outlen - outlen % (size_t)144U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++) {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_9e(&s, data, i0 * (size_t)144U);
+    libcrux_iot_sha3_keccak_absorb_block_9e(&s, data, start);
+    start += (size_t)144U;
   }
   libcrux_iot_sha3_keccak_absorb_final_3a(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U) {
@@ -3143,8 +3420,8 @@ with const generics
 - RATE= 136
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_b2(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
   Eurydice_arr_c0 state_flat;
   Eurydice_arr_a0 repeat_expression[25U];
   for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
@@ -3184,9 +3461,9 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_b2(
   for (size_t i = (size_t)0U; i < (size_t)136U / (size_t)8U; i++) {
     size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U);
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U,
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
             .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
                          libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
@@ -3229,10 +3506,10 @@ with const generics
 - RATE= 136
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_b2(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_b2(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -3286,7 +3563,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_b2(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)136U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -3295,7 +3572,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_b2(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -3304,7 +3581,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_b2(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -3420,9 +3697,10 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_22(
   size_t blocks = outlen / (size_t)136U;
   size_t last = outlen - outlen % (size_t)136U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++) {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, i0 * (size_t)136U);
+    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, start);
+    start += (size_t)136U;
   }
   libcrux_iot_sha3_keccak_absorb_final_22(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U) {
@@ -3471,8 +3749,8 @@ with const generics
 - RATE= 104
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_53(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
   Eurydice_arr_c0 state_flat;
   Eurydice_arr_a0 repeat_expression[25U];
   for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
@@ -3512,9 +3790,9 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_53(
   for (size_t i = (size_t)0U; i < (size_t)104U / (size_t)8U; i++) {
     size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U);
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U,
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
             .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
                          libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
@@ -3557,10 +3835,10 @@ with const generics
 - RATE= 104
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_53(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_53(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -3614,7 +3892,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_53(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)104U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -3623,7 +3901,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_53(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -3632,7 +3910,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_53(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -3748,9 +4026,10 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_dc(
   size_t blocks = outlen / (size_t)104U;
   size_t last = outlen - outlen % (size_t)104U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++) {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_53(&s, data, i0 * (size_t)104U);
+    libcrux_iot_sha3_keccak_absorb_block_53(&s, data, start);
+    start += (size_t)104U;
   }
   libcrux_iot_sha3_keccak_absorb_final_dc(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U) {
@@ -3799,8 +4078,8 @@ with const generics
 - RATE= 72
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_c6(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
   Eurydice_arr_c0 state_flat;
   Eurydice_arr_a0 repeat_expression[25U];
   for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
@@ -3840,9 +4119,9 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_c6(
   for (size_t i = (size_t)0U; i < (size_t)72U / (size_t)8U; i++) {
     size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U);
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U,
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
             .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
                          libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
@@ -3885,10 +4164,10 @@ with const generics
 - RATE= 72
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_c6(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_c6(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -3942,7 +4221,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_c6(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)72U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -3951,7 +4230,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_c6(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -3960,7 +4239,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_c6(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -4076,9 +4355,10 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_dc0(
   size_t blocks = outlen / (size_t)72U;
   size_t last = outlen - outlen % (size_t)72U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++) {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_c6(&s, data, i0 * (size_t)72U);
+    libcrux_iot_sha3_keccak_absorb_block_c6(&s, data, start);
+    start += (size_t)72U;
   }
   libcrux_iot_sha3_keccak_absorb_final_dc0(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U) {
@@ -4140,10 +4420,10 @@ Eurydice_arr_a2 sha224(Eurydice_borrow_slice_u8 payload) {
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 data) {
+Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 payload) {
   Eurydice_arr_ec out = libcrux_secrets_int_public_integers_classify_27_4b(
       (KRML_CLITERAL(Eurydice_arr_ec){.data = {0U}}));
-  sha256_ema(Eurydice_array_to_slice_mut_01(&out), data);
+  sha256_ema(Eurydice_array_to_slice_mut_01(&out), payload);
   return out;
 }
 
@@ -4153,10 +4433,10 @@ Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 data) {
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 data) {
+Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 payload) {
   Eurydice_arr_65 out = libcrux_secrets_int_public_integers_classify_27_69(
       (KRML_CLITERAL(Eurydice_arr_65){.data = {0U}}));
-  sha384_ema(Eurydice_array_to_slice_mut_9f(&out), data);
+  sha384_ema(Eurydice_array_to_slice_mut_9f(&out), payload);
   return out;
 }
 
@@ -4166,10 +4446,10 @@ Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 data) {
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_c7 sha512(Eurydice_borrow_slice_u8 data) {
+Eurydice_arr_c7 sha512(Eurydice_borrow_slice_u8 payload) {
   Eurydice_arr_c7 out = libcrux_secrets_int_public_integers_classify_27_56(
       (KRML_CLITERAL(Eurydice_arr_c7){.data = {0U}}));
-  sha512_ema(Eurydice_array_to_slice_mut_17(&out), data);
+  sha512_ema(Eurydice_array_to_slice_mut_17(&out), payload);
   return out;
 }
 
@@ -4179,8 +4459,8 @@ with const generics
 - RATE= 168
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_60(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
   Eurydice_arr_c0 state_flat;
   Eurydice_arr_a0 repeat_expression[25U];
   for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
@@ -4220,9 +4500,9 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_60(
   for (size_t i = (size_t)0U; i < (size_t)168U / (size_t)8U; i++) {
     size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U);
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U,
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
             .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
                          libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
@@ -4265,10 +4545,10 @@ with const generics
 - RATE= 168
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_60(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_60(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -4322,7 +4602,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_60(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)168U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -4331,7 +4611,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_60(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -4340,7 +4620,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_60(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -4456,9 +4736,10 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_37(
   size_t blocks = outlen / (size_t)168U;
   size_t last = outlen - outlen % (size_t)168U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++) {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_60(&s, data, i0 * (size_t)168U);
+    libcrux_iot_sha3_keccak_absorb_block_60(&s, data, start);
+    start += (size_t)168U;
   }
   libcrux_iot_sha3_keccak_absorb_final_37(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U) {
@@ -4543,9 +4824,10 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_220(
   size_t blocks = outlen / (size_t)136U;
   size_t last = outlen - outlen % (size_t)136U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++) {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, i0 * (size_t)136U);
+    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, start);
+    start += (size_t)136U;
   }
   libcrux_iot_sha3_keccak_absorb_final_220(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U) {
@@ -4612,7 +4894,7 @@ size_t libcrux_iot_sha3_keccak_fill_buffer_f0_b2(
   size_t input_len = inputs.meta;
   size_t consumed = (size_t)0U;
   if (self->buf_len > (size_t)0U) {
-    if (self->buf_len + input_len >= (size_t)136U) {
+    if (input_len >= (size_t)136U - self->buf_len) {
       consumed = (size_t)136U - self->buf_len;
       Eurydice_slice_copy(
           Eurydice_array_to_subslice_from_mut_5f(&self->buf, self->buf_len),
@@ -4830,7 +5112,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
   size_t last_block_len = out.meta % (size_t)8U;
   for (size_t i = (size_t)0U; i < num_full_blocks; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(&self, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -4839,7 +5121,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
             .start = i0 * (size_t)8U, .end = i0 * (size_t)8U + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -4848,12 +5130,12 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
                  .end = i0 * (size_t)8U + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
   if (last_block_len > (size_t)4U) {
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(&self, num_full_blocks / (size_t)5U,
                                            num_full_blocks % (size_t)5U));
     size_t last_half_block_len = last_block_len - (size_t)4U;
@@ -4863,7 +5145,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
                  .end = num_full_blocks * (size_t)8U + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____2, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____3 = Eurydice_slice_subslice_mut_c8(
@@ -4872,7 +5154,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
                  .end = num_full_blocks * (size_t)8U + last_block_len}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(
         uu____3,
         Eurydice_array_to_subslice_shared_d41(
@@ -4880,7 +5162,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
                          .start = (size_t)0U, .end = last_half_block_len})),
         uint8_t);
   } else if (last_block_len > (size_t)0U) {
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(&self, num_full_blocks / (size_t)5U,
                                            num_full_blocks % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____4 = Eurydice_slice_subslice_mut_c8(
@@ -4889,7 +5171,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
                  .end = num_full_blocks * (size_t)8U + last_block_len}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(
         uu____4,
         Eurydice_array_to_subslice_shared_d41(
@@ -4897,6 +5179,48 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
                          .start = (size_t)0U, .end = last_block_len})),
         uint8_t);
   }
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak._squeeze
+with const generics
+- RATE= 136
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak__squeeze_b2(
+    libcrux_iot_sha3_keccak_KeccakXofState_bd *state,
+    Eurydice_mut_borrow_slice_u8 out) {
+  if (state->sponge) {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+  }
+  size_t out_len = out.meta;
+  size_t blocks = out_len / (size_t)136U;
+  size_t last = out_len - out_len % (size_t)136U;
+  size_t mid;
+  if ((size_t)136U >= out_len) {
+    mid = out_len;
+  } else {
+    mid = (size_t)136U;
+  }
+  libcrux_iot_sha3_state_store_18_b2(
+      state->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
+  size_t offset = mid;
+  for (size_t i = (size_t)1U; i < blocks; i++) {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+    libcrux_iot_sha3_state_store_18_b2(
+        state->inner,
+        Eurydice_slice_subslice_mut_c8(
+            out, (KRML_CLITERAL(core_ops_range_Range_87){
+                     .start = offset, .end = offset + (size_t)136U})));
+    offset += (size_t)136U;
+  }
+  if (last > (size_t)0U) {
+    if (last < out_len) {
+      libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+      libcrux_iot_sha3_state_store_18_b2(
+          state->inner, Eurydice_slice_subslice_from_mut_6d(out, offset));
+    }
+  }
+  state->sponge = true;
 }
 
 /**
@@ -4913,38 +5237,7 @@ with const generics
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_squeeze_f0_b2(
     libcrux_iot_sha3_keccak_KeccakXofState_bd *self,
     Eurydice_mut_borrow_slice_u8 out) {
-  if (self->sponge) {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-  }
-  size_t out_len = out.meta;
-  size_t blocks = out_len / (size_t)136U;
-  size_t last = out_len - out_len % (size_t)136U;
-  size_t mid;
-  if ((size_t)136U >= out_len) {
-    mid = out_len;
-  } else {
-    mid = (size_t)136U;
-  }
-  libcrux_iot_sha3_state_store_18_b2(
-      self->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
-  size_t offset = mid;
-  for (size_t i = (size_t)1U; i < blocks; i++) {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-    libcrux_iot_sha3_state_store_18_b2(
-        self->inner,
-        Eurydice_slice_subslice_mut_c8(
-            out, (KRML_CLITERAL(core_ops_range_Range_87){
-                     .start = offset, .end = offset + (size_t)136U})));
-    offset += (size_t)136U;
-  }
-  if (last > (size_t)0U) {
-    if (last < out_len) {
-      libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-      libcrux_iot_sha3_state_store_18_b2(
-          self->inner, Eurydice_slice_subslice_from_mut_6d(out, offset));
-    }
-  }
-  self->sponge = true;
+  libcrux_iot_sha3_keccak__squeeze_b2(self, out);
 }
 
 /**
@@ -4983,7 +5276,7 @@ size_t libcrux_iot_sha3_keccak_fill_buffer_f0_60(
   size_t input_len = inputs.meta;
   size_t consumed = (size_t)0U;
   if (self->buf_len > (size_t)0U) {
-    if (self->buf_len + input_len >= (size_t)168U) {
+    if (input_len >= (size_t)168U - self->buf_len) {
       consumed = (size_t)168U - self->buf_len;
       Eurydice_slice_copy(
           Eurydice_array_to_subslice_from_mut_5f0(&self->buf, self->buf_len),
@@ -5201,7 +5494,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
   size_t last_block_len = out.meta % (size_t)8U;
   for (size_t i = (size_t)0U; i < num_full_blocks; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(&self, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -5210,7 +5503,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
             .start = i0 * (size_t)8U, .end = i0 * (size_t)8U + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -5219,12 +5512,12 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
                  .end = i0 * (size_t)8U + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
   if (last_block_len > (size_t)4U) {
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(&self, num_full_blocks / (size_t)5U,
                                            num_full_blocks % (size_t)5U));
     size_t last_half_block_len = last_block_len - (size_t)4U;
@@ -5234,7 +5527,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
                  .end = num_full_blocks * (size_t)8U + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____2, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____3 = Eurydice_slice_subslice_mut_c8(
@@ -5243,7 +5536,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
                  .end = num_full_blocks * (size_t)8U + last_block_len}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(
         uu____3,
         Eurydice_array_to_subslice_shared_d41(
@@ -5251,7 +5544,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
                          .start = (size_t)0U, .end = last_half_block_len})),
         uint8_t);
   } else if (last_block_len > (size_t)0U) {
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(&self, num_full_blocks / (size_t)5U,
                                            num_full_blocks % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____4 = Eurydice_slice_subslice_mut_c8(
@@ -5260,7 +5553,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
                  .end = num_full_blocks * (size_t)8U + last_block_len}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(
         uu____4,
         Eurydice_array_to_subslice_shared_d41(
@@ -5268,6 +5561,48 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
                          .start = (size_t)0U, .end = last_block_len})),
         uint8_t);
   }
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak._squeeze
+with const generics
+- RATE= 168
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak__squeeze_60(
+    libcrux_iot_sha3_keccak_KeccakXofState_31 *state,
+    Eurydice_mut_borrow_slice_u8 out) {
+  if (state->sponge) {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+  }
+  size_t out_len = out.meta;
+  size_t blocks = out_len / (size_t)168U;
+  size_t last = out_len - out_len % (size_t)168U;
+  size_t mid;
+  if ((size_t)168U >= out_len) {
+    mid = out_len;
+  } else {
+    mid = (size_t)168U;
+  }
+  libcrux_iot_sha3_state_store_18_60(
+      state->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
+  size_t offset = mid;
+  for (size_t i = (size_t)1U; i < blocks; i++) {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+    libcrux_iot_sha3_state_store_18_60(
+        state->inner,
+        Eurydice_slice_subslice_mut_c8(
+            out, (KRML_CLITERAL(core_ops_range_Range_87){
+                     .start = offset, .end = offset + (size_t)168U})));
+    offset += (size_t)168U;
+  }
+  if (last > (size_t)0U) {
+    if (last < out_len) {
+      libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+      libcrux_iot_sha3_state_store_18_60(
+          state->inner, Eurydice_slice_subslice_from_mut_6d(out, offset));
+    }
+  }
+  state->sponge = true;
 }
 
 /**
@@ -5284,38 +5619,7 @@ with const generics
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_squeeze_f0_60(
     libcrux_iot_sha3_keccak_KeccakXofState_31 *self,
     Eurydice_mut_borrow_slice_u8 out) {
-  if (self->sponge) {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-  }
-  size_t out_len = out.meta;
-  size_t blocks = out_len / (size_t)168U;
-  size_t last = out_len - out_len % (size_t)168U;
-  size_t mid;
-  if ((size_t)168U >= out_len) {
-    mid = out_len;
-  } else {
-    mid = (size_t)168U;
-  }
-  libcrux_iot_sha3_state_store_18_60(
-      self->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
-  size_t offset = mid;
-  for (size_t i = (size_t)1U; i < blocks; i++) {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-    libcrux_iot_sha3_state_store_18_60(
-        self->inner,
-        Eurydice_slice_subslice_mut_c8(
-            out, (KRML_CLITERAL(core_ops_range_Range_87){
-                     .start = offset, .end = offset + (size_t)168U})));
-    offset += (size_t)168U;
-  }
-  if (last > (size_t)0U) {
-    if (last < out_len) {
-      libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-      libcrux_iot_sha3_state_store_18_60(
-          self->inner, Eurydice_slice_subslice_from_mut_6d(out, offset));
-    }
-  }
-  self->sponge = true;
+  libcrux_iot_sha3_keccak__squeeze_60(self, out);
 }
 
 /**
@@ -5374,28 +5678,30 @@ uint32_t from_c3(Algorithm v) {
 }
 
 /**
-This function found in impl {core::convert::From<u32> for
-libcrux_iot_sha3::Algorithm}
+This function found in impl {core::convert::TryFrom<u32,
+libcrux_iot_sha3::UnknownAlgorithm> for libcrux_iot_sha3::Algorithm}
 */
-Algorithm from_c2(uint32_t v) {
+core_result_Result_20 try_from_72(uint32_t v) {
   switch (v) {
     case 1U: {
       break;
     }
     case 2U: {
-      return libcrux_iot_sha3_Algorithm_Sha256;
+      return (KRML_CLITERAL(core_result_Result_20){
+          .tag = core_result_Ok, .f0 = libcrux_iot_sha3_Algorithm_Sha256});
     }
     case 3U: {
-      return libcrux_iot_sha3_Algorithm_Sha384;
+      return (KRML_CLITERAL(core_result_Result_20){
+          .tag = core_result_Ok, .f0 = libcrux_iot_sha3_Algorithm_Sha384});
     }
     case 4U: {
-      return libcrux_iot_sha3_Algorithm_Sha512;
+      return (KRML_CLITERAL(core_result_Result_20){
+          .tag = core_result_Ok, .f0 = libcrux_iot_sha3_Algorithm_Sha512});
     }
     default: {
-      KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
-                        "panic!");
-      KRML_HOST_EXIT(255U);
+      return (KRML_CLITERAL(core_result_Result_20){.tag = core_result_Err});
     }
   }
-  return libcrux_iot_sha3_Algorithm_Sha224;
+  return (KRML_CLITERAL(core_result_Result_20){
+      .tag = core_result_Ok, .f0 = libcrux_iot_sha3_Algorithm_Sha224});
 }

--- a/c/sha3/extracted/libcrux_iot_sha3.c
+++ b/c/sha3/extracted/libcrux_iot_sha3.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */
 
 #include "internal/libcrux_iot_sha3.h"

--- a/c/sha3/extracted/libcrux_iot_sha3.h
+++ b/c/sha3/extracted/libcrux_iot_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */
 
 #ifndef libcrux_iot_sha3_H
@@ -77,7 +77,7 @@ Eurydice_arr_a2 sha224(Eurydice_borrow_slice_u8 payload);
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 data);
+Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 payload);
 
 /**
  Returns SHA3-384 digest of input payload.
@@ -85,7 +85,7 @@ Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 data);
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 data);
+Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 payload);
 
 /**
  Returns SHA3-512 digest of input payload.
@@ -93,7 +93,7 @@ Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 data);
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_c7 sha512(Eurydice_borrow_slice_u8 data);
+Eurydice_arr_c7 sha512(Eurydice_borrow_slice_u8 payload);
 
 /**
  Writes SHAKE-128 digest of input payload to externally allocated buffer.

--- a/c/sha3/extracted/libcrux_iot_sha3.h
+++ b/c/sha3/extracted/libcrux_iot_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */
 
 #ifndef libcrux_iot_sha3_H

--- a/c/sha3/extracted/libcrux_iot_sha3.h
+++ b/c/sha3/extracted/libcrux_iot_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
+ * Libcrux: dirty
  */
 
 #ifndef libcrux_iot_sha3_H

--- a/libcrux-iot/Cargo.toml
+++ b/libcrux-iot/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 version = "0.0.3"
 authors = ["Cryspen"]
 license = "AGPL-3.0-only"
-homepage = "iot.cryspen.com" # TODO: Set this up
+homepage = "iot.cryspen.com"                          # TODO: Set this up
 edition = "2021"
 repository = "https://github.com/cryspen/libcrux-iot"
 readme = "README.md"
@@ -22,7 +22,12 @@ hax-lib = { version = "0.3.6" }
 
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)', 'cfg(eurydice)', 'cfg(doc_cfg)', 'cfg(hax_backend_lean)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(hax)',
+    'cfg(eurydice)',
+    'cfg(doc_cfg)',
+    'cfg(hax_backend_lean)',
+] }
 
 [patch.crates-io]
 hax-lib = { git = "https://github.com/cryspen/hax", branch = "jonas/fstar-wrapping" }

--- a/libcrux-iot/Cargo.toml
+++ b/libcrux-iot/Cargo.toml
@@ -22,7 +22,7 @@ hax-lib = { version = "0.3.6" }
 
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)', 'cfg(eurydice)', 'cfg(doc_cfg)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)', 'cfg(eurydice)', 'cfg(doc_cfg)', 'cfg(hax_backend_lean)'] }
 
 [patch.crates-io]
 hax-lib = { git = "https://github.com/cryspen/hax", branch = "jonas/fstar-wrapping" }

--- a/libcrux-iot/sha3/Cargo.toml
+++ b/libcrux-iot/sha3/Cargo.toml
@@ -18,11 +18,15 @@ bench = false # so libtest doesn't eat the arguments to criterion
 [dependencies]
 libcrux-secrets.workspace = true
 libcrux-traits.workspace = true
-
-# This is only required for verification.
-# The hax config is set by the hax toolchain.
-[target.'cfg(hax)'.dependencies]
 hax-lib.workspace = true
+
+# XXX: Unfortunately, it's not possible to use certain hax attributes
+# with `cfg_attr`, which means we can't have hax-lib as a `cfg(hax)`
+# only dependency. (See https://github.com/cryspen/hax/issues/1496)
+# # This is only required for verification.
+# # The hax config is set by the hax toolchain.
+# [target.'cfg(hax)'.dependencies]
+# hax-lib.workspace = true
 
 [features]
 full-unroll = []

--- a/libcrux-iot/sha3/codegen.py
+++ b/libcrux-iot/sha3/codegen.py
@@ -164,21 +164,33 @@ def big_o(i, x, y):
 
     return (-sum([r(x, ninvi_y(j, x, y)) for j in range(i)])) % 2
 
-def cloop(i):
+def gen_theta_c(i, x, zeta):
+    """Emit `keccakf1600_round{i}_theta_c_x{x}_z{zeta}` function."""
     def zeta_y(zeta, i, x, y):
         return (zeta + big_o(i, x, ni_y(i, x, y))) % 2
 
     out = ""
+    out += "#[inline(always)]\n"
+    out += f"pub(crate) fn keccakf1600_round{i}_theta_c_x{x}_z{zeta}(s: &mut KeccakState) {{\n"
+    for y in range(5):
+        zy = zeta_y(zeta, i, x, y)
+        y_ni = ni_y(i, x, y)
+        out += f"    let ax_{y_ni} = s.get_with_zeta({y_ni}, {x}, {zy});\n"
+    out += f"    s.set_lane_value({x}, {zeta}, ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4);\n"
+    out += "}\n\n"
+    return out
+
+
+def gen_theta(i):
+    """Emit `keccakf1600_round{i}_theta` that calls the 10 _c_x_z helpers and _d."""
+    out = ""
+    out += "#[inline(always)]\n"
+    out += f"pub(crate) fn keccakf1600_round{i}_theta(s: &mut KeccakState) {{\n"
     for x in range(5):
         for zeta in range(2):
-            out += "{\n"
-            for y in range(5):
-                zy = zeta_y(zeta, i, x, y)
-                y_ni = ni_y(i,x, y)
-                out += f"let ax_{y_ni} = s.get_with_zeta({y_ni}, {x}, {zy});\n"
-            out += f"s.c[{x}][{zeta}] = ax_0 ^ ax_1 ^ ax_2 ^ ax_3 ^ ax_4;\n"
-            out += "}\n"
-
+            out += f"    keccakf1600_round{i}_theta_c_x{x}_z{zeta}(s);\n"
+    out += f"    keccakf1600_round{i}_theta_d(s);\n"
+    out += "}\n\n"
     return out
 
 def flatten(iterables):
@@ -278,7 +290,7 @@ def aloop_inner(i, y, zeta):
             # if zeta is one, which is always the second and last time we
             # access the round constants and need i, update the i stored in
             # the state.
-            maybe_update_i = "s.i = i + 1;" if zeta_plus_o == 1 else ""
+            maybe_update_i = "s.i = s.i + 1;" if zeta_plus_o == 1 else ""
 
             return f"""let {avar(x)};
             #[cfg(feature = "full-unroll")]
@@ -287,7 +299,7 @@ def aloop_inner(i, y, zeta):
             }};
             #[cfg(not(feature = "full-unroll"))]
             {{
-                {avar(x)} = {base_expr} ^ {rc_name}[i];
+                {avar(x)} = {base_expr} ^ {rc_name}[s.i];
                 {maybe_update_i}
             }};
             """
@@ -306,20 +318,23 @@ def aloop_inner(i, y, zeta):
 
     return out
 
-def abloop(i):
+def gen_pi_rho_chi_y_zeta(i, y, zeta):
+    """Emit `keccakf1600_round{i}_pi_rho_chi_y{y}_zeta{zeta}` function.
+
+    Only the y=0 variants reference `RC_INTERLEAVED_*`, so they alone take the
+    `<const BASE_ROUND: usize>` generic parameter.
+    """
+    const_part = "<const BASE_ROUND: usize>" if y == 0 else ""
     out = ""
-    break_at = 2
-    for y in range(5):
-        for zeta in range(2):
-            out += "{\n"
-            out += bloop_inner(i, y, zeta)
-            out += aloop_inner(i, y, zeta)
-            out += "}\n"
-
-
+    out += "#[inline(always)]\n"
+    out += f"pub(crate) fn keccakf1600_round{i}_pi_rho_chi_y{y}_zeta{zeta}{const_part}(s: &mut KeccakState) {{\n"
+    out += bloop_inner(i, y, zeta)
+    out += aloop_inner(i, y, zeta)
+    out += "}\n\n"
     return out
 
-def dloop(i):
+def gen_theta_d(i):
+    """Emit `keccakf1600_round{i}_theta_d` function."""
     def cvar(x, zeta):
         return f"c_x{x}_zeta{zeta}"
 
@@ -327,21 +342,23 @@ def dloop(i):
         return f"d_x{x}_zeta{zeta}"
 
     def load(x, zeta):
-        return f"let {cvar(x, zeta)} = s.c[{x}][{zeta}];\n"
+        return f"    let {cvar(x, zeta)} = s.c[{x}][{zeta}];\n"
 
     def compute(x, zeta):
         x_minus_one = (x - 1) % 5
         x_plus_one = (x + 1) % 5
         rotate_call = "" if zeta == 1 else ".rotate_left(1)"
-        return f"let {dvar(x, zeta)} = {cvar(x_minus_one, zeta)} ^ {cvar(x_plus_one, 1-zeta)}{rotate_call};\n"
+        return f"    let {dvar(x, zeta)} = {cvar(x_minus_one, zeta)} ^ {cvar(x_plus_one, 1-zeta)}{rotate_call};\n"
 
     def store(x, zeta):
-        return f"s.d[{x}][{zeta}] = {dvar(x, zeta)};\n"
+        return f"    s.d[{x}].0[{zeta}] = {dvar(x, zeta)};\n"
 
-    ld_order = [(4,0),(1,1), (3,0), (0,1), (2,0), (4,1), (1,0), (3,1),(2,1), (0,0)];
-    comp_order = [(0,0), (2,1), (4,0), (1,1), (3,0), (0,1), (2,0), (4,1 ), (1,0), (3,1)]
+    ld_order = [(4,0),(1,1), (3,0), (0,1), (2,0), (4,1), (1,0), (3,1),(2,1), (0,0)]
+    comp_order = [(0,0), (2,1), (4,0), (1,1), (3,0), (0,1), (2,0), (4,1), (1,0), (3,1)]
 
-    out = "{\n"
+    out = ""
+    out += "#[inline(always)]\n"
+    out += f"pub(crate) fn keccakf1600_round{i}_theta_d(s: &mut KeccakState) {{\n"
 
     for j in range(6):
         (x, zeta) = ld_order[j]
@@ -361,30 +378,20 @@ def dloop(i):
         out += compute(x, zeta)
         out += store(x, zeta)
 
-    out += "}\n"
+    out += "}\n\n"
     return out
-
-    
-
-def round(i):
-    out = ""
-    out += cloop(i)
-    out += dloop(i)
-    out += """#[cfg(not(feature = "full-unroll"))]
-    let i = s.i;
-    """
-    out += abloop(i)
-    return out
-
-
-def defn_roundfn(i):
-    return f"""
-#[inline(always)]
-    pub(crate) fn keccakf1600_round{i}<const BASE_ROUND: usize>(s: &mut KeccakState) {{
-        {round(i)}
-    }}
-    """
 
 for i in range(4):
-    print(defn_roundfn(i))
+    for x in range(5):
+        for zeta in range(2):
+            print(gen_theta_c(i, x, zeta), end="")
+    print(gen_theta_d(i), end="")
+    print(gen_theta(i), end="")
+    for y in range(2):
+        for zeta in range(2):
+            print(gen_pi_rho_chi_y_zeta(i, y, zeta), end="")
+    for y in range(2, 5):
+        for zeta in range(2):
+            print(gen_pi_rho_chi_y_zeta(i, y, zeta), end="")
+
 

--- a/libcrux-iot/sha3/hax.py
+++ b/libcrux-iot/sha3/hax.py
@@ -34,6 +34,7 @@ class extractAction(argparse.Action):
             "-**",
             "+libcrux_iot_sha3::lane::**",
             "+libcrux_iot_sha3::state::**",
+            "+libcrux_iot_sha3::keccak::**",
         ]
         include_str = " ".join(includes)
         cargo_hax_into = [

--- a/libcrux-iot/sha3/hax.py
+++ b/libcrux-iot/sha3/hax.py
@@ -105,12 +105,16 @@ class proveAction(argparse.Action):
 class cleanAction(argparse.Action):
 
     def __call__(self, parser, args, values, option_string=None) -> None:
-        fst_files = glob("./proofs/fstar/extraction/*.fst")
-        fsti_files = glob("./proofs/fstar/extraction/*.fsti")
-        if fst_files:
-            shell(["rm"] + fst_files)
-        if fsti_files:
-            shell(["rm"] + fsti_files)
+        # Clean the SHA3 extraction and the secrets extraction
+        subfolders = ["extraction", "secrets"]
+
+        for folder in subfolders:
+            fst_files = glob(f"./proofs/fstar/{folder}/*.fst")
+            fsti_files = glob(f"./proofs/fstar/{folder}/*.fsti")
+            if fst_files:
+                shell(["rm"] + fst_files)
+            if fsti_files:
+                shell(["rm"] + fsti_files)
         return None
 
 

--- a/libcrux-iot/sha3/hax.py
+++ b/libcrux-iot/sha3/hax.py
@@ -33,6 +33,7 @@ class extractAction(argparse.Action):
         includes = [
             "-**",
             "+libcrux_iot_sha3::lane::**",
+            "+libcrux_iot_sha3::state::**",
         ]
         include_str = " ".join(includes)
         cargo_hax_into = [

--- a/libcrux-iot/sha3/hax.py
+++ b/libcrux-iot/sha3/hax.py
@@ -26,10 +26,48 @@ def shell(command, expect=0, cwd=None, env={}):
     if ret.returncode != expect:
         raise Exception("Error {}. Expected {}.".format(ret, expect))
 
+def dependency_path(dep):
+    """Attempt to retrieve the crate root path (as a UTF-8 string) of a dependency `dep`, identified by its crate name."""
+    cargo_command = ["cargo",
+               "metadata",
+               "--format-version",
+               "1"]
+    jq_command = ["jq",
+                  "-r",
+                  f".packages | .[] | select(.name==\"{dep}\") | .manifest_path | split(\"/\") | .[:-1] | join(\"/\")"]
+    cargo_res = subprocess.Popen(cargo_command, stdout=subprocess.PIPE)
+    jq_output = subprocess.run(jq_command, stdin=cargo_res.stdout, capture_output=True, encoding="utf-8")
+    if jq_output.returncode != 0:
+        raise Exception("Error {}. Expected {}.".format(jq_output, 0))
+    return jq_output.stdout.strip()
 
 class extractAction(argparse.Action):
 
     def __call__(self, parser, args, values, option_string=None) -> None:
+        # Extract libcrux-secrets
+        secrets_output_dir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "proofs/fstar/secrets")
+        )
+        include_str = "+**"
+        cargo_hax_into = [
+            "cargo",
+            "hax",
+            "into",
+            "-i",
+            include_str,
+            "--output-dir",
+            secrets_output_dir,
+            "fstar",
+        ]
+        hax_env = {}
+        secrets_dir = dependency_path("libcrux-secrets")
+        print("Secrets at : {}".format(secrets_dir))
+        shell(
+            cargo_hax_into,
+            cwd=secrets_dir,
+            env=hax_env,
+        )
+        
         includes = [
             "+**",
         ]

--- a/libcrux-iot/sha3/hax.py
+++ b/libcrux-iot/sha3/hax.py
@@ -1,0 +1,126 @@
+#! /usr/bin/env python3
+
+import os
+import argparse
+import subprocess
+import sys
+from glob import glob
+
+def shell(command, expect=0, cwd=None, env={}):
+    subprocess_stdout = subprocess.DEVNULL
+
+    print("Env:", env)
+    print("Command: ", end="")
+    for i, word in enumerate(command):
+        if i == 4:
+            print("'{}' ".format(word), end="")
+        else:
+            print("{} ".format(word), end="")
+
+    print("\nDirectory: {}".format(cwd))
+
+    os_env = os.environ
+    os_env.update(env)
+
+    ret = subprocess.run(command, cwd=cwd, env=os_env)
+    if ret.returncode != expect:
+        raise Exception("Error {}. Expected {}.".format(ret, expect))
+
+
+class extractAction(argparse.Action):
+
+    def __call__(self, parser, args, values, option_string=None) -> None:
+        includes = [
+            "-**",
+            "+libcrux_iot_sha3::lane::**",
+        ]
+        include_str = " ".join(includes)
+        cargo_hax_into = [
+            "cargo",
+            "hax",
+            "into",
+            "-i",
+            include_str,
+            "fstar",
+        ]
+        shell(
+            cargo_hax_into,
+            cwd=".",
+            env={},
+        )
+        return None
+
+
+class proveAction(argparse.Action):
+
+    def __call__(self, parser, args, values, option_string=None) -> None:
+        admit_env = {}
+        if args.admit:
+            admit_env = {"OTHERFLAGS": "--admit_smt_queries true"}
+        shell(["make", "-j4", "-C", "proofs/fstar/extraction/"], env=admit_env)
+        return None
+
+
+class cleanAction(argparse.Action):
+
+    def __call__(self, parser, args, values, option_string=None) -> None:
+        fst_files = glob("./proofs/fstar/extraction/*.fst")
+        fsti_files = glob("./proofs/fstar/extraction/*.fsti")
+        if fst_files:
+            shell(["rm"] + fst_files)
+        if fsti_files:
+            shell(["rm"] + fsti_files)
+        return None
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Libcrux-IoT SHA-3 hax script. "
+        + "Make sure to separate sub-command arguments with --."
+    )
+    subparsers = parser.add_subparsers()
+
+    extract_parser = subparsers.add_parser(
+        "extract", help="Extract the F* code for the proofs."
+    )
+    extract_parser.add_argument("extract", nargs="*", action=extractAction)
+
+    prover_parser = subparsers.add_parser(
+        "prove",
+        help="""
+        Run F*.
+
+        This typechecks the extracted code.
+        To lax-typecheck use --admit.
+        """,
+    )
+    prover_parser.add_argument(
+        "--admit",
+        help="Admit all smt queries to lax typecheck.",
+        action="store_true",
+    )
+    prover_parser.add_argument(
+        "prove",
+        nargs="*",
+        action=proveAction,
+    )
+
+    clean_parser = subparsers.add_parser(
+        "clean", help="Remove generated F* code for this crate."
+    )
+    clean_parser.add_argument("clean", nargs="*", action=cleanAction)
+
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+    return parser.parse_args()
+
+
+def main():
+    sys.tracebacklimit = 0
+    parse_arguments()
+
+
+if __name__ == "__main__":
+    main()

--- a/libcrux-iot/sha3/hax.py
+++ b/libcrux-iot/sha3/hax.py
@@ -31,15 +31,16 @@ class extractAction(argparse.Action):
 
     def __call__(self, parser, args, values, option_string=None) -> None:
         includes = [
-            "-**",
-            "+libcrux_iot_sha3::lane::**",
-            "+libcrux_iot_sha3::state::**",
-            "+libcrux_iot_sha3::keccak::**",
+            "+**",
         ]
         include_str = " ".join(includes)
         cargo_hax_into = [
             "cargo",
             "hax",
+            "-C",
+            "-F",
+            "unbuffered-xof",
+            ";",
             "into",
             "-i",
             include_str,

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Incremental.Bundle.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Incremental.Bundle.fst
@@ -1,0 +1,342 @@
+module Libcrux_iot_sha3.Incremental.Bundle
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+/// An unbuffered XOF state.
+type t_UnbufferedXofState = { f_state:Libcrux_iot_sha3.State.t_KeccakState }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_2': Core_models.Fmt.t_Debug t_UnbufferedXofState
+
+unfold
+let impl_2 = impl_2'
+
+let impl: Core_models.Clone.t_Clone t_UnbufferedXofState =
+  { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_1': Core_models.Marker.t_Copy t_UnbufferedXofState
+
+unfold
+let impl_1 = impl_1'
+
+/// Input-buffering SHAKE128 state
+type t_Shake128Xof = { f_state:Libcrux_iot_sha3.Keccak.t_KeccakXofState (mk_usize 168) }
+
+/// Input-buffering SHAKE256 state
+type t_Shake256Xof = { f_state:Libcrux_iot_sha3.Keccak.t_KeccakXofState (mk_usize 136) }
+
+/// Create a new SHAKE-128 state object.
+let shake128_init (_: Prims.unit) : t_UnbufferedXofState =
+  { f_state = Libcrux_iot_sha3.State.impl_KeccakState__new () } <: t_UnbufferedXofState
+
+/// Absorb
+let shake128_absorb_final (s: t_UnbufferedXofState) (data0: t_Slice u8)
+    : Prims.Pure t_UnbufferedXofState
+      (requires (Core_models.Slice.impl__len #u8 data0 <: usize) <. mk_usize 168)
+      (fun _ -> Prims.l_True) =
+  let s:t_UnbufferedXofState =
+    {
+      s with
+      f_state
+      =
+      Libcrux_iot_sha3.Keccak.absorb_final (mk_usize 168)
+        (mk_u8 31)
+        s.f_state
+        data0
+        (mk_usize 0)
+        (Core_models.Slice.impl__len #u8 data0 <: usize)
+    }
+    <:
+    t_UnbufferedXofState
+  in
+  s
+
+/// Squeeze three blocks
+let shake128_squeeze_first_three_blocks (s: t_UnbufferedXofState) (out0: t_Slice u8)
+    : Prims.Pure (t_UnbufferedXofState & t_Slice u8)
+      (requires
+        (Core_models.Slice.impl__len #u8 out0 <: usize) >=. (mk_usize 3 *! mk_usize 168 <: usize))
+      (fun _ -> Prims.l_True) =
+  let (tmp0: Libcrux_iot_sha3.State.t_KeccakState), (tmp1: t_Slice u8) =
+    Libcrux_iot_sha3.Keccak.squeeze_first_three_blocks (mk_usize 168) s.f_state out0
+  in
+  let s:t_UnbufferedXofState = { s with f_state = tmp0 } <: t_UnbufferedXofState in
+  let out0:t_Slice u8 = tmp1 in
+  let _:Prims.unit = () in
+  s, out0 <: (t_UnbufferedXofState & t_Slice u8)
+
+/// Squeeze five blocks
+let shake128_squeeze_first_five_blocks (s: t_UnbufferedXofState) (out0: t_Slice u8)
+    : Prims.Pure (t_UnbufferedXofState & t_Slice u8)
+      (requires
+        (Core_models.Slice.impl__len #u8 out0 <: usize) >=. (mk_usize 5 *! mk_usize 168 <: usize))
+      (fun _ -> Prims.l_True) =
+  let (tmp0: Libcrux_iot_sha3.State.t_KeccakState), (tmp1: t_Slice u8) =
+    Libcrux_iot_sha3.Keccak.squeeze_first_five_blocks (mk_usize 168) s.f_state out0
+  in
+  let s:t_UnbufferedXofState = { s with f_state = tmp0 } <: t_UnbufferedXofState in
+  let out0:t_Slice u8 = tmp1 in
+  let _:Prims.unit = () in
+  s, out0 <: (t_UnbufferedXofState & t_Slice u8)
+
+/// Squeeze another block
+let shake128_squeeze_next_block (s: t_UnbufferedXofState) (out0: t_Slice u8)
+    : Prims.Pure (t_UnbufferedXofState & t_Slice u8)
+      (requires (Core_models.Slice.impl__len #u8 out0 <: usize) >=. mk_usize 168)
+      (fun _ -> Prims.l_True) =
+  let (tmp0: Libcrux_iot_sha3.State.t_KeccakState), (tmp1: t_Slice u8) =
+    Libcrux_iot_sha3.Keccak.squeeze_next_block (mk_usize 168) s.f_state out0
+  in
+  let s:t_UnbufferedXofState = { s with f_state = tmp0 } <: t_UnbufferedXofState in
+  let out0:t_Slice u8 = tmp1 in
+  let _:Prims.unit = () in
+  s, out0 <: (t_UnbufferedXofState & t_Slice u8)
+
+/// Create a new SHAKE-256 state object.
+let shake256_init (_: Prims.unit) : t_UnbufferedXofState =
+  { f_state = Libcrux_iot_sha3.State.impl_KeccakState__new () } <: t_UnbufferedXofState
+
+/// Absorb some data for SHAKE-256 for the last time
+let shake256_absorb_final (s: t_UnbufferedXofState) (data: t_Slice u8)
+    : Prims.Pure t_UnbufferedXofState
+      (requires (Core_models.Slice.impl__len #u8 data <: usize) <. mk_usize 136)
+      (fun _ -> Prims.l_True) =
+  let s:t_UnbufferedXofState =
+    {
+      s with
+      f_state
+      =
+      Libcrux_iot_sha3.Keccak.absorb_final (mk_usize 136)
+        (mk_u8 31)
+        s.f_state
+        data
+        (mk_usize 0)
+        (Core_models.Slice.impl__len #u8 data <: usize)
+    }
+    <:
+    t_UnbufferedXofState
+  in
+  s
+
+/// Squeeze the first SHAKE-256 block
+let shake256_squeeze_first_block (s: t_UnbufferedXofState) (out: t_Slice u8)
+    : Prims.Pure (t_UnbufferedXofState & t_Slice u8)
+      (requires (Core_models.Slice.impl__len #u8 out <: usize) >=. mk_usize 136)
+      (fun _ -> Prims.l_True) =
+  let out:t_Slice u8 = Libcrux_iot_sha3.Keccak.squeeze_first_block (mk_usize 136) s.f_state out in
+  s, out <: (t_UnbufferedXofState & t_Slice u8)
+
+/// Squeeze the next SHAKE-256 block
+let shake256_squeeze_next_block (s: t_UnbufferedXofState) (out: t_Slice u8)
+    : Prims.Pure (t_UnbufferedXofState & t_Slice u8)
+      (requires (Core_models.Slice.impl__len #u8 out <: usize) >=. mk_usize 136)
+      (fun _ -> Prims.l_True) =
+  let (tmp0: Libcrux_iot_sha3.State.t_KeccakState), (tmp1: t_Slice u8) =
+    Libcrux_iot_sha3.Keccak.squeeze_next_block (mk_usize 136) s.f_state out
+  in
+  let s:t_UnbufferedXofState = { s with f_state = tmp0 } <: t_UnbufferedXofState in
+  let out:t_Slice u8 = tmp1 in
+  let _:Prims.unit = () in
+  s, out <: (t_UnbufferedXofState & t_Slice u8)
+
+class t_Sealed (v_Self: Type0) = { __marker_trait_t_Sealed:Prims.unit }
+
+/// Interface for an input-buffering Extendable Output Function
+/// (XOF)
+class t_Xof (v_Self: Type0) (v_RATE: usize) = {
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_i0:t_Sealed v_Self;
+  f_new_pre:Prims.unit -> Type0;
+  f_new_post:Prims.unit -> v_Self -> Type0;
+  f_new:x0: Prims.unit -> Prims.Pure v_Self (f_new_pre x0) (fun result -> f_new_post x0 result);
+  f_absorb_pre:v_Self -> t_Slice u8 -> Type0;
+  f_absorb_post:v_Self -> t_Slice u8 -> v_Self -> Type0;
+  f_absorb:x0: v_Self -> x1: t_Slice u8
+    -> Prims.Pure v_Self (f_absorb_pre x0 x1) (fun result -> f_absorb_post x0 x1 result);
+  f_absorb_final_pre:v_Self -> t_Slice u8 -> Type0;
+  f_absorb_final_post:v_Self -> t_Slice u8 -> v_Self -> Type0;
+  f_absorb_final:x0: v_Self -> x1: t_Slice u8
+    -> Prims.Pure v_Self (f_absorb_final_pre x0 x1) (fun result -> f_absorb_final_post x0 x1 result);
+  f_squeeze_pre:v_Self -> t_Slice u8 -> Type0;
+  f_squeeze_post:v_Self -> t_Slice u8 -> (v_Self & t_Slice u8) -> Type0;
+  f_squeeze:x0: v_Self -> x1: t_Slice u8
+    -> Prims.Pure (v_Self & t_Slice u8)
+        (f_squeeze_pre x0 x1)
+        (fun result -> f_squeeze_post x0 x1 result)
+}
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let _ = fun (v_Self:Type0) (v_RATE:usize) {|i: t_Xof v_Self v_RATE|} -> i._super_i0
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl__from__private: t_Sealed t_Shake128Xof = { __marker_trait_t_Sealed = () }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_3: t_Xof t_Shake128Xof (mk_usize 168) =
+  {
+    _super_i0 = FStar.Tactics.Typeclasses.solve;
+    f_new_pre = (fun (_: Prims.unit) -> true);
+    f_new_post = (fun (_: Prims.unit) (out: t_Shake128Xof) -> true);
+    f_new
+    =
+    (fun (_: Prims.unit) ->
+        { f_state = Libcrux_iot_sha3.Keccak.impl__new (mk_usize 168) () } <: t_Shake128Xof);
+    f_absorb_pre
+    =
+    (fun (self_: t_Shake128Xof) (input: t_Slice u8) ->
+        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 168 &&
+        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 input <: usize)
+            <:
+            Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len
+            <:
+            Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int));
+    f_absorb_post = (fun (self: t_Shake128Xof) (input: t_Slice u8) (out: t_Shake128Xof) -> true);
+    f_absorb
+    =
+    (fun (self: t_Shake128Xof) (input: t_Slice u8) ->
+        let self:t_Shake128Xof =
+          {
+            self with
+            f_state = Libcrux_iot_sha3.Keccak.impl__absorb (mk_usize 168) self.f_state input
+          }
+          <:
+          t_Shake128Xof
+        in
+        self);
+    f_absorb_final_pre
+    =
+    (fun (self_: t_Shake128Xof) (input: t_Slice u8) ->
+        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 168 &&
+        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 input <: usize)
+            <:
+            Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len
+            <:
+            Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int));
+    f_absorb_final_post
+    =
+    (fun (self: t_Shake128Xof) (input: t_Slice u8) (out: t_Shake128Xof) -> true);
+    f_absorb_final
+    =
+    (fun (self: t_Shake128Xof) (input: t_Slice u8) ->
+        let self:t_Shake128Xof =
+          {
+            self with
+            f_state
+            =
+            Libcrux_iot_sha3.Keccak.impl__absorb_final (mk_usize 168) (mk_u8 31) self.f_state input
+          }
+          <:
+          t_Shake128Xof
+        in
+        self);
+    f_squeeze_pre = (fun (self: t_Shake128Xof) (out: t_Slice u8) -> true);
+    f_squeeze_post
+    =
+    (fun (self: t_Shake128Xof) (out: t_Slice u8) (out1: (t_Shake128Xof & t_Slice u8)) -> true);
+    f_squeeze
+    =
+    fun (self: t_Shake128Xof) (out: t_Slice u8) ->
+      let (tmp0: Libcrux_iot_sha3.Keccak.t_KeccakXofState (mk_usize 168)), (tmp1: t_Slice u8) =
+        Libcrux_iot_sha3.Keccak.impl__squeeze (mk_usize 168) self.f_state out
+      in
+      let self:t_Shake128Xof = { self with f_state = tmp0 } <: t_Shake128Xof in
+      let out:t_Slice u8 = tmp1 in
+      let _:Prims.unit = () in
+      self, out <: (t_Shake128Xof & t_Slice u8)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1__from__private: t_Sealed t_Shake256Xof = { __marker_trait_t_Sealed = () }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_4: t_Xof t_Shake256Xof (mk_usize 136) =
+  {
+    _super_i0 = FStar.Tactics.Typeclasses.solve;
+    f_new_pre = (fun (_: Prims.unit) -> true);
+    f_new_post = (fun (_: Prims.unit) (out: t_Shake256Xof) -> true);
+    f_new
+    =
+    (fun (_: Prims.unit) ->
+        { f_state = Libcrux_iot_sha3.Keccak.impl__new (mk_usize 136) () } <: t_Shake256Xof);
+    f_absorb_pre
+    =
+    (fun (self_: t_Shake256Xof) (input: t_Slice u8) ->
+        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 136 &&
+        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 input <: usize)
+            <:
+            Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len
+            <:
+            Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int));
+    f_absorb_post = (fun (self: t_Shake256Xof) (input: t_Slice u8) (out: t_Shake256Xof) -> true);
+    f_absorb
+    =
+    (fun (self: t_Shake256Xof) (input: t_Slice u8) ->
+        let self:t_Shake256Xof =
+          {
+            self with
+            f_state = Libcrux_iot_sha3.Keccak.impl__absorb (mk_usize 136) self.f_state input
+          }
+          <:
+          t_Shake256Xof
+        in
+        self);
+    f_absorb_final_pre
+    =
+    (fun (self_: t_Shake256Xof) (input: t_Slice u8) ->
+        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 136 &&
+        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 input <: usize)
+            <:
+            Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len
+            <:
+            Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int));
+    f_absorb_final_post
+    =
+    (fun (self: t_Shake256Xof) (input: t_Slice u8) (out: t_Shake256Xof) -> true);
+    f_absorb_final
+    =
+    (fun (self: t_Shake256Xof) (input: t_Slice u8) ->
+        let self:t_Shake256Xof =
+          {
+            self with
+            f_state
+            =
+            Libcrux_iot_sha3.Keccak.impl__absorb_final (mk_usize 136) (mk_u8 31) self.f_state input
+          }
+          <:
+          t_Shake256Xof
+        in
+        self);
+    f_squeeze_pre = (fun (self: t_Shake256Xof) (out: t_Slice u8) -> true);
+    f_squeeze_post
+    =
+    (fun (self: t_Shake256Xof) (out: t_Slice u8) (out1: (t_Shake256Xof & t_Slice u8)) -> true);
+    f_squeeze
+    =
+    fun (self: t_Shake256Xof) (out: t_Slice u8) ->
+      let (tmp0: Libcrux_iot_sha3.Keccak.t_KeccakXofState (mk_usize 136)), (tmp1: t_Slice u8) =
+        Libcrux_iot_sha3.Keccak.impl__squeeze (mk_usize 136) self.f_state out
+      in
+      let self:t_Shake256Xof = { self with f_state = tmp0 } <: t_Shake256Xof in
+      let out:t_Slice u8 = tmp1 in
+      let _:Prims.unit = () in
+      self, out <: (t_Shake256Xof & t_Slice u8)
+  }

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Incremental.Bundle.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Incremental.Bundle.fst
@@ -187,16 +187,7 @@ let impl_3: t_Xof t_Shake128Xof (mk_usize 168) =
     f_absorb_pre
     =
     (fun (self_: t_Shake128Xof) (input: t_Slice u8) ->
-        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 168 &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 input <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len
-            <:
-            Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int));
+        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 168);
     f_absorb_post = (fun (self: t_Shake128Xof) (input: t_Slice u8) (out: t_Shake128Xof) -> true);
     f_absorb
     =
@@ -213,16 +204,7 @@ let impl_3: t_Xof t_Shake128Xof (mk_usize 168) =
     f_absorb_final_pre
     =
     (fun (self_: t_Shake128Xof) (input: t_Slice u8) ->
-        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 168 &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 input <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len
-            <:
-            Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int));
+        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 168);
     f_absorb_final_post
     =
     (fun (self: t_Shake128Xof) (input: t_Slice u8) (out: t_Shake128Xof) -> true);
@@ -272,16 +254,7 @@ let impl_4: t_Xof t_Shake256Xof (mk_usize 136) =
     f_absorb_pre
     =
     (fun (self_: t_Shake256Xof) (input: t_Slice u8) ->
-        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 136 &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 input <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len
-            <:
-            Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int));
+        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 136);
     f_absorb_post = (fun (self: t_Shake256Xof) (input: t_Slice u8) (out: t_Shake256Xof) -> true);
     f_absorb
     =
@@ -298,16 +271,7 @@ let impl_4: t_Xof t_Shake256Xof (mk_usize 136) =
     f_absorb_final_pre
     =
     (fun (self_: t_Shake256Xof) (input: t_Slice u8) ->
-        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 136 &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 input <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len
-            <:
-            Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int));
+        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 136);
     f_absorb_final_post
     =
     (fun (self: t_Shake256Xof) (input: t_Slice u8) (out: t_Shake256Xof) -> true);

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Incremental.Private.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Incremental.Private.fst
@@ -1,0 +1,10 @@
+module Libcrux_iot_sha3.Incremental.Private
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+include Libcrux_iot_sha3.Incremental.Bundle {t_Sealed as t_Sealed}
+
+include Libcrux_iot_sha3.Incremental.Bundle {impl__from__private as impl}
+
+include Libcrux_iot_sha3.Incremental.Bundle {impl_1__from__private as impl_1}

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Incremental.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Incremental.fst
@@ -1,0 +1,64 @@
+module Libcrux_iot_sha3.Incremental
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+include Libcrux_iot_sha3.Incremental.Bundle {t_UnbufferedXofState as t_UnbufferedXofState}
+
+include Libcrux_iot_sha3.Incremental.Bundle {impl_2 as impl_2}
+
+include Libcrux_iot_sha3.Incremental.Bundle {impl as impl}
+
+include Libcrux_iot_sha3.Incremental.Bundle {impl_1 as impl_1}
+
+include Libcrux_iot_sha3.Incremental.Bundle {t_Shake128Xof as t_Shake128Xof}
+
+include Libcrux_iot_sha3.Incremental.Bundle {t_Shake256Xof as t_Shake256Xof}
+
+include Libcrux_iot_sha3.Incremental.Bundle {t_Xof as t_Xof}
+
+include Libcrux_iot_sha3.Incremental.Bundle {f_new_pre as f_new_pre}
+
+include Libcrux_iot_sha3.Incremental.Bundle {f_new_post as f_new_post}
+
+include Libcrux_iot_sha3.Incremental.Bundle {f_new as f_new}
+
+include Libcrux_iot_sha3.Incremental.Bundle {f_absorb_pre as f_absorb_pre}
+
+include Libcrux_iot_sha3.Incremental.Bundle {f_absorb_post as f_absorb_post}
+
+include Libcrux_iot_sha3.Incremental.Bundle {f_absorb as f_absorb}
+
+include Libcrux_iot_sha3.Incremental.Bundle {f_absorb_final_pre as f_absorb_final_pre}
+
+include Libcrux_iot_sha3.Incremental.Bundle {f_absorb_final_post as f_absorb_final_post}
+
+include Libcrux_iot_sha3.Incremental.Bundle {f_absorb_final as f_absorb_final}
+
+include Libcrux_iot_sha3.Incremental.Bundle {f_squeeze_pre as f_squeeze_pre}
+
+include Libcrux_iot_sha3.Incremental.Bundle {f_squeeze_post as f_squeeze_post}
+
+include Libcrux_iot_sha3.Incremental.Bundle {f_squeeze as f_squeeze}
+
+include Libcrux_iot_sha3.Incremental.Bundle {impl_3 as impl_3}
+
+include Libcrux_iot_sha3.Incremental.Bundle {impl_4 as impl_4}
+
+include Libcrux_iot_sha3.Incremental.Bundle {shake128_init as shake128_init}
+
+include Libcrux_iot_sha3.Incremental.Bundle {shake128_absorb_final as shake128_absorb_final}
+
+include Libcrux_iot_sha3.Incremental.Bundle {shake128_squeeze_first_three_blocks as shake128_squeeze_first_three_blocks}
+
+include Libcrux_iot_sha3.Incremental.Bundle {shake128_squeeze_first_five_blocks as shake128_squeeze_first_five_blocks}
+
+include Libcrux_iot_sha3.Incremental.Bundle {shake128_squeeze_next_block as shake128_squeeze_next_block}
+
+include Libcrux_iot_sha3.Incremental.Bundle {shake256_init as shake256_init}
+
+include Libcrux_iot_sha3.Incremental.Bundle {shake256_absorb_final as shake256_absorb_final}
+
+include Libcrux_iot_sha3.Incremental.Bundle {shake256_squeeze_first_block as shake256_squeeze_first_block}
+
+include Libcrux_iot_sha3.Incremental.Bundle {shake256_squeeze_next_block as shake256_squeeze_next_block}

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
@@ -535,7 +535,7 @@ let impl__absorb_full (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t
     : Prims.Pure (t_KeccakXofState v_RATE & usize)
       (requires
         v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
-        v_RATE <=. mk_usize 144 &&
+        v_RATE <=. mk_usize 168 &&
         self.f_buf_len <. v_RATE &&
         ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
             <:
@@ -637,7 +637,7 @@ let impl__absorb (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t_Slic
     : Prims.Pure (t_KeccakXofState v_RATE)
       (requires
         v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
-        v_RATE <=. mk_usize 144 &&
+        v_RATE <=. mk_usize 168 &&
         self.f_buf_len <. v_RATE &&
         ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
             <:
@@ -716,7 +716,7 @@ let impl__absorb_final
     : Prims.Pure (t_KeccakXofState v_RATE)
       (requires
         v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
-        v_RATE <=. mk_usize 144 &&
+        v_RATE <=. mk_usize 168 &&
         self.f_buf_len <. v_RATE &&
         ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
             <:
@@ -830,21 +830,23 @@ let impl__absorb_final
   in
   self
 
-/// Squeeze `N` x `LEN` bytes.
-let impl__squeeze (v_RATE: usize) (self: t_KeccakXofState v_RATE) (out: t_Slice u8)
+#push-options "--z3rlimit 60"
+
+let e_squeeze (v_RATE: usize) (state: t_KeccakXofState v_RATE) (out: t_Slice u8)
     : Prims.Pure (t_KeccakXofState v_RATE & t_Slice u8)
       (requires
-        v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
-        v_RATE <=. mk_usize 144)
+        v_RATE =. mk_usize 168 || v_RATE =. mk_usize 144 || v_RATE =. mk_usize 136 ||
+        v_RATE =. mk_usize 104 ||
+        v_RATE =. mk_usize 72)
       (fun _ -> Prims.l_True) =
-  let self:t_KeccakXofState v_RATE =
-    if self.f_sponge
+  let state:t_KeccakXofState v_RATE =
+    if state.f_sponge
     then
-      let self:t_KeccakXofState v_RATE =
-        { self with f_inner = keccakf1600 self.f_inner } <: t_KeccakXofState v_RATE
+      let state:t_KeccakXofState v_RATE =
+        { state with f_inner = keccakf1600 state.f_inner } <: t_KeccakXofState v_RATE
       in
-      self
-    else self
+      state
+    else state
   in
   let out_len:usize = Core_models.Slice.impl__len #u8 out in
   let blocks:usize = out_len /! v_RATE in
@@ -854,7 +856,7 @@ let impl__squeeze (v_RATE: usize) (self: t_KeccakXofState v_RATE) (out: t_Slice 
     Rust_primitives.Hax.Monomorphized_update_at.update_at_range_to out
       ({ Core_models.Ops.Range.f_end = mid } <: Core_models.Ops.Range.t_RangeTo usize)
       (Libcrux_iot_sha3.State.impl_KeccakState__store v_RATE
-          self.f_inner
+          state.f_inner
           (out.[ { Core_models.Ops.Range.f_end = mid } <: Core_models.Ops.Range.t_RangeTo usize ]
             <:
             t_Slice u8)
@@ -862,11 +864,11 @@ let impl__squeeze (v_RATE: usize) (self: t_KeccakXofState v_RATE) (out: t_Slice 
         t_Slice u8)
   in
   let offset:usize = mid in
-  let (offset: usize), (out: t_Slice u8), (self: t_KeccakXofState v_RATE) =
+  let (offset: usize), (out: t_Slice u8), (state: t_KeccakXofState v_RATE) =
     Rust_primitives.Hax.Folds.fold_range (mk_usize 1)
       blocks
       (fun temp_0_ e_k ->
-          let (offset: usize), (out: t_Slice u8), (self: t_KeccakXofState v_RATE) = temp_0_ in
+          let (offset: usize), (out: t_Slice u8), (state: t_KeccakXofState v_RATE) = temp_0_ in
           let e_k:usize = e_k in
           ((Core_models.Slice.impl__len #u8 out <: usize) =. out_len <: bool) &&
           ((Rust_primitives.Hax.Int.from_machine offset <: Hax_lib.Int.t_Int) =
@@ -876,12 +878,12 @@ let impl__squeeze (v_RATE: usize) (self: t_KeccakXofState v_RATE) (out: t_Slice 
               Hax_lib.Int.t_Int)
             <:
             bool))
-      (offset, out, self <: (usize & t_Slice u8 & t_KeccakXofState v_RATE))
+      (offset, out, state <: (usize & t_Slice u8 & t_KeccakXofState v_RATE))
       (fun temp_0_ e_k ->
-          let (offset: usize), (out: t_Slice u8), (self: t_KeccakXofState v_RATE) = temp_0_ in
+          let (offset: usize), (out: t_Slice u8), (state: t_KeccakXofState v_RATE) = temp_0_ in
           let e_k:usize = e_k in
-          let self:t_KeccakXofState v_RATE =
-            { self with f_inner = keccakf1600 self.f_inner } <: t_KeccakXofState v_RATE
+          let state:t_KeccakXofState v_RATE =
+            { state with f_inner = keccakf1600 state.f_inner } <: t_KeccakXofState v_RATE
           in
           let out:t_Slice u8 =
             Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
@@ -892,7 +894,7 @@ let impl__squeeze (v_RATE: usize) (self: t_KeccakXofState v_RATE) (out: t_Slice 
                 <:
                 Core_models.Ops.Range.t_Range usize)
               (Libcrux_iot_sha3.State.impl_KeccakState__store v_RATE
-                  self.f_inner
+                  state.f_inner
                   (out.[ {
                         Core_models.Ops.Range.f_start = offset;
                         Core_models.Ops.Range.f_end = offset +! v_RATE <: usize
@@ -905,9 +907,9 @@ let impl__squeeze (v_RATE: usize) (self: t_KeccakXofState v_RATE) (out: t_Slice 
                 t_Slice u8)
           in
           let offset:usize = offset +! v_RATE in
-          offset, out, self <: (usize & t_Slice u8 & t_KeccakXofState v_RATE))
+          offset, out, state <: (usize & t_Slice u8 & t_KeccakXofState v_RATE))
   in
-  let (out: t_Slice u8), (self: t_KeccakXofState v_RATE) =
+  let (out: t_Slice u8), (state: t_KeccakXofState v_RATE) =
     if last >. mk_usize 0 && last <. out_len
     then
       let _:Prims.unit =
@@ -919,14 +921,14 @@ let impl__squeeze (v_RATE: usize) (self: t_KeccakXofState v_RATE) (out: t_Slice 
           in
           ()
       in
-      let self:t_KeccakXofState v_RATE =
-        { self with f_inner = keccakf1600 self.f_inner } <: t_KeccakXofState v_RATE
+      let state:t_KeccakXofState v_RATE =
+        { state with f_inner = keccakf1600 state.f_inner } <: t_KeccakXofState v_RATE
       in
       let out:t_Slice u8 =
         Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from out
           ({ Core_models.Ops.Range.f_start = offset } <: Core_models.Ops.Range.t_RangeFrom usize)
           (Libcrux_iot_sha3.State.impl_KeccakState__store v_RATE
-              self.f_inner
+              state.f_inner
               (out.[ { Core_models.Ops.Range.f_start = offset }
                   <:
                   Core_models.Ops.Range.t_RangeFrom usize ]
@@ -935,10 +937,26 @@ let impl__squeeze (v_RATE: usize) (self: t_KeccakXofState v_RATE) (out: t_Slice 
             <:
             t_Slice u8)
       in
-      out, self <: (t_Slice u8 & t_KeccakXofState v_RATE)
-    else out, self <: (t_Slice u8 & t_KeccakXofState v_RATE)
+      out, state <: (t_Slice u8 & t_KeccakXofState v_RATE)
+    else out, state <: (t_Slice u8 & t_KeccakXofState v_RATE)
   in
-  let self:t_KeccakXofState v_RATE = { self with f_sponge = true } <: t_KeccakXofState v_RATE in
+  let state:t_KeccakXofState v_RATE = { state with f_sponge = true } <: t_KeccakXofState v_RATE in
+  state, out <: (t_KeccakXofState v_RATE & t_Slice u8)
+
+#pop-options
+
+/// Squeeze `N` x `LEN` bytes.
+let impl__squeeze (v_RATE: usize) (self: t_KeccakXofState v_RATE) (out: t_Slice u8)
+    : Prims.Pure (t_KeccakXofState v_RATE & t_Slice u8)
+      (requires
+        v_RATE =. mk_usize 168 || v_RATE =. mk_usize 144 || v_RATE =. mk_usize 136 ||
+        v_RATE =. mk_usize 104 ||
+        v_RATE =. mk_usize 72)
+      (fun _ -> Prims.l_True) =
+  let (tmp0: t_KeccakXofState v_RATE), (tmp1: t_Slice u8) = e_squeeze v_RATE self out in
+  let self:t_KeccakXofState v_RATE = tmp0 in
+  let out:t_Slice u8 = tmp1 in
+  let _:Prims.unit = () in
   self, out <: (t_KeccakXofState v_RATE & t_Slice u8)
 
 let absorb_block
@@ -948,7 +966,7 @@ let absorb_block
       (start: usize)
     : Prims.Pure Libcrux_iot_sha3.State.t_KeccakState
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
         ((Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) +
           (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
           <:
@@ -972,7 +990,7 @@ let absorb_final
     : Prims.Pure Libcrux_iot_sha3.State.t_KeccakState
       (requires
         v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
-        v_RATE <=. mk_usize 144 &&
+        v_RATE <=. mk_usize 168 &&
         len <. v_RATE &&
         ((Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) +
           (Rust_primitives.Hax.Int.from_machine len <: Hax_lib.Int.t_Int)
@@ -1043,26 +1061,160 @@ let absorb_final
 let squeeze_first_block (v_RATE: usize) (s: Libcrux_iot_sha3.State.t_KeccakState) (out: t_Slice u8)
     : Prims.Pure (t_Slice u8)
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
         v_RATE <=. (Core_models.Slice.impl__len #u8 out <: usize))
-      (fun _ -> Prims.l_True) =
+      (ensures
+        fun out_future ->
+          let out_future:t_Slice u8 = out_future in
+          (Core_models.Slice.impl__len #u8 out_future <: usize) =.
+          (Core_models.Slice.impl__len #u8 out <: usize)) =
   let out:t_Slice u8 = Libcrux_iot_sha3.State.impl_KeccakState__store_block v_RATE s out in
   out
 
 let squeeze_next_block (v_RATE: usize) (s: Libcrux_iot_sha3.State.t_KeccakState) (out: t_Slice u8)
     : Prims.Pure (Libcrux_iot_sha3.State.t_KeccakState & t_Slice u8)
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
         v_RATE <=. (Core_models.Slice.impl__len #u8 out <: usize))
-      (fun _ -> Prims.l_True) =
+      (ensures
+        fun temp_0_ ->
+          let (s_future: Libcrux_iot_sha3.State.t_KeccakState), (out_future: t_Slice u8) =
+            temp_0_
+          in
+          (Core_models.Slice.impl__len #u8 out_future <: usize) =.
+          (Core_models.Slice.impl__len #u8 out <: usize)) =
   let s:Libcrux_iot_sha3.State.t_KeccakState = keccakf1600 s in
   let out:t_Slice u8 = Libcrux_iot_sha3.State.impl_KeccakState__store_block v_RATE s out in
+  s, out <: (Libcrux_iot_sha3.State.t_KeccakState & t_Slice u8)
+
+let squeeze_first_three_blocks
+      (v_RATE: usize)
+      (s: Libcrux_iot_sha3.State.t_KeccakState)
+      (out: t_Slice u8)
+    : Prims.Pure (Libcrux_iot_sha3.State.t_KeccakState & t_Slice u8)
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
+        (mk_usize 3 *! v_RATE <: usize) <=. (Core_models.Slice.impl__len #u8 out <: usize))
+      (fun _ -> Prims.l_True) =
+  let out:t_Slice u8 = squeeze_first_block v_RATE s out in
+  let (tmp0: Libcrux_iot_sha3.State.t_KeccakState), (tmp1: t_Slice u8) =
+    squeeze_next_block v_RATE
+      s
+      (out.[ { Core_models.Ops.Range.f_start = v_RATE } <: Core_models.Ops.Range.t_RangeFrom usize ]
+        <:
+        t_Slice u8)
+  in
+  let s:Libcrux_iot_sha3.State.t_KeccakState = tmp0 in
+  let out:t_Slice u8 =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from out
+      ({ Core_models.Ops.Range.f_start = v_RATE } <: Core_models.Ops.Range.t_RangeFrom usize)
+      tmp1
+  in
+  let _:Prims.unit = () in
+  let (tmp0: Libcrux_iot_sha3.State.t_KeccakState), (tmp1: t_Slice u8) =
+    squeeze_next_block v_RATE
+      s
+      (out.[ { Core_models.Ops.Range.f_start = mk_usize 2 *! v_RATE <: usize }
+          <:
+          Core_models.Ops.Range.t_RangeFrom usize ]
+        <:
+        t_Slice u8)
+  in
+  let s:Libcrux_iot_sha3.State.t_KeccakState = tmp0 in
+  let out:t_Slice u8 =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from out
+      ({ Core_models.Ops.Range.f_start = mk_usize 2 *! v_RATE <: usize }
+        <:
+        Core_models.Ops.Range.t_RangeFrom usize)
+      tmp1
+  in
+  let _:Prims.unit = () in
+  s, out <: (Libcrux_iot_sha3.State.t_KeccakState & t_Slice u8)
+
+let squeeze_first_five_blocks
+      (v_RATE: usize)
+      (s: Libcrux_iot_sha3.State.t_KeccakState)
+      (out: t_Slice u8)
+    : Prims.Pure (Libcrux_iot_sha3.State.t_KeccakState & t_Slice u8)
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
+        (mk_usize 5 *! v_RATE <: usize) <=. (Core_models.Slice.impl__len #u8 out <: usize))
+      (fun _ -> Prims.l_True) =
+  let out:t_Slice u8 = squeeze_first_block v_RATE s out in
+  let (tmp0: Libcrux_iot_sha3.State.t_KeccakState), (tmp1: t_Slice u8) =
+    squeeze_next_block v_RATE
+      s
+      (out.[ { Core_models.Ops.Range.f_start = v_RATE } <: Core_models.Ops.Range.t_RangeFrom usize ]
+        <:
+        t_Slice u8)
+  in
+  let s:Libcrux_iot_sha3.State.t_KeccakState = tmp0 in
+  let out:t_Slice u8 =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from out
+      ({ Core_models.Ops.Range.f_start = v_RATE } <: Core_models.Ops.Range.t_RangeFrom usize)
+      tmp1
+  in
+  let _:Prims.unit = () in
+  let (tmp0: Libcrux_iot_sha3.State.t_KeccakState), (tmp1: t_Slice u8) =
+    squeeze_next_block v_RATE
+      s
+      (out.[ { Core_models.Ops.Range.f_start = mk_usize 2 *! v_RATE <: usize }
+          <:
+          Core_models.Ops.Range.t_RangeFrom usize ]
+        <:
+        t_Slice u8)
+  in
+  let s:Libcrux_iot_sha3.State.t_KeccakState = tmp0 in
+  let out:t_Slice u8 =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from out
+      ({ Core_models.Ops.Range.f_start = mk_usize 2 *! v_RATE <: usize }
+        <:
+        Core_models.Ops.Range.t_RangeFrom usize)
+      tmp1
+  in
+  let _:Prims.unit = () in
+  let (tmp0: Libcrux_iot_sha3.State.t_KeccakState), (tmp1: t_Slice u8) =
+    squeeze_next_block v_RATE
+      s
+      (out.[ { Core_models.Ops.Range.f_start = mk_usize 3 *! v_RATE <: usize }
+          <:
+          Core_models.Ops.Range.t_RangeFrom usize ]
+        <:
+        t_Slice u8)
+  in
+  let s:Libcrux_iot_sha3.State.t_KeccakState = tmp0 in
+  let out:t_Slice u8 =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from out
+      ({ Core_models.Ops.Range.f_start = mk_usize 3 *! v_RATE <: usize }
+        <:
+        Core_models.Ops.Range.t_RangeFrom usize)
+      tmp1
+  in
+  let _:Prims.unit = () in
+  let (tmp0: Libcrux_iot_sha3.State.t_KeccakState), (tmp1: t_Slice u8) =
+    squeeze_next_block v_RATE
+      s
+      (out.[ { Core_models.Ops.Range.f_start = mk_usize 4 *! v_RATE <: usize }
+          <:
+          Core_models.Ops.Range.t_RangeFrom usize ]
+        <:
+        t_Slice u8)
+  in
+  let s:Libcrux_iot_sha3.State.t_KeccakState = tmp0 in
+  let out:t_Slice u8 =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from out
+      ({ Core_models.Ops.Range.f_start = mk_usize 4 *! v_RATE <: usize }
+        <:
+        Core_models.Ops.Range.t_RangeFrom usize)
+      tmp1
+  in
+  let _:Prims.unit = () in
   s, out <: (Libcrux_iot_sha3.State.t_KeccakState & t_Slice u8)
 
 let squeeze_last (v_RATE: usize) (s: Libcrux_iot_sha3.State.t_KeccakState) (out: t_Slice u8)
     : Prims.Pure (t_Slice u8)
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
         (Core_models.Slice.impl__len #u8 out <: usize) <=. mk_usize 200)
       (fun _ -> Prims.l_True) =
   let s:Libcrux_iot_sha3.State.t_KeccakState = keccakf1600 s in
@@ -1094,7 +1246,7 @@ let squeeze_first_and_last
       (out: t_Slice u8)
     : Prims.Pure (t_Slice u8)
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
         (Core_models.Slice.impl__len #u8 out <: usize) <=. mk_usize 200)
       (fun _ -> Prims.l_True) =
   let b:t_Array u8 (mk_usize 200) =
@@ -1125,7 +1277,7 @@ let keccak (v_RATE: usize) (v_DELIM: u8) (data out: t_Slice u8)
     : Prims.Pure (t_Slice u8)
       (requires
         v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
-        v_RATE <=. mk_usize 144)
+        v_RATE <=. mk_usize 168)
       (ensures
         fun out_future ->
           let out_future:t_Slice u8 = out_future in
@@ -1137,33 +1289,27 @@ let keccak (v_RATE: usize) (v_DELIM: u8) (data out: t_Slice u8)
   let blocks:usize = outlen /! v_RATE in
   let last:usize = outlen -! (outlen %! v_RATE <: usize) in
   let s:Libcrux_iot_sha3.State.t_KeccakState = Libcrux_iot_sha3.State.impl_KeccakState__new () in
-  let s:Libcrux_iot_sha3.State.t_KeccakState =
+  let start:usize = mk_usize 0 in
+  let (s: Libcrux_iot_sha3.State.t_KeccakState), (start: usize) =
     Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
       n
-      (fun s i ->
-          let s:Libcrux_iot_sha3.State.t_KeccakState = s in
-          let i:usize = i in
-          ((((Rust_primitives.Hax.Int.from_machine i <: Hax_lib.Int.t_Int) *
-                (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
-                <:
-                Hax_lib.Int.t_Int) +
-              (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
-              <:
-              Hax_lib.Int.t_Int) <=
-            (Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 data <: usize)
-              <:
-              Hax_lib.Int.t_Int)
+      (fun temp_0_ e_i ->
+          let (s: Libcrux_iot_sha3.State.t_KeccakState), (start: usize) = temp_0_ in
+          let e_i:usize = e_i in
+          (Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) =
+          ((Rust_primitives.Hax.Int.from_machine e_i <: Hax_lib.Int.t_Int) *
+            (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
             <:
-            bool) &&
-          ((Core_models.Slice.impl__len #u8 out <: usize) =. outlen <: bool))
-      s
-      (fun s i ->
-          let s:Libcrux_iot_sha3.State.t_KeccakState = s in
-          let i:usize = i in
-          let s:Libcrux_iot_sha3.State.t_KeccakState =
-            absorb_block v_RATE s data (i *! v_RATE <: usize)
-          in
-          s)
+            Hax_lib.Int.t_Int)
+          <:
+          bool)
+      (s, start <: (Libcrux_iot_sha3.State.t_KeccakState & usize))
+      (fun temp_0_ e_i ->
+          let (s: Libcrux_iot_sha3.State.t_KeccakState), (start: usize) = temp_0_ in
+          let e_i:usize = e_i in
+          let s:Libcrux_iot_sha3.State.t_KeccakState = absorb_block v_RATE s data start in
+          let start:usize = start +! v_RATE in
+          s, start <: (Libcrux_iot_sha3.State.t_KeccakState & usize))
   in
   let s:Libcrux_iot_sha3.State.t_KeccakState =
     absorb_final v_RATE
@@ -1172,5 +1318,82 @@ let keccak (v_RATE: usize) (v_DELIM: u8) (data out: t_Slice u8)
       data
       ((Core_models.Slice.impl__len #u8 data <: usize) -! rem <: usize)
       rem
+  in
+  let (out: t_Slice u8), (s: Libcrux_iot_sha3.State.t_KeccakState) =
+    if blocks =. mk_usize 0
+    then
+      squeeze_first_and_last v_RATE s out, s <: (t_Slice u8 & Libcrux_iot_sha3.State.t_KeccakState)
+    else
+      let out:t_Slice u8 = squeeze_first_block v_RATE s out in
+      let offset:usize = v_RATE in
+      let (offset: usize), (out: t_Slice u8), (s: Libcrux_iot_sha3.State.t_KeccakState) =
+        Rust_primitives.Hax.Folds.fold_range (mk_usize 1)
+          blocks
+          (fun temp_0_ e_i ->
+              let (offset: usize), (out: t_Slice u8), (s: Libcrux_iot_sha3.State.t_KeccakState) =
+                temp_0_
+              in
+              let e_i:usize = e_i in
+              ((Core_models.Slice.impl__len #u8 out <: usize) =. outlen <: bool) &&
+              ((Rust_primitives.Hax.Int.from_machine offset <: Hax_lib.Int.t_Int) =
+                ((Rust_primitives.Hax.Int.from_machine e_i <: Hax_lib.Int.t_Int) *
+                  (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
+                  <:
+                  Hax_lib.Int.t_Int)
+                <:
+                bool))
+          (offset, out, s <: (usize & t_Slice u8 & Libcrux_iot_sha3.State.t_KeccakState))
+          (fun temp_0_ e_i ->
+              let (offset: usize), (out: t_Slice u8), (s: Libcrux_iot_sha3.State.t_KeccakState) =
+                temp_0_
+              in
+              let e_i:usize = e_i in
+              let (tmp0: Libcrux_iot_sha3.State.t_KeccakState), (tmp1: t_Slice u8) =
+                squeeze_next_block v_RATE
+                  s
+                  (out.[ { Core_models.Ops.Range.f_start = offset }
+                      <:
+                      Core_models.Ops.Range.t_RangeFrom usize ]
+                    <:
+                    t_Slice u8)
+              in
+              let s:Libcrux_iot_sha3.State.t_KeccakState = tmp0 in
+              let out:t_Slice u8 =
+                Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from out
+                  ({ Core_models.Ops.Range.f_start = offset }
+                    <:
+                    Core_models.Ops.Range.t_RangeFrom usize)
+                  tmp1
+              in
+              let _:Prims.unit = () in
+              let offset:usize = offset +! v_RATE in
+              offset, out, s <: (usize & t_Slice u8 & Libcrux_iot_sha3.State.t_KeccakState))
+      in
+      if last <. outlen
+      then
+        let _:Prims.unit =
+          if true
+          then
+            let _:Prims.unit =
+              match last, offset <: (usize & usize) with
+              | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
+            in
+            ()
+        in
+        Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from out
+          ({ Core_models.Ops.Range.f_start = offset } <: Core_models.Ops.Range.t_RangeFrom usize)
+          (squeeze_last v_RATE
+              s
+              (out.[ { Core_models.Ops.Range.f_start = offset }
+                  <:
+                  Core_models.Ops.Range.t_RangeFrom usize ]
+                <:
+                t_Slice u8)
+            <:
+            t_Slice u8),
+        s
+        <:
+        (t_Slice u8 & Libcrux_iot_sha3.State.t_KeccakState)
+      else out, s <: (t_Slice u8 & Libcrux_iot_sha3.State.t_KeccakState)
   in
   out

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
@@ -1100,21 +1100,21 @@ let impl__absorb_final
 
 #push-options "--z3rlimit 60"
 
-let e_squeeze (v_RATE: usize) (state: t_KeccakXofState v_RATE) (out: t_Slice u8)
+let e_squeeze (v_RATE: usize) (keccak_state: t_KeccakXofState v_RATE) (out: t_Slice u8)
     : Prims.Pure (t_KeccakXofState v_RATE & t_Slice u8)
       (requires
         v_RATE =. mk_usize 168 || v_RATE =. mk_usize 144 || v_RATE =. mk_usize 136 ||
         v_RATE =. mk_usize 104 ||
         v_RATE =. mk_usize 72)
       (fun _ -> Prims.l_True) =
-  let state:t_KeccakXofState v_RATE =
-    if state.f_sponge
+  let keccak_state:t_KeccakXofState v_RATE =
+    if keccak_state.f_sponge
     then
-      let state:t_KeccakXofState v_RATE =
-        { state with f_inner = keccakf1600 state.f_inner } <: t_KeccakXofState v_RATE
+      let keccak_state:t_KeccakXofState v_RATE =
+        { keccak_state with f_inner = keccakf1600 keccak_state.f_inner } <: t_KeccakXofState v_RATE
       in
-      state
-    else state
+      keccak_state
+    else keccak_state
   in
   let out_len:usize = Core_models.Slice.impl__len #u8 out in
   let blocks:usize = out_len /! v_RATE in
@@ -1124,7 +1124,7 @@ let e_squeeze (v_RATE: usize) (state: t_KeccakXofState v_RATE) (out: t_Slice u8)
     Rust_primitives.Hax.Monomorphized_update_at.update_at_range_to out
       ({ Core_models.Ops.Range.f_end = mid } <: Core_models.Ops.Range.t_RangeTo usize)
       (Libcrux_iot_sha3.State.impl_KeccakState__store v_RATE
-          state.f_inner
+          keccak_state.f_inner
           (out.[ { Core_models.Ops.Range.f_end = mid } <: Core_models.Ops.Range.t_RangeTo usize ]
             <:
             t_Slice u8)
@@ -1132,11 +1132,13 @@ let e_squeeze (v_RATE: usize) (state: t_KeccakXofState v_RATE) (out: t_Slice u8)
         t_Slice u8)
   in
   let offset:usize = mid in
-  let (offset: usize), (out: t_Slice u8), (state: t_KeccakXofState v_RATE) =
+  let (keccak_state: t_KeccakXofState v_RATE), (offset: usize), (out: t_Slice u8) =
     Rust_primitives.Hax.Folds.fold_range (mk_usize 1)
       blocks
       (fun temp_0_ e_k ->
-          let (offset: usize), (out: t_Slice u8), (state: t_KeccakXofState v_RATE) = temp_0_ in
+          let (keccak_state: t_KeccakXofState v_RATE), (offset: usize), (out: t_Slice u8) =
+            temp_0_
+          in
           let e_k:usize = e_k in
           ((Core_models.Slice.impl__len #u8 out <: usize) =. out_len <: bool) &&
           ((Rust_primitives.Hax.Int.from_machine offset <: Hax_lib.Int.t_Int) =
@@ -1146,12 +1148,16 @@ let e_squeeze (v_RATE: usize) (state: t_KeccakXofState v_RATE) (out: t_Slice u8)
               Hax_lib.Int.t_Int)
             <:
             bool))
-      (offset, out, state <: (usize & t_Slice u8 & t_KeccakXofState v_RATE))
+      (keccak_state, offset, out <: (t_KeccakXofState v_RATE & usize & t_Slice u8))
       (fun temp_0_ e_k ->
-          let (offset: usize), (out: t_Slice u8), (state: t_KeccakXofState v_RATE) = temp_0_ in
+          let (keccak_state: t_KeccakXofState v_RATE), (offset: usize), (out: t_Slice u8) =
+            temp_0_
+          in
           let e_k:usize = e_k in
-          let state:t_KeccakXofState v_RATE =
-            { state with f_inner = keccakf1600 state.f_inner } <: t_KeccakXofState v_RATE
+          let keccak_state:t_KeccakXofState v_RATE =
+            { keccak_state with f_inner = keccakf1600 keccak_state.f_inner }
+            <:
+            t_KeccakXofState v_RATE
           in
           let out:t_Slice u8 =
             Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
@@ -1162,7 +1168,7 @@ let e_squeeze (v_RATE: usize) (state: t_KeccakXofState v_RATE) (out: t_Slice u8)
                 <:
                 Core_models.Ops.Range.t_Range usize)
               (Libcrux_iot_sha3.State.impl_KeccakState__store v_RATE
-                  state.f_inner
+                  keccak_state.f_inner
                   (out.[ {
                         Core_models.Ops.Range.f_start = offset;
                         Core_models.Ops.Range.f_end = offset +! v_RATE <: usize
@@ -1175,9 +1181,9 @@ let e_squeeze (v_RATE: usize) (state: t_KeccakXofState v_RATE) (out: t_Slice u8)
                 t_Slice u8)
           in
           let offset:usize = offset +! v_RATE in
-          offset, out, state <: (usize & t_Slice u8 & t_KeccakXofState v_RATE))
+          keccak_state, offset, out <: (t_KeccakXofState v_RATE & usize & t_Slice u8))
   in
-  let (out: t_Slice u8), (state: t_KeccakXofState v_RATE) =
+  let (keccak_state: t_KeccakXofState v_RATE), (out: t_Slice u8) =
     if last >. mk_usize 0 && last <. out_len
     then
       let _:Prims.unit =
@@ -1189,14 +1195,14 @@ let e_squeeze (v_RATE: usize) (state: t_KeccakXofState v_RATE) (out: t_Slice u8)
           in
           ()
       in
-      let state:t_KeccakXofState v_RATE =
-        { state with f_inner = keccakf1600 state.f_inner } <: t_KeccakXofState v_RATE
+      let keccak_state:t_KeccakXofState v_RATE =
+        { keccak_state with f_inner = keccakf1600 keccak_state.f_inner } <: t_KeccakXofState v_RATE
       in
       let out:t_Slice u8 =
         Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from out
           ({ Core_models.Ops.Range.f_start = offset } <: Core_models.Ops.Range.t_RangeFrom usize)
           (Libcrux_iot_sha3.State.impl_KeccakState__store v_RATE
-              state.f_inner
+              keccak_state.f_inner
               (out.[ { Core_models.Ops.Range.f_start = offset }
                   <:
                   Core_models.Ops.Range.t_RangeFrom usize ]
@@ -1205,11 +1211,13 @@ let e_squeeze (v_RATE: usize) (state: t_KeccakXofState v_RATE) (out: t_Slice u8)
             <:
             t_Slice u8)
       in
-      out, state <: (t_Slice u8 & t_KeccakXofState v_RATE)
-    else out, state <: (t_Slice u8 & t_KeccakXofState v_RATE)
+      keccak_state, out <: (t_KeccakXofState v_RATE & t_Slice u8)
+    else keccak_state, out <: (t_KeccakXofState v_RATE & t_Slice u8)
   in
-  let state:t_KeccakXofState v_RATE = { state with f_sponge = true } <: t_KeccakXofState v_RATE in
-  state, out <: (t_KeccakXofState v_RATE & t_Slice u8)
+  let keccak_state:t_KeccakXofState v_RATE =
+    { keccak_state with f_sponge = true } <: t_KeccakXofState v_RATE
+  in
+  keccak_state, out <: (t_KeccakXofState v_RATE & t_Slice u8)
 
 #pop-options
 

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
@@ -1,0 +1,1176 @@
+module Libcrux_iot_sha3.Keccak
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Libcrux_secrets.Int.Public_integers in
+  let open Libcrux_secrets.Traits in
+  ()
+
+/// The internal keccak state that can also buffer inputs to absorb.
+/// This is used in the general xof APIs.
+type t_KeccakXofState (v_RATE: usize) = {
+  f_inner:Libcrux_iot_sha3.State.t_KeccakState;
+  f_buf:t_Array u8 v_RATE;
+  f_buf_len:usize;
+  f_sponge:bool
+}
+
+/// An all zero block
+let impl__zero_block (v_RATE: usize) (_: Prims.unit) : t_Array u8 v_RATE =
+  Libcrux_secrets.Traits.f_classify #(t_Array u8 v_RATE)
+    #FStar.Tactics.Typeclasses.solve
+    (Rust_primitives.Hax.repeat (mk_u8 0) v_RATE <: t_Array u8 v_RATE)
+
+/// Generate a new keccak xof state.
+let impl__new (v_RATE: usize) (_: Prims.unit) : t_KeccakXofState v_RATE =
+  {
+    f_inner = Libcrux_iot_sha3.State.impl_KeccakState__new ();
+    f_buf = impl__zero_block v_RATE ();
+    f_buf_len = mk_usize 0;
+    f_sponge = false
+  }
+  <:
+  t_KeccakXofState v_RATE
+
+/// Consume the internal buffer and the required amount of the input to pad to
+/// `RATE`.
+/// Returns the `consumed` bytes from `inputs` if there\'s enough buffered
+/// content to consume, and `0` otherwise.
+/// If `consumed > 0` is returned, `self.buf` contains a full block to be
+/// loaded.
+let impl__fill_buffer (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t_Slice u8)
+    : Prims.Pure (t_KeccakXofState v_RATE & usize)
+      (requires
+        self.f_buf_len <=. v_RATE &&
+        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
+            <:
+            Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int))
+      (ensures
+        fun temp_0_ ->
+          let (self_e_future: t_KeccakXofState v_RATE), (res: usize) = temp_0_ in
+          b2t (res <=. v_RATE <: bool) /\ b2t (self_e_future.f_buf_len <=. v_RATE <: bool) /\
+          (b2t (res >. mk_usize 0 <: bool) ==> b2t (self_e_future.f_buf_len =. v_RATE <: bool))) =
+  let input_len:usize = Core_models.Slice.impl__len #u8 inputs in
+  let consumed:usize = mk_usize 0 in
+  let (consumed: usize), (self: t_KeccakXofState v_RATE) =
+    if self.f_buf_len >. mk_usize 0
+    then
+      if (self.f_buf_len +! input_len <: usize) >=. v_RATE
+      then
+        let consumed:usize = v_RATE -! self.f_buf_len in
+        let self:t_KeccakXofState v_RATE =
+          {
+            self with
+            f_buf
+            =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from self.f_buf
+              ({ Core_models.Ops.Range.f_start = self.f_buf_len }
+                <:
+                Core_models.Ops.Range.t_RangeFrom usize)
+              (Core_models.Slice.impl__copy_from_slice #u8
+                  (self.f_buf.[ { Core_models.Ops.Range.f_start = self.f_buf_len }
+                      <:
+                      Core_models.Ops.Range.t_RangeFrom usize ]
+                    <:
+                    t_Slice u8)
+                  (inputs.[ { Core_models.Ops.Range.f_end = consumed }
+                      <:
+                      Core_models.Ops.Range.t_RangeTo usize ]
+                    <:
+                    t_Slice u8)
+                <:
+                t_Slice u8)
+          }
+          <:
+          t_KeccakXofState v_RATE
+        in
+        let self:t_KeccakXofState v_RATE =
+          { self with f_buf_len = self.f_buf_len +! consumed } <: t_KeccakXofState v_RATE
+        in
+        consumed, self <: (usize & t_KeccakXofState v_RATE)
+      else consumed, self <: (usize & t_KeccakXofState v_RATE)
+    else consumed, self <: (usize & t_KeccakXofState v_RATE)
+  in
+  let hax_temp_output:usize = consumed in
+  self, hax_temp_output <: (t_KeccakXofState v_RATE & usize)
+
+assume
+val v_RC_INTERLEAVED_0_': t_Array u32 (mk_usize 255)
+
+unfold
+let v_RC_INTERLEAVED_0_ = v_RC_INTERLEAVED_0_'
+
+assume
+val v_RC_INTERLEAVED_1_': t_Array u32 (mk_usize 255)
+
+unfold
+let v_RC_INTERLEAVED_1_ = v_RC_INTERLEAVED_1_'
+
+assume
+val keccakf1600_round0_theta_c_x0_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_theta_c_x0_z0 = keccakf1600_round0_theta_c_x0_z0'
+
+assume
+val keccakf1600_round0_theta_c_x0_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_theta_c_x0_z1 = keccakf1600_round0_theta_c_x0_z1'
+
+assume
+val keccakf1600_round0_theta_c_x1_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_theta_c_x1_z0 = keccakf1600_round0_theta_c_x1_z0'
+
+assume
+val keccakf1600_round0_theta_c_x1_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_theta_c_x1_z1 = keccakf1600_round0_theta_c_x1_z1'
+
+assume
+val keccakf1600_round0_theta_c_x2_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_theta_c_x2_z0 = keccakf1600_round0_theta_c_x2_z0'
+
+assume
+val keccakf1600_round0_theta_c_x2_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_theta_c_x2_z1 = keccakf1600_round0_theta_c_x2_z1'
+
+assume
+val keccakf1600_round0_theta_c_x3_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_theta_c_x3_z0 = keccakf1600_round0_theta_c_x3_z0'
+
+assume
+val keccakf1600_round0_theta_c_x3_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_theta_c_x3_z1 = keccakf1600_round0_theta_c_x3_z1'
+
+assume
+val keccakf1600_round0_theta_c_x4_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_theta_c_x4_z0 = keccakf1600_round0_theta_c_x4_z0'
+
+assume
+val keccakf1600_round0_theta_c_x4_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_theta_c_x4_z1 = keccakf1600_round0_theta_c_x4_z1'
+
+assume
+val keccakf1600_round0_theta_d': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_theta_d = keccakf1600_round0_theta_d'
+
+assume
+val keccakf1600_round0_theta': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_theta = keccakf1600_round0_theta'
+
+assume
+val keccakf1600_round0_pi_rho_chi_1_':
+    v_BASE_ROUND: usize ->
+    s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_pi_rho_chi_1_ (v_BASE_ROUND: usize) =
+  keccakf1600_round0_pi_rho_chi_1_' v_BASE_ROUND
+
+assume
+val keccakf1600_round0_pi_rho_chi_2_': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_pi_rho_chi_2_ = keccakf1600_round0_pi_rho_chi_2_'
+
+assume
+val keccakf1600_round1_theta_c_x0_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_theta_c_x0_z0 = keccakf1600_round1_theta_c_x0_z0'
+
+assume
+val keccakf1600_round1_theta_c_x0_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_theta_c_x0_z1 = keccakf1600_round1_theta_c_x0_z1'
+
+assume
+val keccakf1600_round1_theta_c_x1_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_theta_c_x1_z0 = keccakf1600_round1_theta_c_x1_z0'
+
+assume
+val keccakf1600_round1_theta_c_x1_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_theta_c_x1_z1 = keccakf1600_round1_theta_c_x1_z1'
+
+assume
+val keccakf1600_round1_theta_c_x2_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_theta_c_x2_z0 = keccakf1600_round1_theta_c_x2_z0'
+
+assume
+val keccakf1600_round1_theta_c_x2_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_theta_c_x2_z1 = keccakf1600_round1_theta_c_x2_z1'
+
+assume
+val keccakf1600_round1_theta_c_x3_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_theta_c_x3_z0 = keccakf1600_round1_theta_c_x3_z0'
+
+assume
+val keccakf1600_round1_theta_c_x3_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_theta_c_x3_z1 = keccakf1600_round1_theta_c_x3_z1'
+
+assume
+val keccakf1600_round1_theta_c_x4_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_theta_c_x4_z0 = keccakf1600_round1_theta_c_x4_z0'
+
+assume
+val keccakf1600_round1_theta_c_x4_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_theta_c_x4_z1 = keccakf1600_round1_theta_c_x4_z1'
+
+assume
+val keccakf1600_round1_theta_d': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_theta_d = keccakf1600_round1_theta_d'
+
+assume
+val keccakf1600_round1_theta': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_theta = keccakf1600_round1_theta'
+
+assume
+val keccakf1600_round1_pi_rho_chi_1_':
+    v_BASE_ROUND: usize ->
+    s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_pi_rho_chi_1_ (v_BASE_ROUND: usize) =
+  keccakf1600_round1_pi_rho_chi_1_' v_BASE_ROUND
+
+assume
+val keccakf1600_round1_pi_rho_chi_2_': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_pi_rho_chi_2_ = keccakf1600_round1_pi_rho_chi_2_'
+
+assume
+val keccakf1600_round2_theta_c_x0_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_theta_c_x0_z0 = keccakf1600_round2_theta_c_x0_z0'
+
+assume
+val keccakf1600_round2_theta_c_x0_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_theta_c_x0_z1 = keccakf1600_round2_theta_c_x0_z1'
+
+assume
+val keccakf1600_round2_theta_c_x1_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_theta_c_x1_z0 = keccakf1600_round2_theta_c_x1_z0'
+
+assume
+val keccakf1600_round2_theta_c_x1_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_theta_c_x1_z1 = keccakf1600_round2_theta_c_x1_z1'
+
+assume
+val keccakf1600_round2_theta_c_x2_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_theta_c_x2_z0 = keccakf1600_round2_theta_c_x2_z0'
+
+assume
+val keccakf1600_round2_theta_c_x2_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_theta_c_x2_z1 = keccakf1600_round2_theta_c_x2_z1'
+
+assume
+val keccakf1600_round2_theta_c_x3_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_theta_c_x3_z0 = keccakf1600_round2_theta_c_x3_z0'
+
+assume
+val keccakf1600_round2_theta_c_x3_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_theta_c_x3_z1 = keccakf1600_round2_theta_c_x3_z1'
+
+assume
+val keccakf1600_round2_theta_c_x4_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_theta_c_x4_z0 = keccakf1600_round2_theta_c_x4_z0'
+
+assume
+val keccakf1600_round2_theta_c_x4_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_theta_c_x4_z1 = keccakf1600_round2_theta_c_x4_z1'
+
+assume
+val keccakf1600_round2_theta_d': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_theta_d = keccakf1600_round2_theta_d'
+
+assume
+val keccakf1600_round2_theta': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_theta = keccakf1600_round2_theta'
+
+assume
+val keccakf1600_round2_pi_rho_chi_1_':
+    v_BASE_ROUND: usize ->
+    s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_pi_rho_chi_1_ (v_BASE_ROUND: usize) =
+  keccakf1600_round2_pi_rho_chi_1_' v_BASE_ROUND
+
+assume
+val keccakf1600_round2_pi_rho_chi_2_': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_pi_rho_chi_2_ = keccakf1600_round2_pi_rho_chi_2_'
+
+assume
+val keccakf1600_round3_theta_c_x0_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_theta_c_x0_z0 = keccakf1600_round3_theta_c_x0_z0'
+
+assume
+val keccakf1600_round3_theta_c_x0_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_theta_c_x0_z1 = keccakf1600_round3_theta_c_x0_z1'
+
+assume
+val keccakf1600_round3_theta_c_x1_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_theta_c_x1_z0 = keccakf1600_round3_theta_c_x1_z0'
+
+assume
+val keccakf1600_round3_theta_c_x1_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_theta_c_x1_z1 = keccakf1600_round3_theta_c_x1_z1'
+
+assume
+val keccakf1600_round3_theta_c_x2_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_theta_c_x2_z0 = keccakf1600_round3_theta_c_x2_z0'
+
+assume
+val keccakf1600_round3_theta_c_x2_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_theta_c_x2_z1 = keccakf1600_round3_theta_c_x2_z1'
+
+assume
+val keccakf1600_round3_theta_c_x3_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_theta_c_x3_z0 = keccakf1600_round3_theta_c_x3_z0'
+
+assume
+val keccakf1600_round3_theta_c_x3_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_theta_c_x3_z1 = keccakf1600_round3_theta_c_x3_z1'
+
+assume
+val keccakf1600_round3_theta_c_x4_z0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_theta_c_x4_z0 = keccakf1600_round3_theta_c_x4_z0'
+
+assume
+val keccakf1600_round3_theta_c_x4_z1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_theta_c_x4_z1 = keccakf1600_round3_theta_c_x4_z1'
+
+assume
+val keccakf1600_round3_theta_d': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_theta_d = keccakf1600_round3_theta_d'
+
+assume
+val keccakf1600_round3_theta': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_theta = keccakf1600_round3_theta'
+
+assume
+val keccakf1600_round3_pi_rho_chi_1_':
+    v_BASE_ROUND: usize ->
+    s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_pi_rho_chi_1_ (v_BASE_ROUND: usize) =
+  keccakf1600_round3_pi_rho_chi_1_' v_BASE_ROUND
+
+assume
+val keccakf1600_round3_pi_rho_chi_2_': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_pi_rho_chi_2_ = keccakf1600_round3_pi_rho_chi_2_'
+
+assume
+val keccakf1600_4rounds': v_BASE_ROUND: usize -> s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_4rounds (v_BASE_ROUND: usize) = keccakf1600_4rounds' v_BASE_ROUND
+
+assume
+val keccakf1600': s: Libcrux_iot_sha3.State.t_KeccakState -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600 = keccakf1600'
+
+let impl__absorb_full (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t_Slice u8)
+    : Prims.Pure (t_KeccakXofState v_RATE & usize)
+      (requires
+        v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
+        v_RATE <=. mk_usize 144 &&
+        self.f_buf_len <. v_RATE &&
+        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
+            <:
+            Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int))
+      (ensures
+        fun temp_0_ ->
+          let (self_e_future: t_KeccakXofState v_RATE), (remainder: usize) = temp_0_ in
+          remainder <. v_RATE && remainder <=. (Core_models.Slice.impl__len #u8 inputs <: usize) &&
+          self_e_future.f_buf_len <=. v_RATE &&
+          ((Rust_primitives.Hax.Int.from_machine self_e_future.f_buf_len <: Hax_lib.Int.t_Int) +
+            (Rust_primitives.Hax.Int.from_machine remainder <: Hax_lib.Int.t_Int)
+            <:
+            Hax_lib.Int.t_Int) <
+          (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int
+          )) =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit = Hax_lib.v_assert (self.f_buf_len <. v_RATE <: bool) in
+      ()
+  in
+  let (tmp0: t_KeccakXofState v_RATE), (out: usize) = impl__fill_buffer v_RATE self inputs in
+  let self:t_KeccakXofState v_RATE = tmp0 in
+  let input_consumed:usize = out in
+  let self:t_KeccakXofState v_RATE =
+    if input_consumed >. mk_usize 0
+    then
+      let self:t_KeccakXofState v_RATE =
+        {
+          self with
+          f_inner
+          =
+          Libcrux_iot_sha3.State.impl_KeccakState__load_block v_RATE
+            self.f_inner
+            (self.f_buf <: t_Slice u8)
+            (mk_usize 0)
+        }
+        <:
+        t_KeccakXofState v_RATE
+      in
+      let self:t_KeccakXofState v_RATE =
+        { self with f_inner = keccakf1600 self.f_inner } <: t_KeccakXofState v_RATE
+      in
+      let self:t_KeccakXofState v_RATE =
+        { self with f_buf_len = mk_usize 0 } <: t_KeccakXofState v_RATE
+      in
+      self
+    else self
+  in
+  let input_to_consume:usize =
+    (Core_models.Slice.impl__len #u8 inputs <: usize) -! input_consumed
+  in
+  let num_blocks:usize = input_to_consume /! v_RATE in
+  let remainder:usize = input_to_consume %! v_RATE in
+  let e_buf_len:usize = self.f_buf_len in
+  let self:t_KeccakXofState v_RATE =
+    Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+      num_blocks
+      (fun self e_i ->
+          let self:t_KeccakXofState v_RATE = self in
+          let e_i:usize = e_i in
+          self.f_buf_len =. e_buf_len <: bool)
+      self
+      (fun self i ->
+          let self:t_KeccakXofState v_RATE = self in
+          let i:usize = i in
+          let self:t_KeccakXofState v_RATE =
+            {
+              self with
+              f_inner
+              =
+              Libcrux_iot_sha3.State.impl_KeccakState__load_block v_RATE
+                self.f_inner
+                inputs
+                (input_consumed +! (i *! v_RATE <: usize) <: usize)
+            }
+            <:
+            t_KeccakXofState v_RATE
+          in
+          let self:t_KeccakXofState v_RATE =
+            { self with f_inner = keccakf1600 self.f_inner } <: t_KeccakXofState v_RATE
+          in
+          self)
+  in
+  let hax_temp_output:usize = remainder in
+  self, hax_temp_output <: (t_KeccakXofState v_RATE & usize)
+
+/// Absorb
+/// This function takes any number of bytes to absorb and buffers if it\'s not enough.
+/// The function assumes that all input slices in `blocks` have the same length.
+/// Only a multiple of `RATE` blocks are absorbed.
+/// For the remaining bytes [`absorb_final`] needs to be called.
+/// This works best with relatively small `inputs`.
+let impl__absorb (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t_Slice u8)
+    : Prims.Pure (t_KeccakXofState v_RATE)
+      (requires
+        v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
+        v_RATE <=. mk_usize 144 &&
+        self.f_buf_len <. v_RATE &&
+        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
+            <:
+            Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) =
+  let (tmp0: t_KeccakXofState v_RATE), (out: usize) = impl__absorb_full v_RATE self inputs in
+  let self:t_KeccakXofState v_RATE = tmp0 in
+  let input_remainder_len:usize = out in
+  let self:t_KeccakXofState v_RATE =
+    if input_remainder_len >. mk_usize 0
+    then
+      let _:Prims.unit =
+        if true
+        then
+          let _:Prims.unit =
+            Hax_lib.v_assert ((self.f_buf_len =. mk_usize 0 <: bool) ||
+                ((self.f_buf_len +! input_remainder_len <: usize) <=. v_RATE <: bool))
+          in
+          ()
+      in
+      let input_len:usize = Core_models.Slice.impl__len #u8 inputs in
+      let self:t_KeccakXofState v_RATE =
+        {
+          self with
+          f_buf
+          =
+          Rust_primitives.Hax.Monomorphized_update_at.update_at_range self.f_buf
+            ({
+                Core_models.Ops.Range.f_start = self.f_buf_len;
+                Core_models.Ops.Range.f_end = self.f_buf_len +! input_remainder_len <: usize
+              }
+              <:
+              Core_models.Ops.Range.t_Range usize)
+            (Core_models.Slice.impl__copy_from_slice #u8
+                (self.f_buf.[ {
+                      Core_models.Ops.Range.f_start = self.f_buf_len;
+                      Core_models.Ops.Range.f_end = self.f_buf_len +! input_remainder_len <: usize
+                    }
+                    <:
+                    Core_models.Ops.Range.t_Range usize ]
+                  <:
+                  t_Slice u8)
+                (inputs.[ {
+                      Core_models.Ops.Range.f_start = input_len -! input_remainder_len <: usize
+                    }
+                    <:
+                    Core_models.Ops.Range.t_RangeFrom usize ]
+                  <:
+                  t_Slice u8)
+              <:
+              t_Slice u8)
+        }
+        <:
+        t_KeccakXofState v_RATE
+      in
+      let self:t_KeccakXofState v_RATE =
+        { self with f_buf_len = self.f_buf_len +! input_remainder_len } <: t_KeccakXofState v_RATE
+      in
+      self
+    else self
+  in
+  self
+
+/// Absorb a final block.
+/// The `inputs` block may be empty. Everything in the `inputs` block beyond
+/// `RATE` bytes is ignored.
+let impl__absorb_final
+      (v_RATE: usize)
+      (v_DELIMITER: u8)
+      (self: t_KeccakXofState v_RATE)
+      (inputs: t_Slice u8)
+    : Prims.Pure (t_KeccakXofState v_RATE)
+      (requires
+        v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
+        v_RATE <=. mk_usize 144 &&
+        self.f_buf_len <. v_RATE &&
+        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
+            <:
+            Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) =
+  let (tmp0: t_KeccakXofState v_RATE), (out: usize) = impl__absorb_full v_RATE self inputs in
+  let self:t_KeccakXofState v_RATE = tmp0 in
+  let input_remainder_len:usize = out in
+  let input_len:usize = Core_models.Slice.impl__len #u8 inputs in
+  let blocks:t_Array u8 (mk_usize 200) =
+    Libcrux_secrets.Traits.f_classify #(t_Array u8 (mk_usize 200))
+      #FStar.Tactics.Typeclasses.solve
+      (Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 200) <: t_Array u8 (mk_usize 200))
+  in
+  let blocks:t_Array u8 (mk_usize 200) =
+    if self.f_buf_len >. mk_usize 0
+    then
+      let blocks:t_Array u8 (mk_usize 200) =
+        Rust_primitives.Hax.Monomorphized_update_at.update_at_range blocks
+          ({
+              Core_models.Ops.Range.f_start = mk_usize 0;
+              Core_models.Ops.Range.f_end = self.f_buf_len
+            }
+            <:
+            Core_models.Ops.Range.t_Range usize)
+          (Core_models.Slice.impl__copy_from_slice #u8
+              (blocks.[ {
+                    Core_models.Ops.Range.f_start = mk_usize 0;
+                    Core_models.Ops.Range.f_end = self.f_buf_len
+                  }
+                  <:
+                  Core_models.Ops.Range.t_Range usize ]
+                <:
+                t_Slice u8)
+              (self.f_buf.[ {
+                    Core_models.Ops.Range.f_start = mk_usize 0;
+                    Core_models.Ops.Range.f_end = self.f_buf_len
+                  }
+                  <:
+                  Core_models.Ops.Range.t_Range usize ]
+                <:
+                t_Slice u8)
+            <:
+            t_Slice u8)
+      in
+      blocks
+    else blocks
+  in
+  let blocks:t_Array u8 (mk_usize 200) =
+    if input_remainder_len >. mk_usize 0
+    then
+      let blocks:t_Array u8 (mk_usize 200) =
+        Rust_primitives.Hax.Monomorphized_update_at.update_at_range blocks
+          ({
+              Core_models.Ops.Range.f_start = self.f_buf_len;
+              Core_models.Ops.Range.f_end = self.f_buf_len +! input_remainder_len <: usize
+            }
+            <:
+            Core_models.Ops.Range.t_Range usize)
+          (Core_models.Slice.impl__copy_from_slice #u8
+              (blocks.[ {
+                    Core_models.Ops.Range.f_start = self.f_buf_len;
+                    Core_models.Ops.Range.f_end = self.f_buf_len +! input_remainder_len <: usize
+                  }
+                  <:
+                  Core_models.Ops.Range.t_Range usize ]
+                <:
+                t_Slice u8)
+              (inputs.[ {
+                    Core_models.Ops.Range.f_start = input_len -! input_remainder_len <: usize
+                  }
+                  <:
+                  Core_models.Ops.Range.t_RangeFrom usize ]
+                <:
+                t_Slice u8)
+            <:
+            t_Slice u8)
+      in
+      blocks
+    else blocks
+  in
+  let blocks:t_Array u8 (mk_usize 200) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize blocks
+      (self.f_buf_len +! input_remainder_len <: usize)
+      (Libcrux_secrets.Traits.f_classify #u8 #FStar.Tactics.Typeclasses.solve v_DELIMITER <: u8)
+  in
+  let blocks:t_Array u8 (mk_usize 200) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize blocks
+      (v_RATE -! mk_usize 1 <: usize)
+      ((blocks.[ v_RATE -! mk_usize 1 <: usize ] <: u8) |. mk_u8 128 <: u8)
+  in
+  let self:t_KeccakXofState v_RATE =
+    {
+      self with
+      f_inner
+      =
+      Libcrux_iot_sha3.State.impl_KeccakState__load_block_full v_RATE
+        self.f_inner
+        blocks
+        (mk_usize 0)
+    }
+    <:
+    t_KeccakXofState v_RATE
+  in
+  let self:t_KeccakXofState v_RATE =
+    { self with f_inner = keccakf1600 self.f_inner } <: t_KeccakXofState v_RATE
+  in
+  self
+
+/// Squeeze `N` x `LEN` bytes.
+let impl__squeeze (v_RATE: usize) (self: t_KeccakXofState v_RATE) (out: t_Slice u8)
+    : Prims.Pure (t_KeccakXofState v_RATE & t_Slice u8)
+      (requires
+        v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
+        v_RATE <=. mk_usize 144)
+      (fun _ -> Prims.l_True) =
+  let self:t_KeccakXofState v_RATE =
+    if self.f_sponge
+    then
+      let self:t_KeccakXofState v_RATE =
+        { self with f_inner = keccakf1600 self.f_inner } <: t_KeccakXofState v_RATE
+      in
+      self
+    else self
+  in
+  let out_len:usize = Core_models.Slice.impl__len #u8 out in
+  let blocks:usize = out_len /! v_RATE in
+  let last:usize = out_len -! (out_len %! v_RATE <: usize) in
+  let mid:usize = if v_RATE >=. out_len then out_len else v_RATE in
+  let out:t_Slice u8 =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_to out
+      ({ Core_models.Ops.Range.f_end = mid } <: Core_models.Ops.Range.t_RangeTo usize)
+      (Libcrux_iot_sha3.State.impl_KeccakState__store v_RATE
+          self.f_inner
+          (out.[ { Core_models.Ops.Range.f_end = mid } <: Core_models.Ops.Range.t_RangeTo usize ]
+            <:
+            t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  let offset:usize = mid in
+  let (offset: usize), (out: t_Slice u8), (self: t_KeccakXofState v_RATE) =
+    Rust_primitives.Hax.Folds.fold_range (mk_usize 1)
+      blocks
+      (fun temp_0_ e_k ->
+          let (offset: usize), (out: t_Slice u8), (self: t_KeccakXofState v_RATE) = temp_0_ in
+          let e_k:usize = e_k in
+          ((Core_models.Slice.impl__len #u8 out <: usize) =. out_len <: bool) &&
+          ((Rust_primitives.Hax.Int.from_machine offset <: Hax_lib.Int.t_Int) =
+            ((Rust_primitives.Hax.Int.from_machine e_k <: Hax_lib.Int.t_Int) *
+              (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
+              <:
+              Hax_lib.Int.t_Int)
+            <:
+            bool))
+      (offset, out, self <: (usize & t_Slice u8 & t_KeccakXofState v_RATE))
+      (fun temp_0_ e_k ->
+          let (offset: usize), (out: t_Slice u8), (self: t_KeccakXofState v_RATE) = temp_0_ in
+          let e_k:usize = e_k in
+          let self:t_KeccakXofState v_RATE =
+            { self with f_inner = keccakf1600 self.f_inner } <: t_KeccakXofState v_RATE
+          in
+          let out:t_Slice u8 =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+              ({
+                  Core_models.Ops.Range.f_start = offset;
+                  Core_models.Ops.Range.f_end = offset +! v_RATE <: usize
+                }
+                <:
+                Core_models.Ops.Range.t_Range usize)
+              (Libcrux_iot_sha3.State.impl_KeccakState__store v_RATE
+                  self.f_inner
+                  (out.[ {
+                        Core_models.Ops.Range.f_start = offset;
+                        Core_models.Ops.Range.f_end = offset +! v_RATE <: usize
+                      }
+                      <:
+                      Core_models.Ops.Range.t_Range usize ]
+                    <:
+                    t_Slice u8)
+                <:
+                t_Slice u8)
+          in
+          let offset:usize = offset +! v_RATE in
+          offset, out, self <: (usize & t_Slice u8 & t_KeccakXofState v_RATE))
+  in
+  let (out: t_Slice u8), (self: t_KeccakXofState v_RATE) =
+    if last >. mk_usize 0 && last <. out_len
+    then
+      let _:Prims.unit =
+        if true
+        then
+          let _:Prims.unit =
+            match last, offset <: (usize & usize) with
+            | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
+          in
+          ()
+      in
+      let self:t_KeccakXofState v_RATE =
+        { self with f_inner = keccakf1600 self.f_inner } <: t_KeccakXofState v_RATE
+      in
+      let out:t_Slice u8 =
+        Rust_primitives.Hax.Monomorphized_update_at.update_at_range_from out
+          ({ Core_models.Ops.Range.f_start = offset } <: Core_models.Ops.Range.t_RangeFrom usize)
+          (Libcrux_iot_sha3.State.impl_KeccakState__store v_RATE
+              self.f_inner
+              (out.[ { Core_models.Ops.Range.f_start = offset }
+                  <:
+                  Core_models.Ops.Range.t_RangeFrom usize ]
+                <:
+                t_Slice u8)
+            <:
+            t_Slice u8)
+      in
+      out, self <: (t_Slice u8 & t_KeccakXofState v_RATE)
+    else out, self <: (t_Slice u8 & t_KeccakXofState v_RATE)
+  in
+  let self:t_KeccakXofState v_RATE = { self with f_sponge = true } <: t_KeccakXofState v_RATE in
+  self, out <: (t_KeccakXofState v_RATE & t_Slice u8)
+
+let absorb_block
+      (v_RATE: usize)
+      (s: Libcrux_iot_sha3.State.t_KeccakState)
+      (blocks: t_Slice u8)
+      (start: usize)
+    : Prims.Pure Libcrux_iot_sha3.State.t_KeccakState
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        ((Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 blocks <: usize)
+          <:
+          Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) =
+  let s:Libcrux_iot_sha3.State.t_KeccakState =
+    Libcrux_iot_sha3.State.impl_KeccakState__load_block v_RATE s blocks start
+  in
+  let s:Libcrux_iot_sha3.State.t_KeccakState = keccakf1600 s in
+  s
+
+let absorb_final
+      (v_RATE: usize)
+      (v_DELIM: u8)
+      (s: Libcrux_iot_sha3.State.t_KeccakState)
+      (last: t_Slice u8)
+      (start len: usize)
+    : Prims.Pure Libcrux_iot_sha3.State.t_KeccakState
+      (requires
+        v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
+        v_RATE <=. mk_usize 144 &&
+        len <. v_RATE &&
+        ((Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine len <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 last <: usize)
+          <:
+          Hax_lib.Int.t_Int))
+      (fun _ -> Prims.l_True) =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit = Hax_lib.v_assert (len <. v_RATE <: bool) in
+      ()
+  in
+  let blocks:t_Array u8 (mk_usize 200) =
+    Libcrux_secrets.Traits.f_classify #(t_Array u8 (mk_usize 200))
+      #FStar.Tactics.Typeclasses.solve
+      (Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 200) <: t_Array u8 (mk_usize 200))
+  in
+  let blocks:t_Array u8 (mk_usize 200) =
+    if len >. mk_usize 0
+    then
+      let blocks:t_Array u8 (mk_usize 200) =
+        Rust_primitives.Hax.Monomorphized_update_at.update_at_range blocks
+          ({ Core_models.Ops.Range.f_start = mk_usize 0; Core_models.Ops.Range.f_end = len }
+            <:
+            Core_models.Ops.Range.t_Range usize)
+          (Core_models.Slice.impl__copy_from_slice #u8
+              (blocks.[ {
+                    Core_models.Ops.Range.f_start = mk_usize 0;
+                    Core_models.Ops.Range.f_end = len
+                  }
+                  <:
+                  Core_models.Ops.Range.t_Range usize ]
+                <:
+                t_Slice u8)
+              (last.[ {
+                    Core_models.Ops.Range.f_start = start;
+                    Core_models.Ops.Range.f_end = start +! len <: usize
+                  }
+                  <:
+                  Core_models.Ops.Range.t_Range usize ]
+                <:
+                t_Slice u8)
+            <:
+            t_Slice u8)
+      in
+      blocks
+    else blocks
+  in
+  let blocks:t_Array u8 (mk_usize 200) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize blocks
+      len
+      (Libcrux_secrets.Traits.f_classify #u8 #FStar.Tactics.Typeclasses.solve v_DELIM <: u8)
+  in
+  let blocks:t_Array u8 (mk_usize 200) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_usize blocks
+      (v_RATE -! mk_usize 1 <: usize)
+      ((blocks.[ v_RATE -! mk_usize 1 <: usize ] <: u8) |. mk_u8 128 <: u8)
+  in
+  let s:Libcrux_iot_sha3.State.t_KeccakState =
+    Libcrux_iot_sha3.State.impl_KeccakState__load_block_full v_RATE s blocks (mk_usize 0)
+  in
+  let s:Libcrux_iot_sha3.State.t_KeccakState = keccakf1600 s in
+  s
+
+let squeeze_first_block (v_RATE: usize) (s: Libcrux_iot_sha3.State.t_KeccakState) (out: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        v_RATE <=. (Core_models.Slice.impl__len #u8 out <: usize))
+      (fun _ -> Prims.l_True) =
+  let out:t_Slice u8 = Libcrux_iot_sha3.State.impl_KeccakState__store_block v_RATE s out in
+  out
+
+let squeeze_next_block (v_RATE: usize) (s: Libcrux_iot_sha3.State.t_KeccakState) (out: t_Slice u8)
+    : Prims.Pure (Libcrux_iot_sha3.State.t_KeccakState & t_Slice u8)
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        v_RATE <=. (Core_models.Slice.impl__len #u8 out <: usize))
+      (fun _ -> Prims.l_True) =
+  let s:Libcrux_iot_sha3.State.t_KeccakState = keccakf1600 s in
+  let out:t_Slice u8 = Libcrux_iot_sha3.State.impl_KeccakState__store_block v_RATE s out in
+  s, out <: (Libcrux_iot_sha3.State.t_KeccakState & t_Slice u8)
+
+let squeeze_last (v_RATE: usize) (s: Libcrux_iot_sha3.State.t_KeccakState) (out: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (Core_models.Slice.impl__len #u8 out <: usize) <=. mk_usize 200)
+      (fun _ -> Prims.l_True) =
+  let s:Libcrux_iot_sha3.State.t_KeccakState = keccakf1600 s in
+  let b:t_Array u8 (mk_usize 200) =
+    Libcrux_secrets.Traits.f_classify #(t_Array u8 (mk_usize 200))
+      #FStar.Tactics.Typeclasses.solve
+      (Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 200) <: t_Array u8 (mk_usize 200))
+  in
+  let b:t_Array u8 (mk_usize 200) =
+    Libcrux_iot_sha3.State.impl_KeccakState__store_block_full v_RATE s b
+  in
+  let out:t_Slice u8 =
+    Core_models.Slice.impl__copy_from_slice #u8
+      out
+      (b.[ {
+            Core_models.Ops.Range.f_start = mk_usize 0;
+            Core_models.Ops.Range.f_end = Core_models.Slice.impl__len #u8 out <: usize
+          }
+          <:
+          Core_models.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  out
+
+let squeeze_first_and_last
+      (v_RATE: usize)
+      (s: Libcrux_iot_sha3.State.t_KeccakState)
+      (out: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (Core_models.Slice.impl__len #u8 out <: usize) <=. mk_usize 200)
+      (fun _ -> Prims.l_True) =
+  let b:t_Array u8 (mk_usize 200) =
+    Libcrux_secrets.Traits.f_classify #(t_Array u8 (mk_usize 200))
+      #FStar.Tactics.Typeclasses.solve
+      (Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 200) <: t_Array u8 (mk_usize 200))
+  in
+  let b:t_Array u8 (mk_usize 200) =
+    Libcrux_iot_sha3.State.impl_KeccakState__store_block_full v_RATE s b
+  in
+  let out:t_Slice u8 =
+    Core_models.Slice.impl__copy_from_slice #u8
+      out
+      (b.[ {
+            Core_models.Ops.Range.f_start = mk_usize 0;
+            Core_models.Ops.Range.f_end = Core_models.Slice.impl__len #u8 out <: usize
+          }
+          <:
+          Core_models.Ops.Range.t_Range usize ]
+        <:
+        t_Slice u8)
+  in
+  out
+
+let v_WIDTH: usize = mk_usize 200
+
+let keccak (v_RATE: usize) (v_DELIM: u8) (data out: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
+        v_RATE <=. mk_usize 144)
+      (ensures
+        fun out_future ->
+          let out_future:t_Slice u8 = out_future in
+          (Core_models.Slice.impl__len #u8 out_future <: usize) =.
+          (Core_models.Slice.impl__len #u8 out <: usize)) =
+  let n:usize = (Core_models.Slice.impl__len #u8 data <: usize) /! v_RATE in
+  let rem:usize = (Core_models.Slice.impl__len #u8 data <: usize) %! v_RATE in
+  let outlen:usize = Core_models.Slice.impl__len #u8 out in
+  let blocks:usize = outlen /! v_RATE in
+  let last:usize = outlen -! (outlen %! v_RATE <: usize) in
+  let s:Libcrux_iot_sha3.State.t_KeccakState = Libcrux_iot_sha3.State.impl_KeccakState__new () in
+  let s:Libcrux_iot_sha3.State.t_KeccakState =
+    Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+      n
+      (fun s i ->
+          let s:Libcrux_iot_sha3.State.t_KeccakState = s in
+          let i:usize = i in
+          ((((Rust_primitives.Hax.Int.from_machine i <: Hax_lib.Int.t_Int) *
+                (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
+                <:
+                Hax_lib.Int.t_Int) +
+              (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
+              <:
+              Hax_lib.Int.t_Int) <=
+            (Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 data <: usize)
+              <:
+              Hax_lib.Int.t_Int)
+            <:
+            bool) &&
+          ((Core_models.Slice.impl__len #u8 out <: usize) =. outlen <: bool))
+      s
+      (fun s i ->
+          let s:Libcrux_iot_sha3.State.t_KeccakState = s in
+          let i:usize = i in
+          let s:Libcrux_iot_sha3.State.t_KeccakState =
+            absorb_block v_RATE s data (i *! v_RATE <: usize)
+          in
+          s)
+  in
+  let s:Libcrux_iot_sha3.State.t_KeccakState =
+    absorb_final v_RATE
+      v_DELIM
+      s
+      data
+      ((Core_models.Slice.impl__len #u8 data <: usize) -! rem <: usize)
+      rem
+  in
+  out

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
@@ -45,14 +45,14 @@ let impl__new (v_RATE: usize) (_: Prims.unit) : t_KeccakXofState v_RATE =
 let impl__fill_buffer (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t_Slice u8)
     : Prims.Pure (t_KeccakXofState v_RATE & usize)
       (requires
-        self.f_buf_len <=. v_RATE &&
         ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
             <:
             Hax_lib.Int.t_Int) +
           (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
           <:
           Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int))
+        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int) &&
+        self.f_buf_len <. v_RATE)
       (ensures
         fun temp_0_ ->
           let (self_e_future: t_KeccakXofState v_RATE), (res: usize) = temp_0_ in
@@ -852,13 +852,13 @@ let impl__absorb_full (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t
         fun temp_0_ ->
           let (self_e_future: t_KeccakXofState v_RATE), (remainder: usize) = temp_0_ in
           remainder <. v_RATE && remainder <=. (Core_models.Slice.impl__len #u8 inputs <: usize) &&
-          self_e_future.f_buf_len <=. v_RATE &&
           ((Rust_primitives.Hax.Int.from_machine self_e_future.f_buf_len <: Hax_lib.Int.t_Int) +
             (Rust_primitives.Hax.Int.from_machine remainder <: Hax_lib.Int.t_Int)
             <:
             Hax_lib.Int.t_Int) <
           (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int
-          )) =
+          ) &&
+          self_e_future.f_buf_len <. v_RATE) =
   let _:Prims.unit =
     if true
     then

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
@@ -44,26 +44,17 @@ let impl__new (v_RATE: usize) (_: Prims.unit) : t_KeccakXofState v_RATE =
 /// loaded.
 let impl__fill_buffer (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t_Slice u8)
     : Prims.Pure (t_KeccakXofState v_RATE & usize)
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int) &&
-        self.f_buf_len <. v_RATE)
+      (requires self.f_buf_len <. v_RATE)
       (ensures
         fun temp_0_ ->
           let (self_e_future: t_KeccakXofState v_RATE), (res: usize) = temp_0_ in
-          b2t (res <=. v_RATE <: bool) /\ b2t (self_e_future.f_buf_len <=. v_RATE <: bool) /\
-          (b2t (res >. mk_usize 0 <: bool) ==> b2t (self_e_future.f_buf_len =. v_RATE <: bool))) =
+          res <=. v_RATE && self_e_future.f_buf_len <=. v_RATE) =
   let input_len:usize = Core_models.Slice.impl__len #u8 inputs in
   let consumed:usize = mk_usize 0 in
   let (consumed: usize), (self: t_KeccakXofState v_RATE) =
     if self.f_buf_len >. mk_usize 0
     then
-      if (self.f_buf_len +! input_len <: usize) >=. v_RATE
+      if input_len >=. (v_RATE -! self.f_buf_len <: usize)
       then
         let consumed:usize = v_RATE -! self.f_buf_len in
         let self:t_KeccakXofState v_RATE =
@@ -840,24 +831,11 @@ let impl__absorb_full (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t
       (requires
         v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
         v_RATE <=. mk_usize 168 &&
-        self.f_buf_len <. v_RATE &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int))
+        self.f_buf_len <. v_RATE)
       (ensures
         fun temp_0_ ->
           let (self_e_future: t_KeccakXofState v_RATE), (remainder: usize) = temp_0_ in
           remainder <. v_RATE && remainder <=. (Core_models.Slice.impl__len #u8 inputs <: usize) &&
-          ((Rust_primitives.Hax.Int.from_machine self_e_future.f_buf_len <: Hax_lib.Int.t_Int) +
-            (Rust_primitives.Hax.Int.from_machine remainder <: Hax_lib.Int.t_Int)
-            <:
-            Hax_lib.Int.t_Int) <
-          (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int
-          ) &&
           self_e_future.f_buf_len <. v_RATE) =
   let _:Prims.unit =
     if true
@@ -942,14 +920,7 @@ let impl__absorb (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t_Slic
       (requires
         v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
         v_RATE <=. mk_usize 168 &&
-        self.f_buf_len <. v_RATE &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int))
+        self.f_buf_len <. v_RATE)
       (fun _ -> Prims.l_True) =
   let (tmp0: t_KeccakXofState v_RATE), (out: usize) = impl__absorb_full v_RATE self inputs in
   let self:t_KeccakXofState v_RATE = tmp0 in
@@ -1021,14 +992,7 @@ let impl__absorb_final
       (requires
         v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
         v_RATE <=. mk_usize 168 &&
-        self.f_buf_len <. v_RATE &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int))
+        self.f_buf_len <. v_RATE)
       (fun _ -> Prims.l_True) =
   let (tmp0: t_KeccakXofState v_RATE), (out: usize) = impl__absorb_full v_RATE self inputs in
   let self:t_KeccakXofState v_RATE = tmp0 in

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
@@ -199,6 +199,40 @@ unfold
 let keccakf1600_round0_theta = keccakf1600_round0_theta'
 
 assume
+val keccakf1600_round0_pi_rho_chi_y0_zeta0':
+    v_BASE_ROUND: usize ->
+    s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_pi_rho_chi_y0_zeta0 (v_BASE_ROUND: usize) =
+  keccakf1600_round0_pi_rho_chi_y0_zeta0' v_BASE_ROUND
+
+assume
+val keccakf1600_round0_pi_rho_chi_y0_zeta1':
+    v_BASE_ROUND: usize ->
+    s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_pi_rho_chi_y0_zeta1 (v_BASE_ROUND: usize) =
+  keccakf1600_round0_pi_rho_chi_y0_zeta1' v_BASE_ROUND
+
+assume
+val keccakf1600_round0_pi_rho_chi_y1_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_pi_rho_chi_y1_zeta0 = keccakf1600_round0_pi_rho_chi_y1_zeta0'
+
+assume
+val keccakf1600_round0_pi_rho_chi_y1_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_pi_rho_chi_y1_zeta1 = keccakf1600_round0_pi_rho_chi_y1_zeta1'
+
+assume
 val keccakf1600_round0_pi_rho_chi_1_':
     v_BASE_ROUND: usize ->
     s: Libcrux_iot_sha3.State.t_KeccakState
@@ -207,6 +241,48 @@ val keccakf1600_round0_pi_rho_chi_1_':
 unfold
 let keccakf1600_round0_pi_rho_chi_1_ (v_BASE_ROUND: usize) =
   keccakf1600_round0_pi_rho_chi_1_' v_BASE_ROUND
+
+assume
+val keccakf1600_round0_pi_rho_chi_y2_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_pi_rho_chi_y2_zeta0 = keccakf1600_round0_pi_rho_chi_y2_zeta0'
+
+assume
+val keccakf1600_round0_pi_rho_chi_y2_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_pi_rho_chi_y2_zeta1 = keccakf1600_round0_pi_rho_chi_y2_zeta1'
+
+assume
+val keccakf1600_round0_pi_rho_chi_y3_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_pi_rho_chi_y3_zeta0 = keccakf1600_round0_pi_rho_chi_y3_zeta0'
+
+assume
+val keccakf1600_round0_pi_rho_chi_y3_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_pi_rho_chi_y3_zeta1 = keccakf1600_round0_pi_rho_chi_y3_zeta1'
+
+assume
+val keccakf1600_round0_pi_rho_chi_y4_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_pi_rho_chi_y4_zeta0 = keccakf1600_round0_pi_rho_chi_y4_zeta0'
+
+assume
+val keccakf1600_round0_pi_rho_chi_y4_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round0_pi_rho_chi_y4_zeta1 = keccakf1600_round0_pi_rho_chi_y4_zeta1'
 
 assume
 val keccakf1600_round0_pi_rho_chi_2_': s: Libcrux_iot_sha3.State.t_KeccakState
@@ -300,6 +376,40 @@ unfold
 let keccakf1600_round1_theta = keccakf1600_round1_theta'
 
 assume
+val keccakf1600_round1_pi_rho_chi_y0_zeta0':
+    v_BASE_ROUND: usize ->
+    s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_pi_rho_chi_y0_zeta0 (v_BASE_ROUND: usize) =
+  keccakf1600_round1_pi_rho_chi_y0_zeta0' v_BASE_ROUND
+
+assume
+val keccakf1600_round1_pi_rho_chi_y0_zeta1':
+    v_BASE_ROUND: usize ->
+    s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_pi_rho_chi_y0_zeta1 (v_BASE_ROUND: usize) =
+  keccakf1600_round1_pi_rho_chi_y0_zeta1' v_BASE_ROUND
+
+assume
+val keccakf1600_round1_pi_rho_chi_y1_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_pi_rho_chi_y1_zeta0 = keccakf1600_round1_pi_rho_chi_y1_zeta0'
+
+assume
+val keccakf1600_round1_pi_rho_chi_y1_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_pi_rho_chi_y1_zeta1 = keccakf1600_round1_pi_rho_chi_y1_zeta1'
+
+assume
 val keccakf1600_round1_pi_rho_chi_1_':
     v_BASE_ROUND: usize ->
     s: Libcrux_iot_sha3.State.t_KeccakState
@@ -308,6 +418,48 @@ val keccakf1600_round1_pi_rho_chi_1_':
 unfold
 let keccakf1600_round1_pi_rho_chi_1_ (v_BASE_ROUND: usize) =
   keccakf1600_round1_pi_rho_chi_1_' v_BASE_ROUND
+
+assume
+val keccakf1600_round1_pi_rho_chi_y2_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_pi_rho_chi_y2_zeta0 = keccakf1600_round1_pi_rho_chi_y2_zeta0'
+
+assume
+val keccakf1600_round1_pi_rho_chi_y2_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_pi_rho_chi_y2_zeta1 = keccakf1600_round1_pi_rho_chi_y2_zeta1'
+
+assume
+val keccakf1600_round1_pi_rho_chi_y3_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_pi_rho_chi_y3_zeta0 = keccakf1600_round1_pi_rho_chi_y3_zeta0'
+
+assume
+val keccakf1600_round1_pi_rho_chi_y3_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_pi_rho_chi_y3_zeta1 = keccakf1600_round1_pi_rho_chi_y3_zeta1'
+
+assume
+val keccakf1600_round1_pi_rho_chi_y4_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_pi_rho_chi_y4_zeta0 = keccakf1600_round1_pi_rho_chi_y4_zeta0'
+
+assume
+val keccakf1600_round1_pi_rho_chi_y4_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round1_pi_rho_chi_y4_zeta1 = keccakf1600_round1_pi_rho_chi_y4_zeta1'
 
 assume
 val keccakf1600_round1_pi_rho_chi_2_': s: Libcrux_iot_sha3.State.t_KeccakState
@@ -401,6 +553,40 @@ unfold
 let keccakf1600_round2_theta = keccakf1600_round2_theta'
 
 assume
+val keccakf1600_round2_pi_rho_chi_y0_zeta0':
+    v_BASE_ROUND: usize ->
+    s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_pi_rho_chi_y0_zeta0 (v_BASE_ROUND: usize) =
+  keccakf1600_round2_pi_rho_chi_y0_zeta0' v_BASE_ROUND
+
+assume
+val keccakf1600_round2_pi_rho_chi_y0_zeta1':
+    v_BASE_ROUND: usize ->
+    s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_pi_rho_chi_y0_zeta1 (v_BASE_ROUND: usize) =
+  keccakf1600_round2_pi_rho_chi_y0_zeta1' v_BASE_ROUND
+
+assume
+val keccakf1600_round2_pi_rho_chi_y1_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_pi_rho_chi_y1_zeta0 = keccakf1600_round2_pi_rho_chi_y1_zeta0'
+
+assume
+val keccakf1600_round2_pi_rho_chi_y1_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_pi_rho_chi_y1_zeta1 = keccakf1600_round2_pi_rho_chi_y1_zeta1'
+
+assume
 val keccakf1600_round2_pi_rho_chi_1_':
     v_BASE_ROUND: usize ->
     s: Libcrux_iot_sha3.State.t_KeccakState
@@ -409,6 +595,48 @@ val keccakf1600_round2_pi_rho_chi_1_':
 unfold
 let keccakf1600_round2_pi_rho_chi_1_ (v_BASE_ROUND: usize) =
   keccakf1600_round2_pi_rho_chi_1_' v_BASE_ROUND
+
+assume
+val keccakf1600_round2_pi_rho_chi_y2_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_pi_rho_chi_y2_zeta0 = keccakf1600_round2_pi_rho_chi_y2_zeta0'
+
+assume
+val keccakf1600_round2_pi_rho_chi_y2_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_pi_rho_chi_y2_zeta1 = keccakf1600_round2_pi_rho_chi_y2_zeta1'
+
+assume
+val keccakf1600_round2_pi_rho_chi_y3_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_pi_rho_chi_y3_zeta0 = keccakf1600_round2_pi_rho_chi_y3_zeta0'
+
+assume
+val keccakf1600_round2_pi_rho_chi_y3_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_pi_rho_chi_y3_zeta1 = keccakf1600_round2_pi_rho_chi_y3_zeta1'
+
+assume
+val keccakf1600_round2_pi_rho_chi_y4_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_pi_rho_chi_y4_zeta0 = keccakf1600_round2_pi_rho_chi_y4_zeta0'
+
+assume
+val keccakf1600_round2_pi_rho_chi_y4_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round2_pi_rho_chi_y4_zeta1 = keccakf1600_round2_pi_rho_chi_y4_zeta1'
 
 assume
 val keccakf1600_round2_pi_rho_chi_2_': s: Libcrux_iot_sha3.State.t_KeccakState
@@ -502,6 +730,40 @@ unfold
 let keccakf1600_round3_theta = keccakf1600_round3_theta'
 
 assume
+val keccakf1600_round3_pi_rho_chi_y0_zeta0':
+    v_BASE_ROUND: usize ->
+    s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_pi_rho_chi_y0_zeta0 (v_BASE_ROUND: usize) =
+  keccakf1600_round3_pi_rho_chi_y0_zeta0' v_BASE_ROUND
+
+assume
+val keccakf1600_round3_pi_rho_chi_y0_zeta1':
+    v_BASE_ROUND: usize ->
+    s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_pi_rho_chi_y0_zeta1 (v_BASE_ROUND: usize) =
+  keccakf1600_round3_pi_rho_chi_y0_zeta1' v_BASE_ROUND
+
+assume
+val keccakf1600_round3_pi_rho_chi_y1_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_pi_rho_chi_y1_zeta0 = keccakf1600_round3_pi_rho_chi_y1_zeta0'
+
+assume
+val keccakf1600_round3_pi_rho_chi_y1_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_pi_rho_chi_y1_zeta1 = keccakf1600_round3_pi_rho_chi_y1_zeta1'
+
+assume
 val keccakf1600_round3_pi_rho_chi_1_':
     v_BASE_ROUND: usize ->
     s: Libcrux_iot_sha3.State.t_KeccakState
@@ -510,6 +772,48 @@ val keccakf1600_round3_pi_rho_chi_1_':
 unfold
 let keccakf1600_round3_pi_rho_chi_1_ (v_BASE_ROUND: usize) =
   keccakf1600_round3_pi_rho_chi_1_' v_BASE_ROUND
+
+assume
+val keccakf1600_round3_pi_rho_chi_y2_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_pi_rho_chi_y2_zeta0 = keccakf1600_round3_pi_rho_chi_y2_zeta0'
+
+assume
+val keccakf1600_round3_pi_rho_chi_y2_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_pi_rho_chi_y2_zeta1 = keccakf1600_round3_pi_rho_chi_y2_zeta1'
+
+assume
+val keccakf1600_round3_pi_rho_chi_y3_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_pi_rho_chi_y3_zeta0 = keccakf1600_round3_pi_rho_chi_y3_zeta0'
+
+assume
+val keccakf1600_round3_pi_rho_chi_y3_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_pi_rho_chi_y3_zeta1 = keccakf1600_round3_pi_rho_chi_y3_zeta1'
+
+assume
+val keccakf1600_round3_pi_rho_chi_y4_zeta0': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_pi_rho_chi_y4_zeta0 = keccakf1600_round3_pi_rho_chi_y4_zeta0'
+
+assume
+val keccakf1600_round3_pi_rho_chi_y4_zeta1': s: Libcrux_iot_sha3.State.t_KeccakState
+  -> Libcrux_iot_sha3.State.t_KeccakState
+
+unfold
+let keccakf1600_round3_pi_rho_chi_y4_zeta1 = keccakf1600_round3_pi_rho_chi_y4_zeta1'
 
 assume
 val keccakf1600_round3_pi_rho_chi_2_': s: Libcrux_iot_sha3.State.t_KeccakState

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
@@ -1564,13 +1564,7 @@ let keccak (v_RATE: usize) (v_DELIM: u8) (data out: t_Slice u8)
       (fun temp_0_ e_i ->
           let (s: Libcrux_iot_sha3.State.t_KeccakState), (start: usize) = temp_0_ in
           let e_i:usize = e_i in
-          (Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) =
-          ((Rust_primitives.Hax.Int.from_machine e_i <: Hax_lib.Int.t_Int) *
-            (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
-            <:
-            Hax_lib.Int.t_Int)
-          <:
-          bool)
+          start =. (e_i *! v_RATE <: usize) <: bool)
       (s, start <: (Libcrux_iot_sha3.State.t_KeccakState & usize))
       (fun temp_0_ e_i ->
           let (s: Libcrux_iot_sha3.State.t_KeccakState), (start: usize) = temp_0_ in
@@ -1603,13 +1597,7 @@ let keccak (v_RATE: usize) (v_DELIM: u8) (data out: t_Slice u8)
               in
               let e_i:usize = e_i in
               ((Core_models.Slice.impl__len #u8 out <: usize) =. outlen <: bool) &&
-              ((Rust_primitives.Hax.Int.from_machine offset <: Hax_lib.Int.t_Int) =
-                ((Rust_primitives.Hax.Int.from_machine e_i <: Hax_lib.Int.t_Int) *
-                  (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
-                  <:
-                  Hax_lib.Int.t_Int)
-                <:
-                bool))
+              (offset =. (e_i *! v_RATE <: usize) <: bool))
           (offset, out, s <: (usize & t_Slice u8 & Libcrux_iot_sha3.State.t_KeccakState))
           (fun temp_0_ e_i ->
               let (offset: usize), (out: t_Slice u8), (s: Libcrux_iot_sha3.State.t_KeccakState) =

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Lane.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Lane.fst
@@ -1,0 +1,191 @@
+module Libcrux_iot_sha3.Lane
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Libcrux_secrets.Int in
+  let open Libcrux_secrets.Int.Public_integers in
+  let open Libcrux_secrets.Traits in
+  ()
+
+/// A lane of the Keccak state,
+type t_Lane2U32 = | Lane2U32 : t_Array u32 (mk_usize 2) -> t_Lane2U32
+
+let impl_2: Core_models.Clone.t_Clone t_Lane2U32 =
+  { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_3': Core_models.Marker.t_Copy t_Lane2U32
+
+unfold
+let impl_3 = impl_3'
+
+let impl_Lane2U32__from_ints (value: t_Array u32 (mk_usize 2)) : t_Lane2U32 =
+  Lane2U32 value <: t_Lane2U32
+
+let impl_Lane2U32__zero (_: Prims.unit) : t_Lane2U32 =
+  impl_Lane2U32__from_ints (Libcrux_secrets.Traits.f_classify #(t_Array u32 (mk_usize 2))
+        #FStar.Tactics.Typeclasses.solve
+        (let list = [mk_u32 0; mk_u32 0] in
+          FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+          Rust_primitives.Hax.array_of_list 2 list)
+      <:
+      t_Array u32 (mk_usize 2))
+
+let impl_Lane2U32__deinterleave (self: t_Lane2U32) : t_Lane2U32 =
+  let even_bits:u32 = self._0.[ mk_usize 0 ] in
+  let odd_bits:u32 = self._0.[ mk_usize 1 ] in
+  let even_spaced_lo:u32 = even_bits &. mk_u32 65535 in
+  let even_spaced_lo:u32 =
+    (even_spaced_lo ^. (even_spaced_lo <<! mk_i32 16 <: u32) <: u32) &. mk_u32 65535
+  in
+  let even_spaced_lo:u32 =
+    (even_spaced_lo ^. (even_spaced_lo <<! mk_i32 8 <: u32) <: u32) &. mk_u32 16711935
+  in
+  let even_spaced_lo:u32 =
+    (even_spaced_lo ^. (even_spaced_lo <<! mk_i32 4 <: u32) <: u32) &. mk_u32 252645135
+  in
+  let even_spaced_lo:u32 =
+    (even_spaced_lo ^. (even_spaced_lo <<! mk_i32 2 <: u32) <: u32) &. mk_u32 858993459
+  in
+  let even_spaced_lo:u32 =
+    (even_spaced_lo ^. (even_spaced_lo <<! mk_i32 1 <: u32) <: u32) &. mk_u32 1431655765
+  in
+  let even_spaced_hi:u32 = even_bits >>! mk_i32 16 in
+  let even_spaced_hi:u32 =
+    (even_spaced_hi ^. (even_spaced_hi <<! mk_i32 16 <: u32) <: u32) &. mk_u32 65535
+  in
+  let even_spaced_hi:u32 =
+    (even_spaced_hi ^. (even_spaced_hi <<! mk_i32 8 <: u32) <: u32) &. mk_u32 16711935
+  in
+  let even_spaced_hi:u32 =
+    (even_spaced_hi ^. (even_spaced_hi <<! mk_i32 4 <: u32) <: u32) &. mk_u32 252645135
+  in
+  let even_spaced_hi:u32 =
+    (even_spaced_hi ^. (even_spaced_hi <<! mk_i32 2 <: u32) <: u32) &. mk_u32 858993459
+  in
+  let even_spaced_hi:u32 =
+    (even_spaced_hi ^. (even_spaced_hi <<! mk_i32 1 <: u32) <: u32) &. mk_u32 1431655765
+  in
+  let odd_spaced_lo:u32 = odd_bits &. mk_u32 65535 in
+  let odd_spaced_lo:u32 =
+    (odd_spaced_lo ^. (odd_spaced_lo <<! mk_i32 16 <: u32) <: u32) &. mk_u32 65535
+  in
+  let odd_spaced_lo:u32 =
+    (odd_spaced_lo ^. (odd_spaced_lo <<! mk_i32 8 <: u32) <: u32) &. mk_u32 16711935
+  in
+  let odd_spaced_lo:u32 =
+    (odd_spaced_lo ^. (odd_spaced_lo <<! mk_i32 4 <: u32) <: u32) &. mk_u32 252645135
+  in
+  let odd_spaced_lo:u32 =
+    (odd_spaced_lo ^. (odd_spaced_lo <<! mk_i32 2 <: u32) <: u32) &. mk_u32 858993459
+  in
+  let odd_spaced_lo:u32 =
+    (odd_spaced_lo ^. (odd_spaced_lo <<! mk_i32 1 <: u32) <: u32) &. mk_u32 1431655765
+  in
+  let odd_spaced_hi:u32 = odd_bits >>! mk_i32 16 in
+  let odd_spaced_hi:u32 =
+    (odd_spaced_hi ^. (odd_spaced_hi <<! mk_i32 16 <: u32) <: u32) &. mk_u32 65535
+  in
+  let odd_spaced_hi:u32 =
+    (odd_spaced_hi ^. (odd_spaced_hi <<! mk_i32 8 <: u32) <: u32) &. mk_u32 16711935
+  in
+  let odd_spaced_hi:u32 =
+    (odd_spaced_hi ^. (odd_spaced_hi <<! mk_i32 4 <: u32) <: u32) &. mk_u32 252645135
+  in
+  let odd_spaced_hi:u32 =
+    (odd_spaced_hi ^. (odd_spaced_hi <<! mk_i32 2 <: u32) <: u32) &. mk_u32 858993459
+  in
+  let odd_spaced_hi:u32 =
+    (odd_spaced_hi ^. (odd_spaced_hi <<! mk_i32 1 <: u32) <: u32) &. mk_u32 1431655765
+  in
+  Lane2U32
+  (let list =
+      [
+        even_spaced_lo |. (odd_spaced_lo <<! mk_i32 1 <: u32);
+        even_spaced_hi |. (odd_spaced_hi <<! mk_i32 1 <: u32)
+      ]
+    in
+    FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+    Rust_primitives.Hax.array_of_list 2 list)
+  <:
+  t_Lane2U32
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_4: Core_models.Ops.Index.t_Index t_Lane2U32 usize =
+  {
+    f_Output = u32;
+    f_index_pre = (fun (self_: t_Lane2U32) (index: usize) -> index <. mk_usize 2);
+    f_index_post = (fun (self: t_Lane2U32) (index: usize) (out: u32) -> true);
+    f_index = fun (self: t_Lane2U32) (index: usize) -> self._0.[ index ]
+  }
+
+let impl_Lane2U32__interleave (self: t_Lane2U32) : t_Lane2U32 =
+  let lane_u64:u64 =
+    (Libcrux_secrets.Int.f_as_u64 #u32 #FStar.Tactics.Typeclasses.solve (self.[ mk_usize 0 ] <: u32)
+      <:
+      u64) |.
+    ((Libcrux_secrets.Int.f_as_u64 #u32
+          #FStar.Tactics.Typeclasses.solve
+          (self.[ mk_usize 1 ] <: u32)
+        <:
+        u64) <<!
+      mk_i32 32
+      <:
+      u64)
+  in
+  let even_bits:u64 = lane_u64 &. mk_u64 6148914691236517205 in
+  let even_bits:u64 =
+    (even_bits ^. (even_bits >>! mk_i32 1 <: u64) <: u64) &. mk_u64 3689348814741910323
+  in
+  let even_bits:u64 =
+    (even_bits ^. (even_bits >>! mk_i32 2 <: u64) <: u64) &. mk_u64 1085102592571150095
+  in
+  let even_bits:u64 =
+    (even_bits ^. (even_bits >>! mk_i32 4 <: u64) <: u64) &. mk_u64 71777214294589695
+  in
+  let even_bits:u64 =
+    (even_bits ^. (even_bits >>! mk_i32 8 <: u64) <: u64) &. mk_u64 281470681808895
+  in
+  let even_bits:u64 = (even_bits ^. (even_bits >>! mk_i32 16 <: u64) <: u64) &. mk_u64 4294967295 in
+  let odd_bits:u64 = (lane_u64 >>! mk_i32 1 <: u64) &. mk_u64 6148914691236517205 in
+  let odd_bits:u64 =
+    (odd_bits ^. (odd_bits >>! mk_i32 1 <: u64) <: u64) &. mk_u64 3689348814741910323
+  in
+  let odd_bits:u64 =
+    (odd_bits ^. (odd_bits >>! mk_i32 2 <: u64) <: u64) &. mk_u64 1085102592571150095
+  in
+  let odd_bits:u64 =
+    (odd_bits ^. (odd_bits >>! mk_i32 4 <: u64) <: u64) &. mk_u64 71777214294589695
+  in
+  let odd_bits:u64 =
+    (odd_bits ^. (odd_bits >>! mk_i32 8 <: u64) <: u64) &. mk_u64 281470681808895
+  in
+  let odd_bits:u64 = (odd_bits ^. (odd_bits >>! mk_i32 16 <: u64) <: u64) &. mk_u64 4294967295 in
+  impl_Lane2U32__from_ints (let list =
+        [
+          Libcrux_secrets.Int.f_as_u32 #u64 #FStar.Tactics.Typeclasses.solve even_bits <: u32;
+          Libcrux_secrets.Int.f_as_u32 #u64 #FStar.Tactics.Typeclasses.solve odd_bits <: u32
+        ]
+      in
+      FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+      Rust_primitives.Hax.array_of_list 2 list)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1: Core_models.Convert.t_From t_Lane2U32 (t_Array u32 (mk_usize 2)) =
+  {
+    f_from_pre = (fun (value: t_Array u32 (mk_usize 2)) -> true);
+    f_from_post = (fun (value: t_Array u32 (mk_usize 2)) (out: t_Lane2U32) -> true);
+    f_from = fun (value: t_Array u32 (mk_usize 2)) -> Lane2U32 value <: t_Lane2U32
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_5': Core_models.Fmt.t_Debug t_Lane2U32
+
+unfold
+let impl_5 = impl_5'

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.State.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.State.fst
@@ -164,9 +164,13 @@ let impl_KeccakState__set_lane_value (self: t_KeccakState) (i j: usize) (value: 
 let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice u8)
     : Prims.Pure (t_Slice u8)
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
         (Core_models.Slice.impl__len #u8 out <: usize) <=. v_RATE)
-      (fun _ -> Prims.l_True) =
+      (ensures
+        fun out_future ->
+          let out_future:t_Slice u8 = out_future in
+          (Core_models.Slice.impl__len #u8 out_future <: usize) =.
+          (Core_models.Slice.impl__len #u8 out <: usize)) =
   let e_out_len:usize = Core_models.Slice.impl__len #u8 out in
   let num_full_blocks:usize = (Core_models.Slice.impl__len #u8 out <: usize) /! mk_usize 8 in
   let last_block_len:usize = (Core_models.Slice.impl__len #u8 out <: usize) %! mk_usize 8 in
@@ -365,10 +369,14 @@ let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice 
 let load_block_2u32 (v_RATE: usize) (state: t_KeccakState) (blocks: t_Slice u8) (start: usize)
     : Prims.Pure t_KeccakState
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
-        start <=. mk_usize 200 &&
-        ((start +! v_RATE <: usize) +! mk_usize 7 <: usize) <=.
-        (Core_models.Slice.impl__len #u8 blocks <: usize))
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        ((Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 blocks <: usize)
+          <:
+          Hax_lib.Int.t_Int))
       (fun _ -> Prims.l_True) =
   let _:Prims.unit =
     if true
@@ -505,10 +513,14 @@ let impl_KeccakState__load_block
       (start: usize)
     : Prims.Pure t_KeccakState
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
-        start <=. mk_usize 200 &&
-        ((start +! v_RATE <: usize) +! mk_usize 7 <: usize) <=.
-        (Core_models.Slice.impl__len #u8 blocks <: usize))
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        ((Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 blocks <: usize)
+          <:
+          Hax_lib.Int.t_Int))
       (fun _ -> Prims.l_True) =
   let self:t_KeccakState = load_block_2u32 v_RATE self blocks start in
   self
@@ -520,9 +532,12 @@ let load_block_full_2u32
       (start: usize)
     : Prims.Pure t_KeccakState
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
-        start <=. mk_usize 200 &&
-        ((start +! v_RATE <: usize) +! mk_usize 7 <: usize) <=. mk_usize 200)
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        ((Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) +
+          (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
+          <:
+          Hax_lib.Int.t_Int) <=
+        (Rust_primitives.Hax.Int.from_machine (mk_i32 200) <: Hax_lib.Int.t_Int))
       (fun _ -> Prims.l_True) =
   let state:t_KeccakState = load_block_2u32 v_RATE state (blocks <: t_Slice u8) start in
   state
@@ -534,9 +549,9 @@ let impl_KeccakState__load_block_full
       (start: usize)
     : Prims.Pure t_KeccakState
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
         start <=. mk_usize 200 &&
-        ((start +! v_RATE <: usize) +! mk_usize 7 <: usize) <=. mk_usize 200)
+        (start +! v_RATE <: usize) <=. mk_usize 144)
       (fun _ -> Prims.l_True) =
   let self:t_KeccakState = load_block_full_2u32 v_RATE self blocks start in
   self
@@ -544,7 +559,7 @@ let impl_KeccakState__load_block_full
 let store_block_2u32 (v_RATE: usize) (s: t_KeccakState) (out: t_Slice u8)
     : Prims.Pure (t_Slice u8)
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
         v_RATE <=. (Core_models.Slice.impl__len #u8 out <: usize))
       (fun _ -> Prims.l_True) =
   let e_out_len:usize = Core_models.Slice.impl__len #u8 out in
@@ -621,7 +636,7 @@ let store_block_2u32 (v_RATE: usize) (s: t_KeccakState) (out: t_Slice u8)
 let impl_KeccakState__store_block (v_RATE: usize) (self: t_KeccakState) (out: t_Slice u8)
     : Prims.Pure (t_Slice u8)
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
         v_RATE <=. (Core_models.Slice.impl__len #u8 out <: usize))
       (fun _ -> Prims.l_True) =
   let out:t_Slice u8 = store_block_2u32 v_RATE self out in
@@ -629,7 +644,7 @@ let impl_KeccakState__store_block (v_RATE: usize) (self: t_KeccakState) (out: t_
 
 let store_block_full_2u32 (v_RATE: usize) (s: t_KeccakState) (out: t_Array u8 (mk_usize 200))
     : Prims.Pure (t_Array u8 (mk_usize 200))
-      (requires (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200)
+      (requires (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144)
       (fun _ -> Prims.l_True) =
   let out:t_Array u8 (mk_usize 200) =
     Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
@@ -649,7 +664,7 @@ let impl_KeccakState__store_block_full
       (self: t_KeccakState)
       (out: t_Array u8 (mk_usize 200))
     : Prims.Pure (t_Array u8 (mk_usize 200))
-      (requires (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200)
+      (requires (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144)
       (fun _ -> Prims.l_True) =
   let out:t_Array u8 (mk_usize 200) = store_block_full_2u32 v_RATE self out in
   out

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.State.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.State.fst
@@ -185,7 +185,7 @@ let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice 
       (fun out i ->
           let out:t_Slice u8 = out in
           let i:usize = i in
-          let lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
+          let keccak_lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
             Libcrux_iot_sha3.Lane.impl_Lane2U32__deinterleave (impl_KeccakState__get_lane self
                   (i /! mk_usize 5 <: usize)
                   (i %! mk_usize 5 <: usize)
@@ -211,7 +211,9 @@ let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice 
                       Core_models.Ops.Range.t_Range usize ]
                     <:
                     t_Slice u8)
-                  (Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 0 ] <: u32) <: t_Slice u8)
+                  (Core_models.Num.impl_u32__to_le_bytes (keccak_lane.[ mk_usize 0 ] <: u32)
+                    <:
+                    t_Slice u8)
                 <:
                 t_Slice u8)
           in
@@ -236,7 +238,9 @@ let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice 
                       Core_models.Ops.Range.t_Range usize ]
                     <:
                     t_Slice u8)
-                  (Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 1 ] <: u32) <: t_Slice u8)
+                  (Core_models.Num.impl_u32__to_le_bytes (keccak_lane.[ mk_usize 1 ] <: u32)
+                    <:
+                    t_Slice u8)
                 <:
                 t_Slice u8)
           in
@@ -245,7 +249,7 @@ let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice 
   let out:t_Slice u8 =
     if last_block_len >. mk_usize 4
     then
-      let lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
+      let keccak_lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
         Libcrux_iot_sha3.Lane.impl_Lane2U32__deinterleave (impl_KeccakState__get_lane self
               (num_full_blocks /! mk_usize 5 <: usize)
               (num_full_blocks %! mk_usize 5 <: usize)
@@ -274,7 +278,9 @@ let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice 
                   Core_models.Ops.Range.t_Range usize ]
                 <:
                 t_Slice u8)
-              (Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 0 ] <: u32) <: t_Slice u8)
+              (Core_models.Num.impl_u32__to_le_bytes (keccak_lane.[ mk_usize 0 ] <: u32)
+                <:
+                t_Slice u8)
             <:
             t_Slice u8)
       in
@@ -303,7 +309,7 @@ let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice 
                   Core_models.Ops.Range.t_Range usize ]
                 <:
                 t_Slice u8)
-              ((Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 1 ] <: u32)
+              ((Core_models.Num.impl_u32__to_le_bytes (keccak_lane.[ mk_usize 1 ] <: u32)
                   <:
                   t_Array u8 (mk_usize 4)).[ {
                     Core_models.Ops.Range.f_start = mk_usize 0;
@@ -320,7 +326,7 @@ let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice 
     else
       if last_block_len >. mk_usize 0
       then
-        let lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
+        let keccak_lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
           Libcrux_iot_sha3.Lane.impl_Lane2U32__deinterleave (impl_KeccakState__get_lane self
                 (num_full_blocks /! mk_usize 5 <: usize)
                 (num_full_blocks %! mk_usize 5 <: usize)
@@ -348,7 +354,7 @@ let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice 
                     Core_models.Ops.Range.t_Range usize ]
                   <:
                   t_Slice u8)
-                ((Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 0 ] <: u32)
+                ((Core_models.Num.impl_u32__to_le_bytes (keccak_lane.[ mk_usize 0 ] <: u32)
                     <:
                     t_Array u8 (mk_usize 4)).[ {
                       Core_models.Ops.Range.f_start = mk_usize 0;
@@ -366,7 +372,11 @@ let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice 
   in
   out
 
-let load_block_2u32 (v_RATE: usize) (state: t_KeccakState) (blocks: t_Slice u8) (start: usize)
+let load_block_2u32
+      (v_RATE: usize)
+      (keccak_state: t_KeccakState)
+      (blocks: t_Slice u8)
+      (start: usize)
     : Prims.Pure t_KeccakState
       (requires
         (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
@@ -463,22 +473,24 @@ let load_block_2u32 (v_RATE: usize) (state: t_KeccakState) (blocks: t_Slice u8) 
           in
           state_flat)
   in
-  let state:t_KeccakState =
+  let keccak_state:t_KeccakState =
     Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
       (v_RATE /! mk_usize 8 <: usize)
-      (fun state temp_1_ ->
-          let state:t_KeccakState = state in
+      (fun keccak_state temp_1_ ->
+          let keccak_state:t_KeccakState = keccak_state in
           let _:usize = temp_1_ in
           true)
-      state
-      (fun state i ->
-          let state:t_KeccakState = state in
+      keccak_state
+      (fun keccak_state i ->
+          let keccak_state:t_KeccakState = keccak_state in
           let i:usize = i in
           let got:Libcrux_iot_sha3.Lane.t_Lane2U32 =
-            impl_KeccakState__get_lane state (i /! mk_usize 5 <: usize) (i %! mk_usize 5 <: usize)
+            impl_KeccakState__get_lane keccak_state
+              (i /! mk_usize 5 <: usize)
+              (i %! mk_usize 5 <: usize)
           in
-          let state:t_KeccakState =
-            impl_KeccakState__set_lane state
+          let keccak_state:t_KeccakState =
+            impl_KeccakState__set_lane keccak_state
               (i /! mk_usize 5 <: usize)
               (i %! mk_usize 5 <: usize)
               (Libcrux_iot_sha3.Lane.impl_Lane2U32__from_ints (let list =
@@ -502,9 +514,9 @@ let load_block_2u32 (v_RATE: usize) (state: t_KeccakState) (blocks: t_Slice u8) 
                 <:
                 Libcrux_iot_sha3.Lane.t_Lane2U32)
           in
-          state)
+          keccak_state)
   in
-  state
+  keccak_state
 
 let impl_KeccakState__load_block
       (v_RATE: usize)
@@ -527,7 +539,7 @@ let impl_KeccakState__load_block
 
 let load_block_full_2u32
       (v_RATE: usize)
-      (state: t_KeccakState)
+      (keccak_state: t_KeccakState)
       (blocks: t_Array u8 (mk_usize 200))
       (start: usize)
     : Prims.Pure t_KeccakState
@@ -539,8 +551,10 @@ let load_block_full_2u32
           Hax_lib.Int.t_Int) <=
         (Rust_primitives.Hax.Int.from_machine (mk_i32 200) <: Hax_lib.Int.t_Int))
       (fun _ -> Prims.l_True) =
-  let state:t_KeccakState = load_block_2u32 v_RATE state (blocks <: t_Slice u8) start in
-  state
+  let keccak_state:t_KeccakState =
+    load_block_2u32 v_RATE keccak_state (blocks <: t_Slice u8) start
+  in
+  keccak_state
 
 let impl_KeccakState__load_block_full
       (v_RATE: usize)
@@ -574,7 +588,7 @@ let store_block_2u32 (v_RATE: usize) (s: t_KeccakState) (out: t_Slice u8)
       (fun out i ->
           let out:t_Slice u8 = out in
           let i:usize = i in
-          let lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
+          let keccak_lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
             Libcrux_iot_sha3.Lane.impl_Lane2U32__deinterleave (impl_KeccakState__get_lane s
                   (i /! mk_usize 5 <: usize)
                   (i %! mk_usize 5 <: usize)
@@ -600,7 +614,9 @@ let store_block_2u32 (v_RATE: usize) (s: t_KeccakState) (out: t_Slice u8)
                       Core_models.Ops.Range.t_Range usize ]
                     <:
                     t_Slice u8)
-                  (Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 0 ] <: u32) <: t_Slice u8)
+                  (Core_models.Num.impl_u32__to_le_bytes (keccak_lane.[ mk_usize 0 ] <: u32)
+                    <:
+                    t_Slice u8)
                 <:
                 t_Slice u8)
           in
@@ -625,7 +641,9 @@ let store_block_2u32 (v_RATE: usize) (s: t_KeccakState) (out: t_Slice u8)
                       Core_models.Ops.Range.t_Range usize ]
                     <:
                     t_Slice u8)
-                  (Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 1 ] <: u32) <: t_Slice u8)
+                  (Core_models.Num.impl_u32__to_le_bytes (keccak_lane.[ mk_usize 1 ] <: u32)
+                    <:
+                    t_Slice u8)
                 <:
                 t_Slice u8)
           in

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.State.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.State.fst
@@ -1,0 +1,655 @@
+module Libcrux_iot_sha3.State
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Libcrux_iot_sha3.Lane in
+  ()
+
+type t_KeccakState = {
+  f_st:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 25);
+  f_c:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 5);
+  f_d:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 5);
+  f_i:usize
+}
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_2': Core_models.Fmt.t_Debug t_KeccakState
+
+unfold
+let impl_2 = impl_2'
+
+let impl: Core_models.Clone.t_Clone t_KeccakState =
+  { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_1': Core_models.Marker.t_Copy t_KeccakState
+
+unfold
+let impl_1 = impl_1'
+
+let impl_KeccakState__new (_: Prims.unit) : t_KeccakState =
+  {
+    f_st
+    =
+    Rust_primitives.Hax.repeat (Libcrux_iot_sha3.Lane.impl_Lane2U32__zero ()
+        <:
+        Libcrux_iot_sha3.Lane.t_Lane2U32)
+      (mk_usize 25);
+    f_c
+    =
+    Rust_primitives.Hax.repeat (Libcrux_iot_sha3.Lane.impl_Lane2U32__zero ()
+        <:
+        Libcrux_iot_sha3.Lane.t_Lane2U32)
+      (mk_usize 5);
+    f_d
+    =
+    Rust_primitives.Hax.repeat (Libcrux_iot_sha3.Lane.impl_Lane2U32__zero ()
+        <:
+        Libcrux_iot_sha3.Lane.t_Lane2U32)
+      (mk_usize 5);
+    f_i = mk_usize 0
+  }
+  <:
+  t_KeccakState
+
+let impl_KeccakState__get_with_zeta (self: t_KeccakState) (i j zeta: usize)
+    : Prims.Pure u32
+      (requires i <. mk_usize 5 && j <. mk_usize 5 && zeta <. mk_usize 2)
+      (fun _ -> Prims.l_True) =
+  (self.f_st.[ (mk_usize 5 *! j <: usize) +! i <: usize ] <: Libcrux_iot_sha3.Lane.t_Lane2U32).[ zeta
+  ]
+
+let impl_KeccakState__set_with_zeta (self: t_KeccakState) (i j zeta: usize) (v: u32)
+    : Prims.Pure t_KeccakState
+      (requires i <. mk_usize 5 && j <. mk_usize 5 && zeta <. mk_usize 2)
+      (fun _ -> Prims.l_True) =
+  let self:t_KeccakState =
+    {
+      self with
+      f_st
+      =
+      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self.f_st
+        ((mk_usize 5 *! j <: usize) +! i <: usize)
+        ({
+            (self.f_st.[ (mk_usize 5 *! j <: usize) +! i <: usize ]
+              <:
+              Libcrux_iot_sha3.Lane.t_Lane2U32) with
+            Libcrux_iot_sha3.Lane._0
+            =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (self.f_st.[ (mk_usize 5 *!
+                    j
+                    <:
+                    usize) +!
+                  i
+                  <:
+                  usize ]
+                <:
+                Libcrux_iot_sha3.Lane.t_Lane2U32)
+                .Libcrux_iot_sha3.Lane._0
+              zeta
+              v
+            <:
+            t_Array u32 (mk_usize 2)
+          }
+          <:
+          Libcrux_iot_sha3.Lane.t_Lane2U32)
+    }
+    <:
+    t_KeccakState
+  in
+  self
+
+let impl_KeccakState__get_lane (self: t_KeccakState) (i j: usize)
+    : Prims.Pure Libcrux_iot_sha3.Lane.t_Lane2U32
+      (requires i <. mk_usize 5 && j <. mk_usize 5)
+      (fun _ -> Prims.l_True) = self.f_st.[ (mk_usize 5 *! j <: usize) +! i <: usize ]
+
+let impl_KeccakState__set_lane
+      (self: t_KeccakState)
+      (i j: usize)
+      (lane: Libcrux_iot_sha3.Lane.t_Lane2U32)
+    : Prims.Pure t_KeccakState (requires i <. mk_usize 5 && j <. mk_usize 5) (fun _ -> Prims.l_True) =
+  let self:t_KeccakState =
+    {
+      self with
+      f_st
+      =
+      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self.f_st
+        ((mk_usize 5 *! j <: usize) +! i <: usize)
+        lane
+    }
+    <:
+    t_KeccakState
+  in
+  self
+
+let impl_KeccakState__set_lane_value (self: t_KeccakState) (i j: usize) (value: u32)
+    : Prims.Pure t_KeccakState (requires i <. mk_usize 5 && j <. mk_usize 2) (fun _ -> Prims.l_True) =
+  let self:t_KeccakState =
+    {
+      self with
+      f_c
+      =
+      Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self.f_c
+        i
+        ({
+            (self.f_c.[ i ] <: Libcrux_iot_sha3.Lane.t_Lane2U32) with
+            Libcrux_iot_sha3.Lane._0
+            =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize (self.f_c.[ i ]
+                <:
+                Libcrux_iot_sha3.Lane.t_Lane2U32)
+                .Libcrux_iot_sha3.Lane._0
+              j
+              value
+            <:
+            t_Array u32 (mk_usize 2)
+          }
+          <:
+          Libcrux_iot_sha3.Lane.t_Lane2U32)
+    }
+    <:
+    t_KeccakState
+  in
+  self
+
+/// `out` has the exact size we want here. It must be less than or equal to
+/// `RATE`.
+let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
+        (Core_models.Slice.impl__len #u8 out <: usize) <=. v_RATE)
+      (fun _ -> Prims.l_True) =
+  let e_out_len:usize = Core_models.Slice.impl__len #u8 out in
+  let num_full_blocks:usize = (Core_models.Slice.impl__len #u8 out <: usize) /! mk_usize 8 in
+  let last_block_len:usize = (Core_models.Slice.impl__len #u8 out <: usize) %! mk_usize 8 in
+  let out:t_Slice u8 =
+    Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+      num_full_blocks
+      (fun out i ->
+          let out:t_Slice u8 = out in
+          let i:usize = i in
+          (Core_models.Slice.impl__len #u8 out <: usize) =. e_out_len <: bool)
+      out
+      (fun out i ->
+          let out:t_Slice u8 = out in
+          let i:usize = i in
+          let lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
+            Libcrux_iot_sha3.Lane.impl_Lane2U32__deinterleave (impl_KeccakState__get_lane self
+                  (i /! mk_usize 5 <: usize)
+                  (i %! mk_usize 5 <: usize)
+                <:
+                Libcrux_iot_sha3.Lane.t_Lane2U32)
+          in
+          let out:t_Slice u8 =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+              ({
+                  Core_models.Ops.Range.f_start = i *! mk_usize 8 <: usize;
+                  Core_models.Ops.Range.f_end = (i *! mk_usize 8 <: usize) +! mk_usize 4 <: usize
+                }
+                <:
+                Core_models.Ops.Range.t_Range usize)
+              (Core_models.Slice.impl__copy_from_slice #u8
+                  (out.[ {
+                        Core_models.Ops.Range.f_start = i *! mk_usize 8 <: usize;
+                        Core_models.Ops.Range.f_end
+                        =
+                        (i *! mk_usize 8 <: usize) +! mk_usize 4 <: usize
+                      }
+                      <:
+                      Core_models.Ops.Range.t_Range usize ]
+                    <:
+                    t_Slice u8)
+                  (Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 0 ] <: u32) <: t_Slice u8)
+                <:
+                t_Slice u8)
+          in
+          let out:t_Slice u8 =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+              ({
+                  Core_models.Ops.Range.f_start = (i *! mk_usize 8 <: usize) +! mk_usize 4 <: usize;
+                  Core_models.Ops.Range.f_end = (i *! mk_usize 8 <: usize) +! mk_usize 8 <: usize
+                }
+                <:
+                Core_models.Ops.Range.t_Range usize)
+              (Core_models.Slice.impl__copy_from_slice #u8
+                  (out.[ {
+                        Core_models.Ops.Range.f_start
+                        =
+                        (i *! mk_usize 8 <: usize) +! mk_usize 4 <: usize;
+                        Core_models.Ops.Range.f_end
+                        =
+                        (i *! mk_usize 8 <: usize) +! mk_usize 8 <: usize
+                      }
+                      <:
+                      Core_models.Ops.Range.t_Range usize ]
+                    <:
+                    t_Slice u8)
+                  (Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 1 ] <: u32) <: t_Slice u8)
+                <:
+                t_Slice u8)
+          in
+          out)
+  in
+  let out:t_Slice u8 =
+    if last_block_len >. mk_usize 4
+    then
+      let lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
+        Libcrux_iot_sha3.Lane.impl_Lane2U32__deinterleave (impl_KeccakState__get_lane self
+              (num_full_blocks /! mk_usize 5 <: usize)
+              (num_full_blocks %! mk_usize 5 <: usize)
+            <:
+            Libcrux_iot_sha3.Lane.t_Lane2U32)
+      in
+      let last_half_block_len:usize = last_block_len -! mk_usize 4 in
+      let out:t_Slice u8 =
+        Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+          ({
+              Core_models.Ops.Range.f_start = num_full_blocks *! mk_usize 8 <: usize;
+              Core_models.Ops.Range.f_end
+              =
+              (num_full_blocks *! mk_usize 8 <: usize) +! mk_usize 4 <: usize
+            }
+            <:
+            Core_models.Ops.Range.t_Range usize)
+          (Core_models.Slice.impl__copy_from_slice #u8
+              (out.[ {
+                    Core_models.Ops.Range.f_start = num_full_blocks *! mk_usize 8 <: usize;
+                    Core_models.Ops.Range.f_end
+                    =
+                    (num_full_blocks *! mk_usize 8 <: usize) +! mk_usize 4 <: usize
+                  }
+                  <:
+                  Core_models.Ops.Range.t_Range usize ]
+                <:
+                t_Slice u8)
+              (Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 0 ] <: u32) <: t_Slice u8)
+            <:
+            t_Slice u8)
+      in
+      let out:t_Slice u8 =
+        Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+          ({
+              Core_models.Ops.Range.f_start
+              =
+              (num_full_blocks *! mk_usize 8 <: usize) +! mk_usize 4 <: usize;
+              Core_models.Ops.Range.f_end
+              =
+              (num_full_blocks *! mk_usize 8 <: usize) +! last_block_len <: usize
+            }
+            <:
+            Core_models.Ops.Range.t_Range usize)
+          (Core_models.Slice.impl__copy_from_slice #u8
+              (out.[ {
+                    Core_models.Ops.Range.f_start
+                    =
+                    (num_full_blocks *! mk_usize 8 <: usize) +! mk_usize 4 <: usize;
+                    Core_models.Ops.Range.f_end
+                    =
+                    (num_full_blocks *! mk_usize 8 <: usize) +! last_block_len <: usize
+                  }
+                  <:
+                  Core_models.Ops.Range.t_Range usize ]
+                <:
+                t_Slice u8)
+              ((Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 1 ] <: u32)
+                  <:
+                  t_Array u8 (mk_usize 4)).[ {
+                    Core_models.Ops.Range.f_start = mk_usize 0;
+                    Core_models.Ops.Range.f_end = last_half_block_len
+                  }
+                  <:
+                  Core_models.Ops.Range.t_Range usize ]
+                <:
+                t_Slice u8)
+            <:
+            t_Slice u8)
+      in
+      out
+    else
+      if last_block_len >. mk_usize 0
+      then
+        let lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
+          Libcrux_iot_sha3.Lane.impl_Lane2U32__deinterleave (impl_KeccakState__get_lane self
+                (num_full_blocks /! mk_usize 5 <: usize)
+                (num_full_blocks %! mk_usize 5 <: usize)
+              <:
+              Libcrux_iot_sha3.Lane.t_Lane2U32)
+        in
+        let out:t_Slice u8 =
+          Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+            ({
+                Core_models.Ops.Range.f_start = num_full_blocks *! mk_usize 8 <: usize;
+                Core_models.Ops.Range.f_end
+                =
+                (num_full_blocks *! mk_usize 8 <: usize) +! last_block_len <: usize
+              }
+              <:
+              Core_models.Ops.Range.t_Range usize)
+            (Core_models.Slice.impl__copy_from_slice #u8
+                (out.[ {
+                      Core_models.Ops.Range.f_start = num_full_blocks *! mk_usize 8 <: usize;
+                      Core_models.Ops.Range.f_end
+                      =
+                      (num_full_blocks *! mk_usize 8 <: usize) +! last_block_len <: usize
+                    }
+                    <:
+                    Core_models.Ops.Range.t_Range usize ]
+                  <:
+                  t_Slice u8)
+                ((Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 0 ] <: u32)
+                    <:
+                    t_Array u8 (mk_usize 4)).[ {
+                      Core_models.Ops.Range.f_start = mk_usize 0;
+                      Core_models.Ops.Range.f_end = last_block_len
+                    }
+                    <:
+                    Core_models.Ops.Range.t_Range usize ]
+                  <:
+                  t_Slice u8)
+              <:
+              t_Slice u8)
+        in
+        out
+      else out
+  in
+  out
+
+let load_block_2u32 (v_RATE: usize) (state: t_KeccakState) (blocks: t_Slice u8) (start: usize)
+    : Prims.Pure t_KeccakState
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
+        start <=. mk_usize 200 &&
+        ((start +! v_RATE <: usize) +! mk_usize 7 <: usize) <=.
+        (Core_models.Slice.impl__len #u8 blocks <: usize))
+      (fun _ -> Prims.l_True) =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        Hax_lib.v_assert ((v_RATE <=. (Core_models.Slice.impl__len #u8 blocks <: usize) <: bool) &&
+            ((v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 <: bool))
+      in
+      ()
+  in
+  let state_flat:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 25) =
+    Rust_primitives.Hax.repeat (Libcrux_iot_sha3.Lane.impl_Lane2U32__zero ()
+        <:
+        Libcrux_iot_sha3.Lane.t_Lane2U32)
+      (mk_usize 25)
+  in
+  let state_flat:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 25) =
+    Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+      (v_RATE /! mk_usize 8 <: usize)
+      (fun state_flat temp_1_ ->
+          let state_flat:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 25) = state_flat in
+          let _:usize = temp_1_ in
+          true)
+      state_flat
+      (fun state_flat i ->
+          let state_flat:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 25) = state_flat in
+          let i:usize = i in
+          let offset:usize = start +! (mk_usize 8 *! i <: usize) in
+          let a:u32 =
+            Core_models.Num.impl_u32__from_le_bytes (Core_models.Result.impl__unwrap #(t_Array u8
+                      (mk_usize 4))
+                  #Core_models.Array.t_TryFromSliceError
+                  (Core_models.Convert.f_try_into #(t_Slice u8)
+                      #(t_Array u8 (mk_usize 4))
+                      #FStar.Tactics.Typeclasses.solve
+                      (blocks.[ {
+                            Core_models.Ops.Range.f_start = offset;
+                            Core_models.Ops.Range.f_end = offset +! mk_usize 4 <: usize
+                          }
+                          <:
+                          Core_models.Ops.Range.t_Range usize ]
+                        <:
+                        t_Slice u8)
+                    <:
+                    Core_models.Result.t_Result (t_Array u8 (mk_usize 4))
+                      Core_models.Array.t_TryFromSliceError)
+                <:
+                t_Array u8 (mk_usize 4))
+          in
+          let b:u32 =
+            Core_models.Num.impl_u32__from_le_bytes (Core_models.Result.impl__unwrap #(t_Array u8
+                      (mk_usize 4))
+                  #Core_models.Array.t_TryFromSliceError
+                  (Core_models.Convert.f_try_into #(t_Slice u8)
+                      #(t_Array u8 (mk_usize 4))
+                      #FStar.Tactics.Typeclasses.solve
+                      (blocks.[ {
+                            Core_models.Ops.Range.f_start = offset +! mk_usize 4 <: usize;
+                            Core_models.Ops.Range.f_end = offset +! mk_usize 8 <: usize
+                          }
+                          <:
+                          Core_models.Ops.Range.t_Range usize ]
+                        <:
+                        t_Slice u8)
+                    <:
+                    Core_models.Result.t_Result (t_Array u8 (mk_usize 4))
+                      Core_models.Array.t_TryFromSliceError)
+                <:
+                t_Array u8 (mk_usize 4))
+          in
+          let state_flat:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 25) =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize state_flat
+              i
+              (Libcrux_iot_sha3.Lane.impl_Lane2U32__interleave (Core_models.Convert.f_from #Libcrux_iot_sha3.Lane.t_Lane2U32
+                      #(t_Array u32 (mk_usize 2))
+                      #FStar.Tactics.Typeclasses.solve
+                      (let list = [a; b] in
+                        FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+                        Rust_primitives.Hax.array_of_list 2 list)
+                    <:
+                    Libcrux_iot_sha3.Lane.t_Lane2U32)
+                <:
+                Libcrux_iot_sha3.Lane.t_Lane2U32)
+          in
+          state_flat)
+  in
+  let state:t_KeccakState =
+    Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+      (v_RATE /! mk_usize 8 <: usize)
+      (fun state temp_1_ ->
+          let state:t_KeccakState = state in
+          let _:usize = temp_1_ in
+          true)
+      state
+      (fun state i ->
+          let state:t_KeccakState = state in
+          let i:usize = i in
+          let got:Libcrux_iot_sha3.Lane.t_Lane2U32 =
+            impl_KeccakState__get_lane state (i /! mk_usize 5 <: usize) (i %! mk_usize 5 <: usize)
+          in
+          let state:t_KeccakState =
+            impl_KeccakState__set_lane state
+              (i /! mk_usize 5 <: usize)
+              (i %! mk_usize 5 <: usize)
+              (Libcrux_iot_sha3.Lane.impl_Lane2U32__from_ints (let list =
+                      [
+                        (got.[ mk_usize 0 ] <: u32) ^.
+                        ((state_flat.[ i ] <: Libcrux_iot_sha3.Lane.t_Lane2U32).[ mk_usize 0 ]
+                          <:
+                          u32)
+                        <:
+                        u32;
+                        (got.[ mk_usize 1 ] <: u32) ^.
+                        ((state_flat.[ i ] <: Libcrux_iot_sha3.Lane.t_Lane2U32).[ mk_usize 1 ]
+                          <:
+                          u32)
+                        <:
+                        u32
+                      ]
+                    in
+                    FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+                    Rust_primitives.Hax.array_of_list 2 list)
+                <:
+                Libcrux_iot_sha3.Lane.t_Lane2U32)
+          in
+          state)
+  in
+  state
+
+let impl_KeccakState__load_block
+      (v_RATE: usize)
+      (self: t_KeccakState)
+      (blocks: t_Slice u8)
+      (start: usize)
+    : Prims.Pure t_KeccakState
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
+        start <=. mk_usize 200 &&
+        ((start +! v_RATE <: usize) +! mk_usize 7 <: usize) <=.
+        (Core_models.Slice.impl__len #u8 blocks <: usize))
+      (fun _ -> Prims.l_True) =
+  let self:t_KeccakState = load_block_2u32 v_RATE self blocks start in
+  self
+
+let load_block_full_2u32
+      (v_RATE: usize)
+      (state: t_KeccakState)
+      (blocks: t_Array u8 (mk_usize 200))
+      (start: usize)
+    : Prims.Pure t_KeccakState
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
+        start <=. mk_usize 200 &&
+        ((start +! v_RATE <: usize) +! mk_usize 7 <: usize) <=. mk_usize 200)
+      (fun _ -> Prims.l_True) =
+  let state:t_KeccakState = load_block_2u32 v_RATE state (blocks <: t_Slice u8) start in
+  state
+
+let impl_KeccakState__load_block_full
+      (v_RATE: usize)
+      (self: t_KeccakState)
+      (blocks: t_Array u8 (mk_usize 200))
+      (start: usize)
+    : Prims.Pure t_KeccakState
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
+        start <=. mk_usize 200 &&
+        ((start +! v_RATE <: usize) +! mk_usize 7 <: usize) <=. mk_usize 200)
+      (fun _ -> Prims.l_True) =
+  let self:t_KeccakState = load_block_full_2u32 v_RATE self blocks start in
+  self
+
+let store_block_2u32 (v_RATE: usize) (s: t_KeccakState) (out: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
+        v_RATE <=. (Core_models.Slice.impl__len #u8 out <: usize))
+      (fun _ -> Prims.l_True) =
+  let e_out_len:usize = Core_models.Slice.impl__len #u8 out in
+  let out:t_Slice u8 =
+    Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+      (v_RATE /! mk_usize 8 <: usize)
+      (fun out i ->
+          let out:t_Slice u8 = out in
+          let i:usize = i in
+          (Core_models.Slice.impl__len #u8 out <: usize) =. e_out_len <: bool)
+      out
+      (fun out i ->
+          let out:t_Slice u8 = out in
+          let i:usize = i in
+          let lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
+            Libcrux_iot_sha3.Lane.impl_Lane2U32__deinterleave (impl_KeccakState__get_lane s
+                  (i /! mk_usize 5 <: usize)
+                  (i %! mk_usize 5 <: usize)
+                <:
+                Libcrux_iot_sha3.Lane.t_Lane2U32)
+          in
+          let out:t_Slice u8 =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+              ({
+                  Core_models.Ops.Range.f_start = mk_usize 8 *! i <: usize;
+                  Core_models.Ops.Range.f_end = (mk_usize 8 *! i <: usize) +! mk_usize 4 <: usize
+                }
+                <:
+                Core_models.Ops.Range.t_Range usize)
+              (Core_models.Slice.impl__copy_from_slice #u8
+                  (out.[ {
+                        Core_models.Ops.Range.f_start = mk_usize 8 *! i <: usize;
+                        Core_models.Ops.Range.f_end
+                        =
+                        (mk_usize 8 *! i <: usize) +! mk_usize 4 <: usize
+                      }
+                      <:
+                      Core_models.Ops.Range.t_Range usize ]
+                    <:
+                    t_Slice u8)
+                  (Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 0 ] <: u32) <: t_Slice u8)
+                <:
+                t_Slice u8)
+          in
+          let out:t_Slice u8 =
+            Rust_primitives.Hax.Monomorphized_update_at.update_at_range out
+              ({
+                  Core_models.Ops.Range.f_start = (mk_usize 8 *! i <: usize) +! mk_usize 4 <: usize;
+                  Core_models.Ops.Range.f_end = (mk_usize 8 *! i <: usize) +! mk_usize 8 <: usize
+                }
+                <:
+                Core_models.Ops.Range.t_Range usize)
+              (Core_models.Slice.impl__copy_from_slice #u8
+                  (out.[ {
+                        Core_models.Ops.Range.f_start
+                        =
+                        (mk_usize 8 *! i <: usize) +! mk_usize 4 <: usize;
+                        Core_models.Ops.Range.f_end
+                        =
+                        (mk_usize 8 *! i <: usize) +! mk_usize 8 <: usize
+                      }
+                      <:
+                      Core_models.Ops.Range.t_Range usize ]
+                    <:
+                    t_Slice u8)
+                  (Core_models.Num.impl_u32__to_le_bytes (lane.[ mk_usize 1 ] <: u32) <: t_Slice u8)
+                <:
+                t_Slice u8)
+          in
+          out)
+  in
+  out
+
+let impl_KeccakState__store_block (v_RATE: usize) (self: t_KeccakState) (out: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200 &&
+        v_RATE <=. (Core_models.Slice.impl__len #u8 out <: usize))
+      (fun _ -> Prims.l_True) =
+  let out:t_Slice u8 = store_block_2u32 v_RATE self out in
+  out
+
+let store_block_full_2u32 (v_RATE: usize) (s: t_KeccakState) (out: t_Array u8 (mk_usize 200))
+    : Prims.Pure (t_Array u8 (mk_usize 200))
+      (requires (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200)
+      (fun _ -> Prims.l_True) =
+  let out:t_Array u8 (mk_usize 200) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
+      (Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull)
+      (store_block_2u32 v_RATE
+          s
+          (out.[ Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull ]
+            <:
+            t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  out
+
+let impl_KeccakState__store_block_full
+      (v_RATE: usize)
+      (self: t_KeccakState)
+      (out: t_Array u8 (mk_usize 200))
+    : Prims.Pure (t_Array u8 (mk_usize 200))
+      (requires (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 200)
+      (fun _ -> Prims.l_True) =
+  let out:t_Array u8 (mk_usize 200) = store_block_full_2u32 v_RATE self out in
+  out

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.State.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.State.fst
@@ -164,7 +164,7 @@ let impl_KeccakState__set_lane_value (self: t_KeccakState) (i j: usize) (value: 
 let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice u8)
     : Prims.Pure (t_Slice u8)
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
         (Core_models.Slice.impl__len #u8 out <: usize) <=. v_RATE)
       (ensures
         fun out_future ->
@@ -369,7 +369,7 @@ let impl_KeccakState__store (v_RATE: usize) (self: t_KeccakState) (out: t_Slice 
 let load_block_2u32 (v_RATE: usize) (state: t_KeccakState) (blocks: t_Slice u8) (start: usize)
     : Prims.Pure t_KeccakState
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
         ((Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) +
           (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
           <:
@@ -513,7 +513,7 @@ let impl_KeccakState__load_block
       (start: usize)
     : Prims.Pure t_KeccakState
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
         ((Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) +
           (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
           <:
@@ -532,7 +532,7 @@ let load_block_full_2u32
       (start: usize)
     : Prims.Pure t_KeccakState
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
         ((Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) +
           (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
           <:
@@ -549,9 +549,9 @@ let impl_KeccakState__load_block_full
       (start: usize)
     : Prims.Pure t_KeccakState
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
         start <=. mk_usize 200 &&
-        (start +! v_RATE <: usize) <=. mk_usize 144)
+        (start +! v_RATE <: usize) <=. mk_usize 168)
       (fun _ -> Prims.l_True) =
   let self:t_KeccakState = load_block_full_2u32 v_RATE self blocks start in
   self
@@ -559,7 +559,7 @@ let impl_KeccakState__load_block_full
 let store_block_2u32 (v_RATE: usize) (s: t_KeccakState) (out: t_Slice u8)
     : Prims.Pure (t_Slice u8)
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
         v_RATE <=. (Core_models.Slice.impl__len #u8 out <: usize))
       (fun _ -> Prims.l_True) =
   let e_out_len:usize = Core_models.Slice.impl__len #u8 out in
@@ -636,7 +636,7 @@ let store_block_2u32 (v_RATE: usize) (s: t_KeccakState) (out: t_Slice u8)
 let impl_KeccakState__store_block (v_RATE: usize) (self: t_KeccakState) (out: t_Slice u8)
     : Prims.Pure (t_Slice u8)
       (requires
-        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144 &&
+        (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168 &&
         v_RATE <=. (Core_models.Slice.impl__len #u8 out <: usize))
       (fun _ -> Prims.l_True) =
   let out:t_Slice u8 = store_block_2u32 v_RATE self out in
@@ -644,7 +644,7 @@ let impl_KeccakState__store_block (v_RATE: usize) (self: t_KeccakState) (out: t_
 
 let store_block_full_2u32 (v_RATE: usize) (s: t_KeccakState) (out: t_Array u8 (mk_usize 200))
     : Prims.Pure (t_Array u8 (mk_usize 200))
-      (requires (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144)
+      (requires (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168)
       (fun _ -> Prims.l_True) =
   let out:t_Array u8 (mk_usize 200) =
     Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
@@ -664,7 +664,7 @@ let impl_KeccakState__store_block_full
       (self: t_KeccakState)
       (out: t_Array u8 (mk_usize 200))
     : Prims.Pure (t_Array u8 (mk_usize 200))
-      (requires (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 144)
+      (requires (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 && v_RATE <=. mk_usize 168)
       (fun _ -> Prims.l_True) =
   let out:t_Array u8 (mk_usize 200) = store_block_full_2u32 v_RATE self out in
   out

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.State.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.State.fst
@@ -397,22 +397,16 @@ let load_block_2u32
       in
       ()
   in
-  let state_flat:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 25) =
-    Rust_primitives.Hax.repeat (Libcrux_iot_sha3.Lane.impl_Lane2U32__zero ()
-        <:
-        Libcrux_iot_sha3.Lane.t_Lane2U32)
-      (mk_usize 25)
-  in
-  let state_flat:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 25) =
+  let keccak_state:t_KeccakState =
     Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
       (v_RATE /! mk_usize 8 <: usize)
-      (fun state_flat temp_1_ ->
-          let state_flat:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 25) = state_flat in
+      (fun keccak_state temp_1_ ->
+          let keccak_state:t_KeccakState = keccak_state in
           let _:usize = temp_1_ in
           true)
-      state_flat
-      (fun state_flat i ->
-          let state_flat:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 25) = state_flat in
+      keccak_state
+      (fun keccak_state i ->
+          let keccak_state:t_KeccakState = keccak_state in
           let i:usize = i in
           let offset:usize = start +! (mk_usize 8 *! i <: usize) in
           let a:u32 =
@@ -457,33 +451,16 @@ let load_block_2u32
                 <:
                 t_Array u8 (mk_usize 4))
           in
-          let state_flat:t_Array Libcrux_iot_sha3.Lane.t_Lane2U32 (mk_usize 25) =
-            Rust_primitives.Hax.Monomorphized_update_at.update_at_usize state_flat
-              i
-              (Libcrux_iot_sha3.Lane.impl_Lane2U32__interleave (Core_models.Convert.f_from #Libcrux_iot_sha3.Lane.t_Lane2U32
-                      #(t_Array u32 (mk_usize 2))
-                      #FStar.Tactics.Typeclasses.solve
-                      (let list = [a; b] in
-                        FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
-                        Rust_primitives.Hax.array_of_list 2 list)
-                    <:
-                    Libcrux_iot_sha3.Lane.t_Lane2U32)
+          let lane:Libcrux_iot_sha3.Lane.t_Lane2U32 =
+            Libcrux_iot_sha3.Lane.impl_Lane2U32__interleave (Core_models.Convert.f_from #Libcrux_iot_sha3.Lane.t_Lane2U32
+                  #(t_Array u32 (mk_usize 2))
+                  #FStar.Tactics.Typeclasses.solve
+                  (let list = [a; b] in
+                    FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);
+                    Rust_primitives.Hax.array_of_list 2 list)
                 <:
                 Libcrux_iot_sha3.Lane.t_Lane2U32)
           in
-          state_flat)
-  in
-  let keccak_state:t_KeccakState =
-    Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
-      (v_RATE /! mk_usize 8 <: usize)
-      (fun keccak_state temp_1_ ->
-          let keccak_state:t_KeccakState = keccak_state in
-          let _:usize = temp_1_ in
-          true)
-      keccak_state
-      (fun keccak_state i ->
-          let keccak_state:t_KeccakState = keccak_state in
-          let i:usize = i in
           let got:Libcrux_iot_sha3.Lane.t_Lane2U32 =
             impl_KeccakState__get_lane keccak_state
               (i /! mk_usize 5 <: usize)
@@ -495,18 +472,8 @@ let load_block_2u32
               (i %! mk_usize 5 <: usize)
               (Libcrux_iot_sha3.Lane.impl_Lane2U32__from_ints (let list =
                       [
-                        (got.[ mk_usize 0 ] <: u32) ^.
-                        ((state_flat.[ i ] <: Libcrux_iot_sha3.Lane.t_Lane2U32).[ mk_usize 0 ]
-                          <:
-                          u32)
-                        <:
-                        u32;
-                        (got.[ mk_usize 1 ] <: u32) ^.
-                        ((state_flat.[ i ] <: Libcrux_iot_sha3.Lane.t_Lane2U32).[ mk_usize 1 ]
-                          <:
-                          u32)
-                        <:
-                        u32
+                        (got.[ mk_usize 0 ] <: u32) ^. (lane.[ mk_usize 0 ] <: u32) <: u32;
+                        (got.[ mk_usize 1 ] <: u32) ^. (lane.[ mk_usize 1 ] <: u32) <: u32
                       ]
                     in
                     FStar.Pervasives.assert_norm (Prims.eq2 (List.Tot.length list) 2);

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.fst
@@ -422,6 +422,15 @@ let hash (v_LEN: usize) (algorithm: t_Algorithm) (payload: t_Slice u8)
       in
       ()
   in
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        match v_LEN, digest_size algorithm <: (usize & usize) with
+        | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
+      in
+      ()
+  in
   let out:t_Array u8 v_LEN =
     Libcrux_secrets.Traits.f_classify #(t_Array u8 v_LEN)
       #FStar.Tactics.Typeclasses.solve

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.fst
@@ -44,46 +44,107 @@ let t_Algorithm_cast_to_repr (x: t_Algorithm) : u32 =
   | Algorithm_Sha384  -> anon_const_Algorithm_Sha384__anon_const_0
   | Algorithm_Sha512  -> anon_const_Algorithm_Sha512__anon_const_0
 
-let impl_2: Core_models.Clone.t_Clone t_Algorithm =
+let impl_3: Core_models.Clone.t_Clone t_Algorithm =
   { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
-val impl_1': Core_models.Marker.t_Copy t_Algorithm
+val impl_2': Core_models.Marker.t_Copy t_Algorithm
 
 unfold
-let impl_1 = impl_1'
+let impl_2 = impl_2'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
-val impl_3': Core_models.Fmt.t_Debug t_Algorithm
-
-unfold
-let impl_3 = impl_3'
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-assume
-val impl_4': Core_models.Marker.t_StructuralPartialEq t_Algorithm
+val impl_4': Core_models.Fmt.t_Debug t_Algorithm
 
 unfold
 let impl_4 = impl_4'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
-val impl_5': Core_models.Cmp.t_PartialEq t_Algorithm t_Algorithm
+val impl_5': Core_models.Marker.t_StructuralPartialEq t_Algorithm
 
 unfold
 let impl_5 = impl_5'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
-val impl_6': Core_models.Convert.t_From t_Algorithm u32
+val impl_6': Core_models.Cmp.t_PartialEq t_Algorithm t_Algorithm
 
 unfold
 let impl_6 = impl_6'
 
+/// Error returned when a `u32` does not correspond to an [`Algorithm`].
+type t_UnknownAlgorithm = | UnknownAlgorithm : t_UnknownAlgorithm
+
+let impl_8: Core_models.Clone.t_Clone t_UnknownAlgorithm =
+  { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
+
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl: Core_models.Convert.t_From u32 t_Algorithm =
+assume
+val impl_7': Core_models.Marker.t_Copy t_UnknownAlgorithm
+
+unfold
+let impl_7 = impl_7'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_9': Core_models.Fmt.t_Debug t_UnknownAlgorithm
+
+unfold
+let impl_9 = impl_9'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_10': Core_models.Marker.t_StructuralPartialEq t_UnknownAlgorithm
+
+unfold
+let impl_10 = impl_10'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_11': Core_models.Cmp.t_PartialEq t_UnknownAlgorithm t_UnknownAlgorithm
+
+unfold
+let impl_11 = impl_11'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl: Core_models.Convert.t_TryFrom t_Algorithm u32 =
+  {
+    f_Error = t_UnknownAlgorithm;
+    f_try_from_pre = (fun (v: u32) -> true);
+    f_try_from_post
+    =
+    (fun (v: u32) (out: Core_models.Result.t_Result t_Algorithm t_UnknownAlgorithm) -> true);
+    f_try_from
+    =
+    fun (v: u32) ->
+      match v <: u32 with
+      | Rust_primitives.Integers.MkInt 1 ->
+        Core_models.Result.Result_Ok (Algorithm_Sha224 <: t_Algorithm)
+        <:
+        Core_models.Result.t_Result t_Algorithm t_UnknownAlgorithm
+      | Rust_primitives.Integers.MkInt 2 ->
+        Core_models.Result.Result_Ok (Algorithm_Sha256 <: t_Algorithm)
+        <:
+        Core_models.Result.t_Result t_Algorithm t_UnknownAlgorithm
+      | Rust_primitives.Integers.MkInt 3 ->
+        Core_models.Result.Result_Ok (Algorithm_Sha384 <: t_Algorithm)
+        <:
+        Core_models.Result.t_Result t_Algorithm t_UnknownAlgorithm
+      | Rust_primitives.Integers.MkInt 4 ->
+        Core_models.Result.Result_Ok (Algorithm_Sha512 <: t_Algorithm)
+        <:
+        Core_models.Result.t_Result t_Algorithm t_UnknownAlgorithm
+      | _ ->
+        Core_models.Result.Result_Err (UnknownAlgorithm <: t_UnknownAlgorithm)
+        <:
+        Core_models.Result.t_Result t_Algorithm t_UnknownAlgorithm
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1: Core_models.Convert.t_From u32 t_Algorithm =
   {
     f_from_pre = (fun (v: t_Algorithm) -> true);
     f_from_post = (fun (v: t_Algorithm) (out: u32) -> true);

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.fst
@@ -22,7 +22,7 @@ let v_SHA3_384_DIGEST_SIZE: usize = mk_usize 48
 /// Size in bytes of a SHA3 512 digest
 let v_SHA3_512_DIGEST_SIZE: usize = mk_usize 64
 
-/// The Digest Algorithm
+/// The Digest Algorithm.
 type t_Algorithm =
   | Algorithm_Sha224 : t_Algorithm
   | Algorithm_Sha256 : t_Algorithm

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.fst
@@ -1,0 +1,512 @@
+module Libcrux_iot_sha3
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Libcrux_secrets.Int.Public_integers in
+  let open Libcrux_secrets.Traits in
+  ()
+
+/// Size in bytes of a SHA3 244 digest
+let v_SHA3_224_DIGEST_SIZE: usize = mk_usize 28
+
+/// Size in bytes of a SHA3 256 digest
+let v_SHA3_256_DIGEST_SIZE: usize = mk_usize 32
+
+/// Size in bytes of a SHA3 384 digest
+let v_SHA3_384_DIGEST_SIZE: usize = mk_usize 48
+
+/// Size in bytes of a SHA3 512 digest
+let v_SHA3_512_DIGEST_SIZE: usize = mk_usize 64
+
+/// The Digest Algorithm
+type t_Algorithm =
+  | Algorithm_Sha224 : t_Algorithm
+  | Algorithm_Sha256 : t_Algorithm
+  | Algorithm_Sha384 : t_Algorithm
+  | Algorithm_Sha512 : t_Algorithm
+
+let anon_const_Algorithm_Sha224__anon_const_0: u32 = mk_u32 1
+
+let anon_const_Algorithm_Sha256__anon_const_0: u32 = mk_u32 2
+
+let anon_const_Algorithm_Sha384__anon_const_0: u32 = mk_u32 3
+
+let anon_const_Algorithm_Sha512__anon_const_0: u32 = mk_u32 4
+
+let t_Algorithm_cast_to_repr (x: t_Algorithm) : u32 =
+  match x <: t_Algorithm with
+  | Algorithm_Sha224  -> anon_const_Algorithm_Sha224__anon_const_0
+  | Algorithm_Sha256  -> anon_const_Algorithm_Sha256__anon_const_0
+  | Algorithm_Sha384  -> anon_const_Algorithm_Sha384__anon_const_0
+  | Algorithm_Sha512  -> anon_const_Algorithm_Sha512__anon_const_0
+
+let impl_2: Core_models.Clone.t_Clone t_Algorithm =
+  { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_1': Core_models.Marker.t_Copy t_Algorithm
+
+unfold
+let impl_1 = impl_1'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_3': Core_models.Fmt.t_Debug t_Algorithm
+
+unfold
+let impl_3 = impl_3'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_4': Core_models.Marker.t_StructuralPartialEq t_Algorithm
+
+unfold
+let impl_4 = impl_4'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_5': Core_models.Cmp.t_PartialEq t_Algorithm t_Algorithm
+
+unfold
+let impl_5 = impl_5'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_6': Core_models.Convert.t_From t_Algorithm u32
+
+unfold
+let impl_6 = impl_6'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl: Core_models.Convert.t_From u32 t_Algorithm =
+  {
+    f_from_pre = (fun (v: t_Algorithm) -> true);
+    f_from_post = (fun (v: t_Algorithm) (out: u32) -> true);
+    f_from
+    =
+    fun (v: t_Algorithm) ->
+      match v <: t_Algorithm with
+      | Algorithm_Sha224  -> mk_u32 1
+      | Algorithm_Sha256  -> mk_u32 2
+      | Algorithm_Sha384  -> mk_u32 3
+      | Algorithm_Sha512  -> mk_u32 4
+  }
+
+/// Returns the size of a digest in bytes for a given [`Algorithm`].
+let digest_size (mode: t_Algorithm) : usize =
+  match mode <: t_Algorithm with
+  | Algorithm_Sha224  -> v_SHA3_224_DIGEST_SIZE
+  | Algorithm_Sha256  -> v_SHA3_256_DIGEST_SIZE
+  | Algorithm_Sha384  -> v_SHA3_384_DIGEST_SIZE
+  | Algorithm_Sha512  -> v_SHA3_512_DIGEST_SIZE
+
+let keccakx1 (v_RATE: usize) (v_DELIM: u8) (data out: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
+        v_RATE <=. mk_usize 168)
+      (fun _ -> Prims.l_True) =
+  let out:t_Slice u8 = Libcrux_iot_sha3.Keccak.keccak v_RATE v_DELIM data out in
+  out
+
+/// Writes SHA3-224 digest of input payload to externally allocated buffer.
+/// Preconditions:
+/// - `payload` is at most `u32::MAX` bytes long
+/// - `digest` is exactly [`SHA3_224_DIGEST_SIZE`] bytes long
+let sha224_ema (digest payload: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (Core_models.Slice.impl__len #u8 payload <: usize) <=.
+        (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize) &&
+        (Core_models.Slice.impl__len #u8 digest <: usize) =. v_SHA3_224_DIGEST_SIZE)
+      (fun _ -> Prims.l_True) =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        Hax_lib.v_assert ((Core_models.Slice.impl__len #u8 payload <: usize) <=.
+            (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize)
+            <:
+            bool)
+      in
+      ()
+  in
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        Hax_lib.v_assert ((Core_models.Slice.impl__len #u8 digest <: usize) =.
+            v_SHA3_224_DIGEST_SIZE
+            <:
+            bool)
+      in
+      ()
+  in
+  let digest:t_Slice u8 = keccakx1 (mk_usize 144) (mk_u8 6) payload digest in
+  digest
+
+/// Returns SHA3-224 digest of input payload.
+/// Preconditions:
+/// - `payload` is at most `u32::MAX` bytes long
+let sha224 (payload: t_Slice u8)
+    : Prims.Pure (t_Array u8 (mk_usize 28))
+      (requires
+        (Core_models.Slice.impl__len #u8 payload <: usize) <=.
+        (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize))
+      (fun _ -> Prims.l_True) =
+  let out:t_Array u8 (mk_usize 28) =
+    Libcrux_secrets.Traits.f_classify #(t_Array u8 (mk_usize 28))
+      #FStar.Tactics.Typeclasses.solve
+      (Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 28) <: t_Array u8 (mk_usize 28))
+  in
+  let out:t_Array u8 (mk_usize 28) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
+      (Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull)
+      (sha224_ema (out.[ Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull ]
+            <:
+            t_Slice u8)
+          payload
+        <:
+        t_Slice u8)
+  in
+  out
+
+/// Writes SHA3-256 digest of input payload to externally allocated buffer.
+/// Preconditions:
+/// - `payload` is at most `u32::MAX` bytes long
+/// - `digest` is exactly [`SHA3_256_DIGEST_SIZE`] bytes long
+let sha256_ema (digest payload: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (Core_models.Slice.impl__len #u8 payload <: usize) <=.
+        (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize) &&
+        (Core_models.Slice.impl__len #u8 digest <: usize) =. v_SHA3_256_DIGEST_SIZE)
+      (fun _ -> Prims.l_True) =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        Hax_lib.v_assert ((Core_models.Slice.impl__len #u8 payload <: usize) <=.
+            (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize)
+            <:
+            bool)
+      in
+      ()
+  in
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        Hax_lib.v_assert ((Core_models.Slice.impl__len #u8 digest <: usize) =.
+            v_SHA3_256_DIGEST_SIZE
+            <:
+            bool)
+      in
+      ()
+  in
+  let digest:t_Slice u8 = keccakx1 (mk_usize 136) (mk_u8 6) payload digest in
+  digest
+
+/// Returns SHA3-256 digest of input payload.
+/// Preconditions:
+/// - `payload` is at most `u32::MAX` bytes long
+let sha256 (payload: t_Slice u8)
+    : Prims.Pure (t_Array u8 (mk_usize 32))
+      (requires
+        (Core_models.Slice.impl__len #u8 payload <: usize) <=.
+        (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize))
+      (fun _ -> Prims.l_True) =
+  let out:t_Array u8 (mk_usize 32) =
+    Libcrux_secrets.Traits.f_classify #(t_Array u8 (mk_usize 32))
+      #FStar.Tactics.Typeclasses.solve
+      (Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 32) <: t_Array u8 (mk_usize 32))
+  in
+  let out:t_Array u8 (mk_usize 32) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
+      (Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull)
+      (sha256_ema (out.[ Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull ]
+            <:
+            t_Slice u8)
+          payload
+        <:
+        t_Slice u8)
+  in
+  out
+
+/// Writes SHA3-384 digest of input payload to externally allocated buffer.
+/// Preconditions:
+/// - `payload` is at most `u32::MAX` bytes long
+/// - `digest` is exactly [`SHA3_384_DIGEST_SIZE`] bytes long
+let sha384_ema (digest payload: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (Core_models.Slice.impl__len #u8 payload <: usize) <=.
+        (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize) &&
+        (Core_models.Slice.impl__len #u8 digest <: usize) =. v_SHA3_384_DIGEST_SIZE)
+      (fun _ -> Prims.l_True) =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        Hax_lib.v_assert ((Core_models.Slice.impl__len #u8 payload <: usize) <=.
+            (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize)
+            <:
+            bool)
+      in
+      ()
+  in
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        Hax_lib.v_assert ((Core_models.Slice.impl__len #u8 digest <: usize) =.
+            v_SHA3_384_DIGEST_SIZE
+            <:
+            bool)
+      in
+      ()
+  in
+  let digest:t_Slice u8 = keccakx1 (mk_usize 104) (mk_u8 6) payload digest in
+  digest
+
+/// Returns SHA3-384 digest of input payload.
+/// Preconditions:
+/// - `payload` is at most `u32::MAX` bytes long
+let sha384 (payload: t_Slice u8)
+    : Prims.Pure (t_Array u8 (mk_usize 48))
+      (requires
+        (Core_models.Slice.impl__len #u8 payload <: usize) <=.
+        (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize))
+      (fun _ -> Prims.l_True) =
+  let out:t_Array u8 (mk_usize 48) =
+    Libcrux_secrets.Traits.f_classify #(t_Array u8 (mk_usize 48))
+      #FStar.Tactics.Typeclasses.solve
+      (Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 48) <: t_Array u8 (mk_usize 48))
+  in
+  let out:t_Array u8 (mk_usize 48) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
+      (Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull)
+      (sha384_ema (out.[ Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull ]
+            <:
+            t_Slice u8)
+          payload
+        <:
+        t_Slice u8)
+  in
+  out
+
+/// Writes SHA3-512 digest of input payload to externally allocated buffer.
+/// Preconditions:
+/// - `payload` is at most `u32::MAX` bytes long
+/// - `digest` is exactly [`SHA3_512_DIGEST_SIZE`] bytes long
+let sha512_ema (digest payload: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (Core_models.Slice.impl__len #u8 payload <: usize) <=.
+        (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize) &&
+        (Core_models.Slice.impl__len #u8 digest <: usize) =. v_SHA3_512_DIGEST_SIZE)
+      (fun _ -> Prims.l_True) =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        Hax_lib.v_assert ((Core_models.Slice.impl__len #u8 payload <: usize) <=.
+            (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize)
+            <:
+            bool)
+      in
+      ()
+  in
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        Hax_lib.v_assert ((Core_models.Slice.impl__len #u8 digest <: usize) =.
+            v_SHA3_512_DIGEST_SIZE
+            <:
+            bool)
+      in
+      ()
+  in
+  let digest:t_Slice u8 = keccakx1 (mk_usize 72) (mk_u8 6) payload digest in
+  digest
+
+/// Hashes using a particular [`Algorithm`] of the SHA3 family.
+/// # Examples
+///```rust
+/// use libcrux_iot_sha3::{digest_size, hash, Algorithm};
+/// let payload = b\"Kecak is a Balinese dance.\";
+/// let digest: [u8; digest_size(Algorithm::Sha256)] = hash(Algorithm::Sha256, payload);
+/// ```
+let hash (v_LEN: usize) (algorithm: t_Algorithm) (payload: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_LEN)
+      (requires
+        (Core_models.Slice.impl__len #u8 payload <: usize) <=.
+        (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize) &&
+        v_LEN =. (digest_size algorithm <: usize))
+      (fun _ -> Prims.l_True) =
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        Hax_lib.v_assert ((Core_models.Slice.impl__len #u8 payload <: usize) <=.
+            (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize)
+            <:
+            bool)
+      in
+      ()
+  in
+  let out:t_Array u8 v_LEN =
+    Libcrux_secrets.Traits.f_classify #(t_Array u8 v_LEN)
+      #FStar.Tactics.Typeclasses.solve
+      (Rust_primitives.Hax.repeat (mk_u8 0) v_LEN <: t_Array u8 v_LEN)
+  in
+  let out:t_Array u8 v_LEN =
+    match algorithm <: t_Algorithm with
+    | Algorithm_Sha224  ->
+      Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
+        (Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull)
+        (sha224_ema (out.[ Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull ]
+              <:
+              t_Slice u8)
+            payload
+          <:
+          t_Slice u8)
+    | Algorithm_Sha256  ->
+      Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
+        (Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull)
+        (sha256_ema (out.[ Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull ]
+              <:
+              t_Slice u8)
+            payload
+          <:
+          t_Slice u8)
+    | Algorithm_Sha384  ->
+      Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
+        (Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull)
+        (sha384_ema (out.[ Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull ]
+              <:
+              t_Slice u8)
+            payload
+          <:
+          t_Slice u8)
+    | Algorithm_Sha512  ->
+      Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
+        (Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull)
+        (sha512_ema (out.[ Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull ]
+              <:
+              t_Slice u8)
+            payload
+          <:
+          t_Slice u8)
+  in
+  out
+
+/// Returns SHA3-512 digest of input payload.
+/// Preconditions:
+/// - `payload` is at most `u32::MAX` bytes long
+let sha512 (payload: t_Slice u8)
+    : Prims.Pure (t_Array u8 (mk_usize 64))
+      (requires
+        (Core_models.Slice.impl__len #u8 payload <: usize) <=.
+        (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize))
+      (fun _ -> Prims.l_True) =
+  let out:t_Array u8 (mk_usize 64) =
+    Libcrux_secrets.Traits.f_classify #(t_Array u8 (mk_usize 64))
+      #FStar.Tactics.Typeclasses.solve
+      (Rust_primitives.Hax.repeat (mk_u8 0) (mk_usize 64) <: t_Array u8 (mk_usize 64))
+  in
+  let out:t_Array u8 (mk_usize 64) =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
+      (Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull)
+      (sha512_ema (out.[ Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull ]
+            <:
+            t_Slice u8)
+          payload
+        <:
+        t_Slice u8)
+  in
+  out
+
+/// Returns SHAKE-128 digest of input payload.
+/// Preconditions:
+/// - `BYTES` is at most `u32::MAX as usize`
+let shake128 (v_BYTES: usize) (data: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_BYTES)
+      (requires v_BYTES <=. (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize))
+      (fun _ -> Prims.l_True) =
+  let out:t_Array u8 v_BYTES =
+    Libcrux_secrets.Traits.f_classify #(t_Array u8 v_BYTES)
+      #FStar.Tactics.Typeclasses.solve
+      (Rust_primitives.Hax.repeat (mk_u8 0) v_BYTES <: t_Array u8 v_BYTES)
+  in
+  let out:t_Array u8 v_BYTES =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
+      (Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull)
+      (keccakx1 (mk_usize 168)
+          (mk_u8 31)
+          data
+          (out.[ Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull ]
+            <:
+            t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  out
+
+/// Writes SHAKE-128 digest of input payload to externally allocated buffer.
+/// Writes `out.len()` bytes
+/// Preconditions:
+/// - `out` is at most `u32::MAX` bytes long
+let shake128_ema (out data: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (Core_models.Slice.impl__len #u8 out <: usize) <=.
+        (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize))
+      (fun _ -> Prims.l_True) =
+  let out:t_Slice u8 = keccakx1 (mk_usize 168) (mk_u8 31) data out in
+  out
+
+/// Returns SHAKE256 digest of input payload.
+/// Preconditions:
+/// - `BYTES` is at most `u32::MAX as usize`
+let shake256 (v_BYTES: usize) (data: t_Slice u8)
+    : Prims.Pure (t_Array u8 v_BYTES)
+      (requires v_BYTES <=. (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize))
+      (fun _ -> Prims.l_True) =
+  let out:t_Array u8 v_BYTES =
+    Libcrux_secrets.Traits.f_classify #(t_Array u8 v_BYTES)
+      #FStar.Tactics.Typeclasses.solve
+      (Rust_primitives.Hax.repeat (mk_u8 0) v_BYTES <: t_Array u8 v_BYTES)
+  in
+  let out:t_Array u8 v_BYTES =
+    Rust_primitives.Hax.Monomorphized_update_at.update_at_range_full out
+      (Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull)
+      (keccakx1 (mk_usize 136)
+          (mk_u8 31)
+          data
+          (out.[ Core_models.Ops.Range.RangeFull <: Core_models.Ops.Range.t_RangeFull ]
+            <:
+            t_Slice u8)
+        <:
+        t_Slice u8)
+  in
+  out
+
+/// Writes SHAKE256 digest of input payload to externally allocated buffer.
+/// Writes `out.len()` bytes.
+/// Preconditions:
+/// - `out` is at most `u32::MAX` bytes long
+let shake256_ema (out data: t_Slice u8)
+    : Prims.Pure (t_Slice u8)
+      (requires
+        (Core_models.Slice.impl__len #u8 out <: usize) <=.
+        (cast (Core_models.Num.impl_u32__MAX <: u32) <: usize))
+      (fun _ -> Prims.l_True) =
+  let out:t_Slice u8 = keccakx1 (mk_usize 136) (mk_u8 31) data out in
+  out

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Makefile
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Makefile
@@ -1,0 +1,7 @@
+# SLOW_MODULES += Libcrux_ml_kem.Vector.Portable.Serialize.fst
+# ADMIT_MODULES =
+
+FSTAR_INCLUDE_DIRS_EXTRA += ../secrets \
+	      $(shell git rev-parse --show-toplevel)/fstar-helpers/fstar-bitvec \
+
+include $(shell git rev-parse --show-toplevel)/fstar-helpers/Makefile.base

--- a/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Int.Classify_public.fst
+++ b/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Int.Classify_public.fst
@@ -1,0 +1,34 @@
+module Libcrux_secrets.Int.Classify_public
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Libcrux_secrets.Traits in
+  ()
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl
+      (#v_T: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Libcrux_secrets.Traits.t_Scalar v_T)
+    : Libcrux_secrets.Traits.t_ClassifyRef (t_Slice v_T) =
+  {
+    f_ClassifiedRef = t_Slice v_T;
+    f_classify_ref_pre = (fun (self: t_Slice v_T) -> true);
+    f_classify_ref_post = (fun (self: t_Slice v_T) (out: t_Slice v_T) -> true);
+    f_classify_ref = fun (self: t_Slice v_T) -> self
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1
+      (#v_T: Type0)
+      (#[FStar.Tactics.Typeclasses.tcresolve ()] i0: Libcrux_secrets.Traits.t_Scalar v_T)
+    : Libcrux_secrets.Traits.t_DeclassifyRef (t_Slice v_T) =
+  {
+    f_DeclassifiedRef = t_Slice v_T;
+    f_declassify_ref_pre = (fun (self: t_Slice v_T) -> true);
+    f_declassify_ref_post = (fun (self: t_Slice v_T) (out: t_Slice v_T) -> true);
+    f_declassify_ref = fun (self: t_Slice v_T) -> self
+  }

--- a/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Int.Portable.fst
+++ b/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Int.Portable.fst
@@ -1,0 +1,566 @@
+module Libcrux_secrets.Int.Portable
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Libcrux_secrets.Int.Public_integers in
+  let open Libcrux_secrets.Traits in
+  ()
+
+let is_non_zero_32_ (selector: u8) : u32 =
+  Core_models.Hint.black_box #u32
+    (((Core_models.Num.impl_u32__wrapping_add (~.(cast (Core_models.Hint.black_box #u8 selector
+                    <:
+                    u8)
+                <:
+                u32)
+              <:
+              u32)
+            (mk_u32 1)
+          <:
+          u32) >>!
+        mk_i32 31
+        <:
+        u32) &.
+      mk_u32 1
+      <:
+      u32)
+
+let is_non_zero_64_ (selector: u8) : u64 =
+  Core_models.Hint.black_box #u64
+    (((Core_models.Num.impl_u64__wrapping_add (~.(cast (Core_models.Hint.black_box #u8 selector
+                    <:
+                    u8)
+                <:
+                u64)
+              <:
+              u64)
+            (mk_u64 1)
+          <:
+          u64) >>!
+        mk_i32 63
+        <:
+        u64) &.
+      mk_u64 1
+      <:
+      u64)
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl: Libcrux_secrets.Int.t_Select (t_Slice u8) =
+  {
+    f_select_pre = (fun (self: t_Slice u8) (other: t_Slice u8) (selector: u8) -> true);
+    f_select_post
+    =
+    (fun (self: t_Slice u8) (other: t_Slice u8) (selector: u8) (out: t_Slice u8) -> true);
+    f_select
+    =
+    fun (self: t_Slice u8) (other: t_Slice u8) (selector: u8) ->
+      let mask:u8 =
+        Core_models.Num.impl_u8__wrapping_sub (cast (is_non_zero_32_ (Libcrux_secrets.Traits.f_declassify
+                      #u8
+                      #FStar.Tactics.Typeclasses.solve
+                      selector
+                    <:
+                    u8)
+                <:
+                u32)
+            <:
+            u8)
+          (mk_u8 1)
+      in
+      let self:t_Slice u8 =
+        Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+          (Core_models.Slice.impl__len #u8 self <: usize)
+          (fun self temp_1_ ->
+              let self:t_Slice u8 = self in
+              let _:usize = temp_1_ in
+              true)
+          self
+          (fun self i ->
+              let self:t_Slice u8 = self in
+              let i:usize = i in
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
+                i
+                (((self.[ i ] <: u8) &. mask <: u8) |. ((other.[ i ] <: u8) &. (~.mask <: u8) <: u8)
+                  <:
+                  u8)
+              <:
+              t_Slice u8)
+      in
+      self
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1: Libcrux_secrets.Int.t_Select (t_Slice u16) =
+  {
+    f_select_pre = (fun (self: t_Slice u16) (other: t_Slice u16) (selector: u8) -> true);
+    f_select_post
+    =
+    (fun (self: t_Slice u16) (other: t_Slice u16) (selector: u8) (out: t_Slice u16) -> true);
+    f_select
+    =
+    fun (self: t_Slice u16) (other: t_Slice u16) (selector: u8) ->
+      let mask:u16 =
+        Core_models.Num.impl_u16__wrapping_sub (cast (is_non_zero_32_ (Libcrux_secrets.Traits.f_declassify
+                      #u8
+                      #FStar.Tactics.Typeclasses.solve
+                      selector
+                    <:
+                    u8)
+                <:
+                u32)
+            <:
+            u16)
+          (mk_u16 1)
+      in
+      let self:t_Slice u16 =
+        Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+          (Core_models.Slice.impl__len #u16 self <: usize)
+          (fun self temp_1_ ->
+              let self:t_Slice u16 = self in
+              let _:usize = temp_1_ in
+              true)
+          self
+          (fun self i ->
+              let self:t_Slice u16 = self in
+              let i:usize = i in
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
+                i
+                (((self.[ i ] <: u16) &. mask <: u16) |.
+                  ((other.[ i ] <: u16) &. (~.mask <: u16) <: u16)
+                  <:
+                  u16)
+              <:
+              t_Slice u16)
+      in
+      self
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_2: Libcrux_secrets.Int.t_Select (t_Slice u32) =
+  {
+    f_select_pre = (fun (self: t_Slice u32) (other: t_Slice u32) (selector: u8) -> true);
+    f_select_post
+    =
+    (fun (self: t_Slice u32) (other: t_Slice u32) (selector: u8) (out: t_Slice u32) -> true);
+    f_select
+    =
+    fun (self: t_Slice u32) (other: t_Slice u32) (selector: u8) ->
+      let mask:u32 =
+        Core_models.Num.impl_u32__wrapping_sub (is_non_zero_32_ (Libcrux_secrets.Traits.f_declassify
+                  #u8
+                  #FStar.Tactics.Typeclasses.solve
+                  selector
+                <:
+                u8)
+            <:
+            u32)
+          (mk_u32 1)
+      in
+      let self:t_Slice u32 =
+        Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+          (Core_models.Slice.impl__len #u32 self <: usize)
+          (fun self temp_1_ ->
+              let self:t_Slice u32 = self in
+              let _:usize = temp_1_ in
+              true)
+          self
+          (fun self i ->
+              let self:t_Slice u32 = self in
+              let i:usize = i in
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
+                i
+                (((self.[ i ] <: u32) &. mask <: u32) |.
+                  ((other.[ i ] <: u32) &. (~.mask <: u32) <: u32)
+                  <:
+                  u32)
+              <:
+              t_Slice u32)
+      in
+      self
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_3: Libcrux_secrets.Int.t_Select (t_Slice u64) =
+  {
+    f_select_pre = (fun (self: t_Slice u64) (other: t_Slice u64) (selector: u8) -> true);
+    f_select_post
+    =
+    (fun (self: t_Slice u64) (other: t_Slice u64) (selector: u8) (out: t_Slice u64) -> true);
+    f_select
+    =
+    fun (self: t_Slice u64) (other: t_Slice u64) (selector: u8) ->
+      let mask:u64 =
+        Core_models.Num.impl_u64__wrapping_sub (is_non_zero_64_ (Libcrux_secrets.Traits.f_declassify
+                  #u8
+                  #FStar.Tactics.Typeclasses.solve
+                  selector
+                <:
+                u8)
+            <:
+            u64)
+          (mk_u64 1)
+      in
+      let self:t_Slice u64 =
+        Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+          (Core_models.Slice.impl__len #u64 self <: usize)
+          (fun self temp_1_ ->
+              let self:t_Slice u64 = self in
+              let _:usize = temp_1_ in
+              true)
+          self
+          (fun self i ->
+              let self:t_Slice u64 = self in
+              let i:usize = i in
+              Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
+                i
+                (((self.[ i ] <: u64) &. mask <: u64) |.
+                  ((other.[ i ] <: u64) &. (~.mask <: u64) <: u64)
+                  <:
+                  u64)
+              <:
+              t_Slice u64)
+      in
+      self
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_4: Libcrux_secrets.Int.t_Swap (t_Slice u8) =
+  {
+    f_cswap_pre = (fun (self: t_Slice u8) (other: t_Slice u8) (selector: u8) -> true);
+    f_cswap_post
+    =
+    (fun (self: t_Slice u8) (other: t_Slice u8) (selector: u8) (out: (t_Slice u8 & t_Slice u8)) ->
+        true);
+    f_cswap
+    =
+    fun (self: t_Slice u8) (other: t_Slice u8) (selector: u8) ->
+      let _:Prims.unit =
+        if true
+        then
+          let _:Prims.unit =
+            match
+              Core_models.Slice.impl__len #u8 self, Core_models.Slice.impl__len #u8 other
+              <:
+              (usize & usize)
+            with
+            | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
+          in
+          ()
+      in
+      let mask:u8 =
+        Core_models.Hint.black_box #u8
+          (Core_models.Num.impl_u8__wrapping_sub (cast (((Core_models.Num.impl_u32__wrapping_add (~.(
+                              cast (Core_models.Hint.black_box #u8
+                                    (Libcrux_secrets.Traits.f_declassify #u8
+                                        #FStar.Tactics.Typeclasses.solve
+                                        selector
+                                      <:
+                                      u8)
+                                  <:
+                                  u8)
+                              <:
+                              u32)
+                            <:
+                            u32)
+                          (mk_u32 1)
+                        <:
+                        u32) >>!
+                      mk_i32 31
+                      <:
+                      u32) &.
+                    mk_u32 1
+                    <:
+                    u32)
+                <:
+                u8)
+              (mk_u8 1)
+            <:
+            u8)
+      in
+      let (other: t_Slice u8), (self: t_Slice u8) =
+        Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+          (Core_models.Slice.impl__len #u8 self <: usize)
+          (fun temp_0_ temp_1_ ->
+              let (other: t_Slice u8), (self: t_Slice u8) = temp_0_ in
+              let _:usize = temp_1_ in
+              true)
+          (other, self <: (t_Slice u8 & t_Slice u8))
+          (fun temp_0_ i ->
+              let (other: t_Slice u8), (self: t_Slice u8) = temp_0_ in
+              let i:usize = i in
+              let dummy:u8 = (~.mask <: u8) &. ((self.[ i ] <: u8) ^. (other.[ i ] <: u8) <: u8) in
+              let self:t_Slice u8 =
+                Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
+                  i
+                  ((self.[ i ] <: u8) ^. dummy <: u8)
+              in
+              let other:t_Slice u8 =
+                Rust_primitives.Hax.Monomorphized_update_at.update_at_usize other
+                  i
+                  ((other.[ i ] <: u8) ^. dummy <: u8)
+              in
+              other, self <: (t_Slice u8 & t_Slice u8))
+      in
+      self, other <: (t_Slice u8 & t_Slice u8)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_5: Libcrux_secrets.Int.t_Swap (t_Slice u16) =
+  {
+    f_cswap_pre = (fun (self: t_Slice u16) (other: t_Slice u16) (selector: u8) -> true);
+    f_cswap_post
+    =
+    (fun
+        (self: t_Slice u16)
+        (other: t_Slice u16)
+        (selector: u8)
+        (out: (t_Slice u16 & t_Slice u16))
+        ->
+        true);
+    f_cswap
+    =
+    fun (self: t_Slice u16) (other: t_Slice u16) (selector: u8) ->
+      let _:Prims.unit =
+        if true
+        then
+          let _:Prims.unit =
+            match
+              Core_models.Slice.impl__len #u16 self, Core_models.Slice.impl__len #u16 other
+              <:
+              (usize & usize)
+            with
+            | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
+          in
+          ()
+      in
+      let mask:u16 =
+        Core_models.Hint.black_box #u16
+          (Core_models.Num.impl_u16__wrapping_sub (cast (((Core_models.Num.impl_u32__wrapping_add (~.(
+                              cast (Core_models.Hint.black_box #u8
+                                    (Libcrux_secrets.Traits.f_declassify #u8
+                                        #FStar.Tactics.Typeclasses.solve
+                                        selector
+                                      <:
+                                      u8)
+                                  <:
+                                  u8)
+                              <:
+                              u32)
+                            <:
+                            u32)
+                          (mk_u32 1)
+                        <:
+                        u32) >>!
+                      mk_i32 31
+                      <:
+                      u32) &.
+                    mk_u32 1
+                    <:
+                    u32)
+                <:
+                u16)
+              (mk_u16 1)
+            <:
+            u16)
+      in
+      let (other: t_Slice u16), (self: t_Slice u16) =
+        Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+          (Core_models.Slice.impl__len #u16 self <: usize)
+          (fun temp_0_ temp_1_ ->
+              let (other: t_Slice u16), (self: t_Slice u16) = temp_0_ in
+              let _:usize = temp_1_ in
+              true)
+          (other, self <: (t_Slice u16 & t_Slice u16))
+          (fun temp_0_ i ->
+              let (other: t_Slice u16), (self: t_Slice u16) = temp_0_ in
+              let i:usize = i in
+              let dummy:u16 =
+                (~.mask <: u16) &. ((self.[ i ] <: u16) ^. (other.[ i ] <: u16) <: u16)
+              in
+              let self:t_Slice u16 =
+                Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
+                  i
+                  ((self.[ i ] <: u16) ^. dummy <: u16)
+              in
+              let other:t_Slice u16 =
+                Rust_primitives.Hax.Monomorphized_update_at.update_at_usize other
+                  i
+                  ((other.[ i ] <: u16) ^. dummy <: u16)
+              in
+              other, self <: (t_Slice u16 & t_Slice u16))
+      in
+      self, other <: (t_Slice u16 & t_Slice u16)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_6: Libcrux_secrets.Int.t_Swap (t_Slice u32) =
+  {
+    f_cswap_pre = (fun (self: t_Slice u32) (other: t_Slice u32) (selector: u8) -> true);
+    f_cswap_post
+    =
+    (fun
+        (self: t_Slice u32)
+        (other: t_Slice u32)
+        (selector: u8)
+        (out: (t_Slice u32 & t_Slice u32))
+        ->
+        true);
+    f_cswap
+    =
+    fun (self: t_Slice u32) (other: t_Slice u32) (selector: u8) ->
+      let _:Prims.unit =
+        if true
+        then
+          let _:Prims.unit =
+            match
+              Core_models.Slice.impl__len #u32 self, Core_models.Slice.impl__len #u32 other
+              <:
+              (usize & usize)
+            with
+            | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
+          in
+          ()
+      in
+      let mask:u32 =
+        Core_models.Hint.black_box #u32
+          (Core_models.Num.impl_u32__wrapping_sub (((Core_models.Num.impl_u32__wrapping_add (~.(cast
+                            (Core_models.Hint.black_box #u8
+                                (Libcrux_secrets.Traits.f_declassify #u8
+                                    #FStar.Tactics.Typeclasses.solve
+                                    selector
+                                  <:
+                                  u8)
+                              <:
+                              u8)
+                          <:
+                          u32)
+                        <:
+                        u32)
+                      (mk_u32 1)
+                    <:
+                    u32) >>!
+                  mk_i32 31
+                  <:
+                  u32) &.
+                mk_u32 1
+                <:
+                u32)
+              (mk_u32 1)
+            <:
+            u32)
+      in
+      let (other: t_Slice u32), (self: t_Slice u32) =
+        Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+          (Core_models.Slice.impl__len #u32 self <: usize)
+          (fun temp_0_ temp_1_ ->
+              let (other: t_Slice u32), (self: t_Slice u32) = temp_0_ in
+              let _:usize = temp_1_ in
+              true)
+          (other, self <: (t_Slice u32 & t_Slice u32))
+          (fun temp_0_ i ->
+              let (other: t_Slice u32), (self: t_Slice u32) = temp_0_ in
+              let i:usize = i in
+              let dummy:u32 =
+                (~.mask <: u32) &. ((self.[ i ] <: u32) ^. (other.[ i ] <: u32) <: u32)
+              in
+              let self:t_Slice u32 =
+                Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
+                  i
+                  ((self.[ i ] <: u32) ^. dummy <: u32)
+              in
+              let other:t_Slice u32 =
+                Rust_primitives.Hax.Monomorphized_update_at.update_at_usize other
+                  i
+                  ((other.[ i ] <: u32) ^. dummy <: u32)
+              in
+              other, self <: (t_Slice u32 & t_Slice u32))
+      in
+      self, other <: (t_Slice u32 & t_Slice u32)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_7: Libcrux_secrets.Int.t_Swap (t_Slice u64) =
+  {
+    f_cswap_pre = (fun (self: t_Slice u64) (other: t_Slice u64) (selector: u8) -> true);
+    f_cswap_post
+    =
+    (fun
+        (self: t_Slice u64)
+        (other: t_Slice u64)
+        (selector: u8)
+        (out: (t_Slice u64 & t_Slice u64))
+        ->
+        true);
+    f_cswap
+    =
+    fun (self: t_Slice u64) (other: t_Slice u64) (selector: u8) ->
+      let _:Prims.unit =
+        if true
+        then
+          let _:Prims.unit =
+            match
+              Core_models.Slice.impl__len #u64 self, Core_models.Slice.impl__len #u64 other
+              <:
+              (usize & usize)
+            with
+            | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
+          in
+          ()
+      in
+      let mask:u64 =
+        Core_models.Hint.black_box #u64
+          (Core_models.Num.impl_u64__wrapping_sub (((Core_models.Num.impl_u64__wrapping_add (~.(cast
+                            (Libcrux_secrets.Traits.f_declassify #u8
+                                #FStar.Tactics.Typeclasses.solve
+                                selector
+                              <:
+                              u8)
+                          <:
+                          u64)
+                        <:
+                        u64)
+                      (mk_u64 1)
+                    <:
+                    u64) >>!
+                  mk_i32 63
+                  <:
+                  u64) &.
+                mk_u64 1
+                <:
+                u64)
+              (mk_u64 1)
+            <:
+            u64)
+      in
+      let (other: t_Slice u64), (self: t_Slice u64) =
+        Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
+          (Core_models.Slice.impl__len #u64 self <: usize)
+          (fun temp_0_ temp_1_ ->
+              let (other: t_Slice u64), (self: t_Slice u64) = temp_0_ in
+              let _:usize = temp_1_ in
+              true)
+          (other, self <: (t_Slice u64 & t_Slice u64))
+          (fun temp_0_ i ->
+              let (other: t_Slice u64), (self: t_Slice u64) = temp_0_ in
+              let i:usize = i in
+              let dummy:u64 =
+                (~.mask <: u64) &. ((self.[ i ] <: u64) ^. (other.[ i ] <: u64) <: u64)
+              in
+              let self:t_Slice u64 =
+                Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
+                  i
+                  ((self.[ i ] <: u64) ^. dummy <: u64)
+              in
+              let other:t_Slice u64 =
+                Rust_primitives.Hax.Monomorphized_update_at.update_at_usize other
+                  i
+                  ((other.[ i ] <: u64) ^. dummy <: u64)
+              in
+              other, self <: (t_Slice u64 & t_Slice u64))
+      in
+      self, other <: (t_Slice u64 & t_Slice u64)
+  }

--- a/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Int.Portable.fst
+++ b/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Int.Portable.fst
@@ -6,47 +6,51 @@ open Core_models
 let _ =
   (* This module has implicit dependencies, here we make them explicit. *)
   (* The implicit dependencies arise from typeclasses instances. *)
+  let open Libcrux_secrets.Int in
   let open Libcrux_secrets.Int.Public_integers in
   let open Libcrux_secrets.Traits in
   ()
 
-let is_non_zero_32_ (selector: u8) : u32 =
-  Core_models.Hint.black_box #u32
-    (((Core_models.Num.impl_u32__wrapping_add (~.(cast (Core_models.Hint.black_box #u8 selector
-                    <:
-                    u8)
-                <:
-                u32)
-              <:
-              u32)
-            (mk_u32 1)
+/// Mask for constant time swapping/selecting
+/// If selector == 0 -> mask = 0b111..11
+/// If selector != 0 -> mask = 0b000..00
+let ct_mask32 (selector: u8) : u32 =
+  let selector:u8 = Core_models.Hint.black_box #u8 selector in
+  let is_non_zero:u32 =
+    (Core_models.Num.impl_u32__wrapping_add (~.(Libcrux_secrets.Int.f_as_u32 #u8
+              #FStar.Tactics.Typeclasses.solve
+              selector
+            <:
+            u32)
           <:
-          u32) >>!
-        mk_i32 31
-        <:
-        u32) &.
-      mk_u32 1
+          u32)
+        (Libcrux_secrets.Int.v_U32 (mk_u32 1) <: u32)
       <:
-      u32)
+      u32) >>!
+    mk_i32 31
+  in
+  let is_non_zero:u32 = Core_models.Hint.black_box #u32 is_non_zero in
+  let mask:u32 = Core_models.Num.impl_u32__wrapping_sub is_non_zero (mk_u32 1) in
+  Libcrux_secrets.Int.f_as_u32 #u32 #FStar.Tactics.Typeclasses.solve mask
 
-let is_non_zero_64_ (selector: u8) : u64 =
-  Core_models.Hint.black_box #u64
-    (((Core_models.Num.impl_u64__wrapping_add (~.(cast (Core_models.Hint.black_box #u8 selector
-                    <:
-                    u8)
-                <:
-                u64)
-              <:
-              u64)
-            (mk_u64 1)
+let ct_mask64 (selector: u8) : u64 =
+  let selector:u8 = Core_models.Hint.black_box #u8 selector in
+  let is_non_zero:u64 =
+    (Core_models.Num.impl_u64__wrapping_add (~.(Libcrux_secrets.Int.f_as_u64 #u8
+              #FStar.Tactics.Typeclasses.solve
+              selector
+            <:
+            u64)
           <:
-          u64) >>!
-        mk_i32 63
-        <:
-        u64) &.
-      mk_u64 1
+          u64)
+        (Libcrux_secrets.Int.v_U64 (mk_u64 1) <: u64)
       <:
-      u64)
+      u64) >>!
+    mk_i32 63
+  in
+  let is_non_zero:u64 = Core_models.Hint.black_box #u64 is_non_zero in
+  let mask:u64 = Core_models.Num.impl_u64__wrapping_sub is_non_zero (mk_u64 1) in
+  Libcrux_secrets.Int.f_as_u64 #u64 #FStar.Tactics.Typeclasses.solve mask
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 let impl: Libcrux_secrets.Int.t_Select (t_Slice u8) =
@@ -58,18 +62,18 @@ let impl: Libcrux_secrets.Int.t_Select (t_Slice u8) =
     f_select
     =
     fun (self: t_Slice u8) (other: t_Slice u8) (selector: u8) ->
-      let mask:u8 =
-        Core_models.Num.impl_u8__wrapping_sub (cast (is_non_zero_32_ (Libcrux_secrets.Traits.f_declassify
-                      #u8
-                      #FStar.Tactics.Typeclasses.solve
-                      selector
-                    <:
-                    u8)
-                <:
-                u32)
-            <:
-            u8)
-          (mk_u8 1)
+      let _:Prims.unit =
+        match
+          Core_models.Slice.impl__len #u8 self, Core_models.Slice.impl__len #u8 other
+          <:
+          (usize & usize)
+        with
+        | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
+      in
+      let (mask: u8):u8 =
+        Libcrux_secrets.Int.f_as_u8 #u32
+          #FStar.Tactics.Typeclasses.solve
+          (ct_mask32 selector <: u32)
       in
       let self:t_Slice u8 =
         Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
@@ -84,7 +88,12 @@ let impl: Libcrux_secrets.Int.t_Select (t_Slice u8) =
               let i:usize = i in
               Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
                 i
-                (((self.[ i ] <: u8) &. mask <: u8) |. ((other.[ i ] <: u8) &. (~.mask <: u8) <: u8)
+                (Libcrux_secrets.Traits.f_declassify #u8
+                    #FStar.Tactics.Typeclasses.solve
+                    ((mask &. (self.[ i ] <: u8) <: u8) |.
+                      ((~.mask <: u8) &. (other.[ i ] <: u8) <: u8)
+                      <:
+                      u8)
                   <:
                   u8)
               <:
@@ -103,18 +112,18 @@ let impl_1: Libcrux_secrets.Int.t_Select (t_Slice u16) =
     f_select
     =
     fun (self: t_Slice u16) (other: t_Slice u16) (selector: u8) ->
-      let mask:u16 =
-        Core_models.Num.impl_u16__wrapping_sub (cast (is_non_zero_32_ (Libcrux_secrets.Traits.f_declassify
-                      #u8
-                      #FStar.Tactics.Typeclasses.solve
-                      selector
-                    <:
-                    u8)
-                <:
-                u32)
-            <:
-            u16)
-          (mk_u16 1)
+      let _:Prims.unit =
+        match
+          Core_models.Slice.impl__len #u16 self, Core_models.Slice.impl__len #u16 other
+          <:
+          (usize & usize)
+        with
+        | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
+      in
+      let (mask: u16):u16 =
+        Libcrux_secrets.Int.f_as_u16 #u32
+          #FStar.Tactics.Typeclasses.solve
+          (ct_mask32 selector <: u32)
       in
       let self:t_Slice u16 =
         Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
@@ -129,8 +138,12 @@ let impl_1: Libcrux_secrets.Int.t_Select (t_Slice u16) =
               let i:usize = i in
               Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
                 i
-                (((self.[ i ] <: u16) &. mask <: u16) |.
-                  ((other.[ i ] <: u16) &. (~.mask <: u16) <: u16)
+                (Libcrux_secrets.Traits.f_declassify #u16
+                    #FStar.Tactics.Typeclasses.solve
+                    ((mask &. (self.[ i ] <: u16) <: u16) |.
+                      ((~.mask <: u16) &. (other.[ i ] <: u16) <: u16)
+                      <:
+                      u16)
                   <:
                   u16)
               <:
@@ -149,16 +162,18 @@ let impl_2: Libcrux_secrets.Int.t_Select (t_Slice u32) =
     f_select
     =
     fun (self: t_Slice u32) (other: t_Slice u32) (selector: u8) ->
-      let mask:u32 =
-        Core_models.Num.impl_u32__wrapping_sub (is_non_zero_32_ (Libcrux_secrets.Traits.f_declassify
-                  #u8
-                  #FStar.Tactics.Typeclasses.solve
-                  selector
-                <:
-                u8)
-            <:
-            u32)
-          (mk_u32 1)
+      let _:Prims.unit =
+        match
+          Core_models.Slice.impl__len #u32 self, Core_models.Slice.impl__len #u32 other
+          <:
+          (usize & usize)
+        with
+        | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
+      in
+      let (mask: u32):u32 =
+        Libcrux_secrets.Int.f_as_u32 #u32
+          #FStar.Tactics.Typeclasses.solve
+          (ct_mask32 selector <: u32)
       in
       let self:t_Slice u32 =
         Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
@@ -173,8 +188,12 @@ let impl_2: Libcrux_secrets.Int.t_Select (t_Slice u32) =
               let i:usize = i in
               Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
                 i
-                (((self.[ i ] <: u32) &. mask <: u32) |.
-                  ((other.[ i ] <: u32) &. (~.mask <: u32) <: u32)
+                (Libcrux_secrets.Traits.f_declassify #u32
+                    #FStar.Tactics.Typeclasses.solve
+                    ((mask &. (self.[ i ] <: u32) <: u32) |.
+                      ((~.mask <: u32) &. (other.[ i ] <: u32) <: u32)
+                      <:
+                      u32)
                   <:
                   u32)
               <:
@@ -193,16 +212,18 @@ let impl_3: Libcrux_secrets.Int.t_Select (t_Slice u64) =
     f_select
     =
     fun (self: t_Slice u64) (other: t_Slice u64) (selector: u8) ->
-      let mask:u64 =
-        Core_models.Num.impl_u64__wrapping_sub (is_non_zero_64_ (Libcrux_secrets.Traits.f_declassify
-                  #u8
-                  #FStar.Tactics.Typeclasses.solve
-                  selector
-                <:
-                u8)
-            <:
-            u64)
-          (mk_u64 1)
+      let _:Prims.unit =
+        match
+          Core_models.Slice.impl__len #u64 self, Core_models.Slice.impl__len #u64 other
+          <:
+          (usize & usize)
+        with
+        | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
+      in
+      let (mask: u64):u64 =
+        Libcrux_secrets.Int.f_as_u64 #u64
+          #FStar.Tactics.Typeclasses.solve
+          (ct_mask64 selector <: u64)
       in
       let self:t_Slice u64 =
         Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
@@ -217,8 +238,12 @@ let impl_3: Libcrux_secrets.Int.t_Select (t_Slice u64) =
               let i:usize = i in
               Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
                 i
-                (((self.[ i ] <: u64) &. mask <: u64) |.
-                  ((other.[ i ] <: u64) &. (~.mask <: u64) <: u64)
+                (Libcrux_secrets.Traits.f_declassify #u64
+                    #FStar.Tactics.Typeclasses.solve
+                    ((mask &. (self.[ i ] <: u64) <: u64) |.
+                      ((~.mask <: u64) &. (other.[ i ] <: u64) <: u64)
+                      <:
+                      u64)
                   <:
                   u64)
               <:
@@ -239,47 +264,17 @@ let impl_4: Libcrux_secrets.Int.t_Swap (t_Slice u8) =
     =
     fun (self: t_Slice u8) (other: t_Slice u8) (selector: u8) ->
       let _:Prims.unit =
-        if true
-        then
-          let _:Prims.unit =
-            match
-              Core_models.Slice.impl__len #u8 self, Core_models.Slice.impl__len #u8 other
-              <:
-              (usize & usize)
-            with
-            | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
-          in
-          ()
+        match
+          Core_models.Slice.impl__len #u8 self, Core_models.Slice.impl__len #u8 other
+          <:
+          (usize & usize)
+        with
+        | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
       in
-      let mask:u8 =
-        Core_models.Hint.black_box #u8
-          (Core_models.Num.impl_u8__wrapping_sub (cast (((Core_models.Num.impl_u32__wrapping_add (~.(
-                              cast (Core_models.Hint.black_box #u8
-                                    (Libcrux_secrets.Traits.f_declassify #u8
-                                        #FStar.Tactics.Typeclasses.solve
-                                        selector
-                                      <:
-                                      u8)
-                                  <:
-                                  u8)
-                              <:
-                              u32)
-                            <:
-                            u32)
-                          (mk_u32 1)
-                        <:
-                        u32) >>!
-                      mk_i32 31
-                      <:
-                      u32) &.
-                    mk_u32 1
-                    <:
-                    u32)
-                <:
-                u8)
-              (mk_u8 1)
-            <:
-            u8)
+      let (mask: u8):u8 =
+        Libcrux_secrets.Int.f_as_u8 #u32
+          #FStar.Tactics.Typeclasses.solve
+          (ct_mask32 selector <: u32)
       in
       let (other: t_Slice u8), (self: t_Slice u8) =
         Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
@@ -292,16 +287,26 @@ let impl_4: Libcrux_secrets.Int.t_Swap (t_Slice u8) =
           (fun temp_0_ i ->
               let (other: t_Slice u8), (self: t_Slice u8) = temp_0_ in
               let i:usize = i in
-              let dummy:u8 = (~.mask <: u8) &. ((self.[ i ] <: u8) ^. (other.[ i ] <: u8) <: u8) in
+              let (dummy: u8):u8 =
+                (~.mask <: u8) &. ((self.[ i ] <: u8) ^. (other.[ i ] <: u8) <: u8)
+              in
               let self:t_Slice u8 =
                 Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
                   i
-                  ((self.[ i ] <: u8) ^. dummy <: u8)
+                  (Libcrux_secrets.Traits.f_declassify #u8
+                      #FStar.Tactics.Typeclasses.solve
+                      (dummy ^. (self.[ i ] <: u8) <: u8)
+                    <:
+                    u8)
               in
               let other:t_Slice u8 =
                 Rust_primitives.Hax.Monomorphized_update_at.update_at_usize other
                   i
-                  ((other.[ i ] <: u8) ^. dummy <: u8)
+                  (Libcrux_secrets.Traits.f_declassify #u8
+                      #FStar.Tactics.Typeclasses.solve
+                      (dummy ^. (other.[ i ] <: u8) <: u8)
+                    <:
+                    u8)
               in
               other, self <: (t_Slice u8 & t_Slice u8))
       in
@@ -325,47 +330,17 @@ let impl_5: Libcrux_secrets.Int.t_Swap (t_Slice u16) =
     =
     fun (self: t_Slice u16) (other: t_Slice u16) (selector: u8) ->
       let _:Prims.unit =
-        if true
-        then
-          let _:Prims.unit =
-            match
-              Core_models.Slice.impl__len #u16 self, Core_models.Slice.impl__len #u16 other
-              <:
-              (usize & usize)
-            with
-            | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
-          in
-          ()
+        match
+          Core_models.Slice.impl__len #u16 self, Core_models.Slice.impl__len #u16 other
+          <:
+          (usize & usize)
+        with
+        | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
       in
-      let mask:u16 =
-        Core_models.Hint.black_box #u16
-          (Core_models.Num.impl_u16__wrapping_sub (cast (((Core_models.Num.impl_u32__wrapping_add (~.(
-                              cast (Core_models.Hint.black_box #u8
-                                    (Libcrux_secrets.Traits.f_declassify #u8
-                                        #FStar.Tactics.Typeclasses.solve
-                                        selector
-                                      <:
-                                      u8)
-                                  <:
-                                  u8)
-                              <:
-                              u32)
-                            <:
-                            u32)
-                          (mk_u32 1)
-                        <:
-                        u32) >>!
-                      mk_i32 31
-                      <:
-                      u32) &.
-                    mk_u32 1
-                    <:
-                    u32)
-                <:
-                u16)
-              (mk_u16 1)
-            <:
-            u16)
+      let (mask: u16):u16 =
+        Libcrux_secrets.Int.f_as_u16 #u32
+          #FStar.Tactics.Typeclasses.solve
+          (ct_mask32 selector <: u32)
       in
       let (other: t_Slice u16), (self: t_Slice u16) =
         Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
@@ -378,18 +353,26 @@ let impl_5: Libcrux_secrets.Int.t_Swap (t_Slice u16) =
           (fun temp_0_ i ->
               let (other: t_Slice u16), (self: t_Slice u16) = temp_0_ in
               let i:usize = i in
-              let dummy:u16 =
+              let (dummy: u16):u16 =
                 (~.mask <: u16) &. ((self.[ i ] <: u16) ^. (other.[ i ] <: u16) <: u16)
               in
               let self:t_Slice u16 =
                 Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
                   i
-                  ((self.[ i ] <: u16) ^. dummy <: u16)
+                  (Libcrux_secrets.Traits.f_declassify #u16
+                      #FStar.Tactics.Typeclasses.solve
+                      (dummy ^. (self.[ i ] <: u16) <: u16)
+                    <:
+                    u16)
               in
               let other:t_Slice u16 =
                 Rust_primitives.Hax.Monomorphized_update_at.update_at_usize other
                   i
-                  ((other.[ i ] <: u16) ^. dummy <: u16)
+                  (Libcrux_secrets.Traits.f_declassify #u16
+                      #FStar.Tactics.Typeclasses.solve
+                      (dummy ^. (other.[ i ] <: u16) <: u16)
+                    <:
+                    u16)
               in
               other, self <: (t_Slice u16 & t_Slice u16))
       in
@@ -413,45 +396,17 @@ let impl_6: Libcrux_secrets.Int.t_Swap (t_Slice u32) =
     =
     fun (self: t_Slice u32) (other: t_Slice u32) (selector: u8) ->
       let _:Prims.unit =
-        if true
-        then
-          let _:Prims.unit =
-            match
-              Core_models.Slice.impl__len #u32 self, Core_models.Slice.impl__len #u32 other
-              <:
-              (usize & usize)
-            with
-            | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
-          in
-          ()
+        match
+          Core_models.Slice.impl__len #u32 self, Core_models.Slice.impl__len #u32 other
+          <:
+          (usize & usize)
+        with
+        | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
       in
-      let mask:u32 =
-        Core_models.Hint.black_box #u32
-          (Core_models.Num.impl_u32__wrapping_sub (((Core_models.Num.impl_u32__wrapping_add (~.(cast
-                            (Core_models.Hint.black_box #u8
-                                (Libcrux_secrets.Traits.f_declassify #u8
-                                    #FStar.Tactics.Typeclasses.solve
-                                    selector
-                                  <:
-                                  u8)
-                              <:
-                              u8)
-                          <:
-                          u32)
-                        <:
-                        u32)
-                      (mk_u32 1)
-                    <:
-                    u32) >>!
-                  mk_i32 31
-                  <:
-                  u32) &.
-                mk_u32 1
-                <:
-                u32)
-              (mk_u32 1)
-            <:
-            u32)
+      let (mask: u32):u32 =
+        Libcrux_secrets.Int.f_as_u32 #u32
+          #FStar.Tactics.Typeclasses.solve
+          (ct_mask32 selector <: u32)
       in
       let (other: t_Slice u32), (self: t_Slice u32) =
         Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
@@ -464,18 +419,26 @@ let impl_6: Libcrux_secrets.Int.t_Swap (t_Slice u32) =
           (fun temp_0_ i ->
               let (other: t_Slice u32), (self: t_Slice u32) = temp_0_ in
               let i:usize = i in
-              let dummy:u32 =
+              let (dummy: u32):u32 =
                 (~.mask <: u32) &. ((self.[ i ] <: u32) ^. (other.[ i ] <: u32) <: u32)
               in
               let self:t_Slice u32 =
                 Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
                   i
-                  ((self.[ i ] <: u32) ^. dummy <: u32)
+                  (Libcrux_secrets.Traits.f_declassify #u32
+                      #FStar.Tactics.Typeclasses.solve
+                      (dummy ^. (self.[ i ] <: u32) <: u32)
+                    <:
+                    u32)
               in
               let other:t_Slice u32 =
                 Rust_primitives.Hax.Monomorphized_update_at.update_at_usize other
                   i
-                  ((other.[ i ] <: u32) ^. dummy <: u32)
+                  (Libcrux_secrets.Traits.f_declassify #u32
+                      #FStar.Tactics.Typeclasses.solve
+                      (dummy ^. (other.[ i ] <: u32) <: u32)
+                    <:
+                    u32)
               in
               other, self <: (t_Slice u32 & t_Slice u32))
       in
@@ -499,42 +462,17 @@ let impl_7: Libcrux_secrets.Int.t_Swap (t_Slice u64) =
     =
     fun (self: t_Slice u64) (other: t_Slice u64) (selector: u8) ->
       let _:Prims.unit =
-        if true
-        then
-          let _:Prims.unit =
-            match
-              Core_models.Slice.impl__len #u64 self, Core_models.Slice.impl__len #u64 other
-              <:
-              (usize & usize)
-            with
-            | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
-          in
-          ()
+        match
+          Core_models.Slice.impl__len #u64 self, Core_models.Slice.impl__len #u64 other
+          <:
+          (usize & usize)
+        with
+        | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
       in
-      let mask:u64 =
-        Core_models.Hint.black_box #u64
-          (Core_models.Num.impl_u64__wrapping_sub (((Core_models.Num.impl_u64__wrapping_add (~.(cast
-                            (Libcrux_secrets.Traits.f_declassify #u8
-                                #FStar.Tactics.Typeclasses.solve
-                                selector
-                              <:
-                              u8)
-                          <:
-                          u64)
-                        <:
-                        u64)
-                      (mk_u64 1)
-                    <:
-                    u64) >>!
-                  mk_i32 63
-                  <:
-                  u64) &.
-                mk_u64 1
-                <:
-                u64)
-              (mk_u64 1)
-            <:
-            u64)
+      let (mask: u64):u64 =
+        Libcrux_secrets.Int.f_as_u64 #u64
+          #FStar.Tactics.Typeclasses.solve
+          (ct_mask64 selector <: u64)
       in
       let (other: t_Slice u64), (self: t_Slice u64) =
         Rust_primitives.Hax.Folds.fold_range (mk_usize 0)
@@ -547,18 +485,26 @@ let impl_7: Libcrux_secrets.Int.t_Swap (t_Slice u64) =
           (fun temp_0_ i ->
               let (other: t_Slice u64), (self: t_Slice u64) = temp_0_ in
               let i:usize = i in
-              let dummy:u64 =
+              let (dummy: u64):u64 =
                 (~.mask <: u64) &. ((self.[ i ] <: u64) ^. (other.[ i ] <: u64) <: u64)
               in
               let self:t_Slice u64 =
                 Rust_primitives.Hax.Monomorphized_update_at.update_at_usize self
                   i
-                  ((self.[ i ] <: u64) ^. dummy <: u64)
+                  (Libcrux_secrets.Traits.f_declassify #u64
+                      #FStar.Tactics.Typeclasses.solve
+                      (dummy ^. (self.[ i ] <: u64) <: u64)
+                    <:
+                    u64)
               in
               let other:t_Slice u64 =
                 Rust_primitives.Hax.Monomorphized_update_at.update_at_usize other
                   i
-                  ((other.[ i ] <: u64) ^. dummy <: u64)
+                  (Libcrux_secrets.Traits.f_declassify #u64
+                      #FStar.Tactics.Typeclasses.solve
+                      (dummy ^. (other.[ i ] <: u64) <: u64)
+                    <:
+                    u64)
               in
               other, self <: (t_Slice u64 & t_Slice u64))
       in

--- a/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Int.Public_integers.fst
+++ b/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Int.Public_integers.fst
@@ -1,0 +1,51 @@
+module Libcrux_secrets.Int.Public_integers
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+/// Construct a public integer (identity)
+let secret (#v_T: Type0) (x: v_T) : v_T = x
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl (#v_T: Type0) : Libcrux_secrets.Traits.t_Classify v_T =
+  {
+    f_Classified = v_T;
+    f_classify_pre = (fun (self: v_T) -> true);
+    f_classify_post = (fun (self: v_T) (out: v_T) -> true);
+    f_classify = fun (self: v_T) -> self
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1 (#v_T: Type0) : Libcrux_secrets.Traits.t_Declassify v_T =
+  {
+    f_Declassified = v_T;
+    f_declassify_pre = (fun (self: v_T) -> true);
+    f_declassify_post = (fun (self: v_T) (out: v_T) -> true);
+    f_declassify = fun (self: v_T) -> self
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_2 (#v_T: Type0) : Libcrux_secrets.Traits.t_ClassifyRef v_T =
+  {
+    f_ClassifiedRef = v_T;
+    f_classify_ref_pre = (fun (self: v_T) -> true);
+    f_classify_ref_post = (fun (self: v_T) (out: v_T) -> true);
+    f_classify_ref = fun (self: v_T) -> self
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_3 (#v_T: Type0) : Libcrux_secrets.Traits.t_DeclassifyRef v_T =
+  {
+    f_DeclassifiedRef = v_T;
+    f_declassify_ref_pre = (fun (self: v_T) -> true);
+    f_declassify_ref_post = (fun (self: v_T) (out: v_T) -> true);
+    f_declassify_ref = fun (self: v_T) -> self
+  }
+
+/// Classify a mutable slice (identity)
+/// We define a separate function for this because hax has limited support for &mut-returning functions
+let classify_mut_slice (#v_T: Type0) (x: v_T) : v_T = x
+
+/// Classify a mutable slice (identity)
+/// We define a separate function for this because hax has limited support for &mut-returning functions
+let declassify_mut_slice (#v_T: Type0) (x: v_T) : v_T = x

--- a/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Int.fst
+++ b/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Int.fst
@@ -1,0 +1,1269 @@
+module Libcrux_secrets.Int
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+let _ =
+  (* This module has implicit dependencies, here we make them explicit. *)
+  (* The implicit dependencies arise from typeclasses instances. *)
+  let open Libcrux_secrets.Int.Public_integers in
+  let open Libcrux_secrets.Traits in
+  ()
+
+let v_U8 (v: u8) : u8 = Libcrux_secrets.Int.Public_integers.secret #u8 v
+
+let v_U16 (v: u16) : u16 = Libcrux_secrets.Int.Public_integers.secret #u16 v
+
+let v_U32 (v: u32) : u32 = Libcrux_secrets.Int.Public_integers.secret #u32 v
+
+let v_U64 (v: u64) : u64 = Libcrux_secrets.Int.Public_integers.secret #u64 v
+
+let v_U128 (v: u128) : u128 = Libcrux_secrets.Int.Public_integers.secret #u128 v
+
+let v_I8 (v: i8) : i8 = Libcrux_secrets.Int.Public_integers.secret #i8 v
+
+let v_I16 (v: i16) : i16 = Libcrux_secrets.Int.Public_integers.secret #i16 v
+
+let v_I32 (v: i32) : i32 = Libcrux_secrets.Int.Public_integers.secret #i32 v
+
+let v_I64 (v: i64) : i64 = Libcrux_secrets.Int.Public_integers.secret #i64 v
+
+let v_I128 (v: i128) : i128 = Libcrux_secrets.Int.Public_integers.secret #i128 v
+
+/// A trait defining cast operations for secret/public integers
+class t_CastOps (v_Self: Type0) = {
+  f_as_u8_pre:v_Self -> Type0;
+  f_as_u8_post:v_Self -> u8 -> Type0;
+  f_as_u8:x0: v_Self -> Prims.Pure u8 (f_as_u8_pre x0) (fun result -> f_as_u8_post x0 result);
+  f_as_i8_pre:v_Self -> Type0;
+  f_as_i8_post:v_Self -> i8 -> Type0;
+  f_as_i8:x0: v_Self -> Prims.Pure i8 (f_as_i8_pre x0) (fun result -> f_as_i8_post x0 result);
+  f_as_u16_pre:v_Self -> Type0;
+  f_as_u16_post:v_Self -> u16 -> Type0;
+  f_as_u16:x0: v_Self -> Prims.Pure u16 (f_as_u16_pre x0) (fun result -> f_as_u16_post x0 result);
+  f_as_i16_pre:v_Self -> Type0;
+  f_as_i16_post:v_Self -> i16 -> Type0;
+  f_as_i16:x0: v_Self -> Prims.Pure i16 (f_as_i16_pre x0) (fun result -> f_as_i16_post x0 result);
+  f_as_u32_pre:v_Self -> Type0;
+  f_as_u32_post:v_Self -> u32 -> Type0;
+  f_as_u32:x0: v_Self -> Prims.Pure u32 (f_as_u32_pre x0) (fun result -> f_as_u32_post x0 result);
+  f_as_i32_pre:v_Self -> Type0;
+  f_as_i32_post:v_Self -> i32 -> Type0;
+  f_as_i32:x0: v_Self -> Prims.Pure i32 (f_as_i32_pre x0) (fun result -> f_as_i32_post x0 result);
+  f_as_u64_pre:v_Self -> Type0;
+  f_as_u64_post:v_Self -> u64 -> Type0;
+  f_as_u64:x0: v_Self -> Prims.Pure u64 (f_as_u64_pre x0) (fun result -> f_as_u64_post x0 result);
+  f_as_i64_pre:v_Self -> Type0;
+  f_as_i64_post:v_Self -> i64 -> Type0;
+  f_as_i64:x0: v_Self -> Prims.Pure i64 (f_as_i64_pre x0) (fun result -> f_as_i64_post x0 result);
+  f_as_u128_pre:v_Self -> Type0;
+  f_as_u128_post:v_Self -> u128 -> Type0;
+  f_as_u128:x0: v_Self
+    -> Prims.Pure u128 (f_as_u128_pre x0) (fun result -> f_as_u128_post x0 result);
+  f_as_i128_pre:v_Self -> Type0;
+  f_as_i128_post:v_Self -> i128 -> Type0;
+  f_as_i128:x0: v_Self
+    -> Prims.Pure i128 (f_as_i128_pre x0) (fun result -> f_as_i128_post x0 result)
+}
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl: t_CastOps u8 =
+  {
+    f_as_u8_pre = (fun (self: u8) -> true);
+    f_as_u8_post = (fun (self: u8) (out: u8) -> true);
+    f_as_u8
+    =
+    (fun (self: u8) ->
+        Libcrux_secrets.Traits.f_classify #u8
+          #FStar.Tactics.Typeclasses.solve
+          (Libcrux_secrets.Traits.f_declassify #u8 #FStar.Tactics.Typeclasses.solve self <: u8));
+    f_as_i8_pre = (fun (self: u8) -> true);
+    f_as_i8_post = (fun (self: u8) (out: i8) -> true);
+    f_as_i8
+    =
+    (fun (self: u8) ->
+        Libcrux_secrets.Traits.f_classify #i8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u8 #FStar.Tactics.Typeclasses.solve self <: u8
+              )
+            <:
+            i8));
+    f_as_u16_pre = (fun (self: u8) -> true);
+    f_as_u16_post = (fun (self: u8) (out: u16) -> true);
+    f_as_u16
+    =
+    (fun (self: u8) ->
+        Libcrux_secrets.Traits.f_classify #u16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u8 #FStar.Tactics.Typeclasses.solve self <: u8
+              )
+            <:
+            u16));
+    f_as_i16_pre = (fun (self: u8) -> true);
+    f_as_i16_post = (fun (self: u8) (out: i16) -> true);
+    f_as_i16
+    =
+    (fun (self: u8) ->
+        Libcrux_secrets.Traits.f_classify #i16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u8 #FStar.Tactics.Typeclasses.solve self <: u8
+              )
+            <:
+            i16));
+    f_as_u32_pre = (fun (self: u8) -> true);
+    f_as_u32_post = (fun (self: u8) (out: u32) -> true);
+    f_as_u32
+    =
+    (fun (self: u8) ->
+        Libcrux_secrets.Traits.f_classify #u32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u8 #FStar.Tactics.Typeclasses.solve self <: u8
+              )
+            <:
+            u32));
+    f_as_i32_pre = (fun (self: u8) -> true);
+    f_as_i32_post = (fun (self: u8) (out: i32) -> true);
+    f_as_i32
+    =
+    (fun (self: u8) ->
+        Libcrux_secrets.Traits.f_classify #i32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u8 #FStar.Tactics.Typeclasses.solve self <: u8
+              )
+            <:
+            i32));
+    f_as_u64_pre = (fun (self: u8) -> true);
+    f_as_u64_post = (fun (self: u8) (out: u64) -> true);
+    f_as_u64
+    =
+    (fun (self: u8) ->
+        Libcrux_secrets.Traits.f_classify #u64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u8 #FStar.Tactics.Typeclasses.solve self <: u8
+              )
+            <:
+            u64));
+    f_as_i64_pre = (fun (self: u8) -> true);
+    f_as_i64_post = (fun (self: u8) (out: i64) -> true);
+    f_as_i64
+    =
+    (fun (self: u8) ->
+        Libcrux_secrets.Traits.f_classify #i64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u8 #FStar.Tactics.Typeclasses.solve self <: u8
+              )
+            <:
+            i64));
+    f_as_u128_pre = (fun (self: u8) -> true);
+    f_as_u128_post = (fun (self: u8) (out: u128) -> true);
+    f_as_u128
+    =
+    (fun (self: u8) ->
+        Libcrux_secrets.Traits.f_classify #u128
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u8 #FStar.Tactics.Typeclasses.solve self <: u8
+              )
+            <:
+            u128));
+    f_as_i128_pre = (fun (self: u8) -> true);
+    f_as_i128_post = (fun (self: u8) (out: i128) -> true);
+    f_as_i128
+    =
+    fun (self: u8) ->
+      Libcrux_secrets.Traits.f_classify #i128
+        #FStar.Tactics.Typeclasses.solve
+        (cast (Libcrux_secrets.Traits.f_declassify #u8 #FStar.Tactics.Typeclasses.solve self <: u8)
+          <:
+          i128)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_CastOps_for_u16: t_CastOps u16 =
+  {
+    f_as_u8_pre = (fun (self: u16) -> true);
+    f_as_u8_post = (fun (self: u16) (out: u8) -> true);
+    f_as_u8
+    =
+    (fun (self: u16) ->
+        Libcrux_secrets.Traits.f_classify #u8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u16)
+            <:
+            u8));
+    f_as_i8_pre = (fun (self: u16) -> true);
+    f_as_i8_post = (fun (self: u16) (out: i8) -> true);
+    f_as_i8
+    =
+    (fun (self: u16) ->
+        Libcrux_secrets.Traits.f_classify #i8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u16)
+            <:
+            i8));
+    f_as_u16_pre = (fun (self: u16) -> true);
+    f_as_u16_post = (fun (self: u16) (out: u16) -> true);
+    f_as_u16
+    =
+    (fun (self: u16) ->
+        Libcrux_secrets.Traits.f_classify #u16
+          #FStar.Tactics.Typeclasses.solve
+          (Libcrux_secrets.Traits.f_declassify #u16 #FStar.Tactics.Typeclasses.solve self <: u16));
+    f_as_i16_pre = (fun (self: u16) -> true);
+    f_as_i16_post = (fun (self: u16) (out: i16) -> true);
+    f_as_i16
+    =
+    (fun (self: u16) ->
+        Libcrux_secrets.Traits.f_classify #i16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u16)
+            <:
+            i16));
+    f_as_u32_pre = (fun (self: u16) -> true);
+    f_as_u32_post = (fun (self: u16) (out: u32) -> true);
+    f_as_u32
+    =
+    (fun (self: u16) ->
+        Libcrux_secrets.Traits.f_classify #u32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u16)
+            <:
+            u32));
+    f_as_i32_pre = (fun (self: u16) -> true);
+    f_as_i32_post = (fun (self: u16) (out: i32) -> true);
+    f_as_i32
+    =
+    (fun (self: u16) ->
+        Libcrux_secrets.Traits.f_classify #i32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u16)
+            <:
+            i32));
+    f_as_u64_pre = (fun (self: u16) -> true);
+    f_as_u64_post = (fun (self: u16) (out: u64) -> true);
+    f_as_u64
+    =
+    (fun (self: u16) ->
+        Libcrux_secrets.Traits.f_classify #u64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u16)
+            <:
+            u64));
+    f_as_i64_pre = (fun (self: u16) -> true);
+    f_as_i64_post = (fun (self: u16) (out: i64) -> true);
+    f_as_i64
+    =
+    (fun (self: u16) ->
+        Libcrux_secrets.Traits.f_classify #i64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u16)
+            <:
+            i64));
+    f_as_u128_pre = (fun (self: u16) -> true);
+    f_as_u128_post = (fun (self: u16) (out: u128) -> true);
+    f_as_u128
+    =
+    (fun (self: u16) ->
+        Libcrux_secrets.Traits.f_classify #u128
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u16)
+            <:
+            u128));
+    f_as_i128_pre = (fun (self: u16) -> true);
+    f_as_i128_post = (fun (self: u16) (out: i128) -> true);
+    f_as_i128
+    =
+    fun (self: u16) ->
+      Libcrux_secrets.Traits.f_classify #i128
+        #FStar.Tactics.Typeclasses.solve
+        (cast (Libcrux_secrets.Traits.f_declassify #u16 #FStar.Tactics.Typeclasses.solve self <: u16
+            )
+          <:
+          i128)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_CastOps_for_u32: t_CastOps u32 =
+  {
+    f_as_u8_pre = (fun (self: u32) -> true);
+    f_as_u8_post = (fun (self: u32) (out: u8) -> true);
+    f_as_u8
+    =
+    (fun (self: u32) ->
+        Libcrux_secrets.Traits.f_classify #u8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u32)
+            <:
+            u8));
+    f_as_i8_pre = (fun (self: u32) -> true);
+    f_as_i8_post = (fun (self: u32) (out: i8) -> true);
+    f_as_i8
+    =
+    (fun (self: u32) ->
+        Libcrux_secrets.Traits.f_classify #i8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u32)
+            <:
+            i8));
+    f_as_u16_pre = (fun (self: u32) -> true);
+    f_as_u16_post = (fun (self: u32) (out: u16) -> true);
+    f_as_u16
+    =
+    (fun (self: u32) ->
+        Libcrux_secrets.Traits.f_classify #u16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u32)
+            <:
+            u16));
+    f_as_i16_pre = (fun (self: u32) -> true);
+    f_as_i16_post = (fun (self: u32) (out: i16) -> true);
+    f_as_i16
+    =
+    (fun (self: u32) ->
+        Libcrux_secrets.Traits.f_classify #i16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u32)
+            <:
+            i16));
+    f_as_u32_pre = (fun (self: u32) -> true);
+    f_as_u32_post = (fun (self: u32) (out: u32) -> true);
+    f_as_u32
+    =
+    (fun (self: u32) ->
+        Libcrux_secrets.Traits.f_classify #u32
+          #FStar.Tactics.Typeclasses.solve
+          (Libcrux_secrets.Traits.f_declassify #u32 #FStar.Tactics.Typeclasses.solve self <: u32));
+    f_as_i32_pre = (fun (self: u32) -> true);
+    f_as_i32_post = (fun (self: u32) (out: i32) -> true);
+    f_as_i32
+    =
+    (fun (self: u32) ->
+        Libcrux_secrets.Traits.f_classify #i32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u32)
+            <:
+            i32));
+    f_as_u64_pre = (fun (self: u32) -> true);
+    f_as_u64_post = (fun (self: u32) (out: u64) -> true);
+    f_as_u64
+    =
+    (fun (self: u32) ->
+        Libcrux_secrets.Traits.f_classify #u64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u32)
+            <:
+            u64));
+    f_as_i64_pre = (fun (self: u32) -> true);
+    f_as_i64_post = (fun (self: u32) (out: i64) -> true);
+    f_as_i64
+    =
+    (fun (self: u32) ->
+        Libcrux_secrets.Traits.f_classify #i64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u32)
+            <:
+            i64));
+    f_as_u128_pre = (fun (self: u32) -> true);
+    f_as_u128_post = (fun (self: u32) (out: u128) -> true);
+    f_as_u128
+    =
+    (fun (self: u32) ->
+        Libcrux_secrets.Traits.f_classify #u128
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u32)
+            <:
+            u128));
+    f_as_i128_pre = (fun (self: u32) -> true);
+    f_as_i128_post = (fun (self: u32) (out: i128) -> true);
+    f_as_i128
+    =
+    fun (self: u32) ->
+      Libcrux_secrets.Traits.f_classify #i128
+        #FStar.Tactics.Typeclasses.solve
+        (cast (Libcrux_secrets.Traits.f_declassify #u32 #FStar.Tactics.Typeclasses.solve self <: u32
+            )
+          <:
+          i128)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_CastOps_for_u64: t_CastOps u64 =
+  {
+    f_as_u8_pre = (fun (self: u64) -> true);
+    f_as_u8_post = (fun (self: u64) (out: u8) -> true);
+    f_as_u8
+    =
+    (fun (self: u64) ->
+        Libcrux_secrets.Traits.f_classify #u8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u64)
+            <:
+            u8));
+    f_as_i8_pre = (fun (self: u64) -> true);
+    f_as_i8_post = (fun (self: u64) (out: i8) -> true);
+    f_as_i8
+    =
+    (fun (self: u64) ->
+        Libcrux_secrets.Traits.f_classify #i8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u64)
+            <:
+            i8));
+    f_as_u16_pre = (fun (self: u64) -> true);
+    f_as_u16_post = (fun (self: u64) (out: u16) -> true);
+    f_as_u16
+    =
+    (fun (self: u64) ->
+        Libcrux_secrets.Traits.f_classify #u16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u64)
+            <:
+            u16));
+    f_as_i16_pre = (fun (self: u64) -> true);
+    f_as_i16_post = (fun (self: u64) (out: i16) -> true);
+    f_as_i16
+    =
+    (fun (self: u64) ->
+        Libcrux_secrets.Traits.f_classify #i16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u64)
+            <:
+            i16));
+    f_as_u32_pre = (fun (self: u64) -> true);
+    f_as_u32_post = (fun (self: u64) (out: u32) -> true);
+    f_as_u32
+    =
+    (fun (self: u64) ->
+        Libcrux_secrets.Traits.f_classify #u32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u64)
+            <:
+            u32));
+    f_as_i32_pre = (fun (self: u64) -> true);
+    f_as_i32_post = (fun (self: u64) (out: i32) -> true);
+    f_as_i32
+    =
+    (fun (self: u64) ->
+        Libcrux_secrets.Traits.f_classify #i32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u64)
+            <:
+            i32));
+    f_as_u64_pre = (fun (self: u64) -> true);
+    f_as_u64_post = (fun (self: u64) (out: u64) -> true);
+    f_as_u64
+    =
+    (fun (self: u64) ->
+        Libcrux_secrets.Traits.f_classify #u64
+          #FStar.Tactics.Typeclasses.solve
+          (Libcrux_secrets.Traits.f_declassify #u64 #FStar.Tactics.Typeclasses.solve self <: u64));
+    f_as_i64_pre = (fun (self: u64) -> true);
+    f_as_i64_post = (fun (self: u64) (out: i64) -> true);
+    f_as_i64
+    =
+    (fun (self: u64) ->
+        Libcrux_secrets.Traits.f_classify #i64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u64)
+            <:
+            i64));
+    f_as_u128_pre = (fun (self: u64) -> true);
+    f_as_u128_post = (fun (self: u64) (out: u128) -> true);
+    f_as_u128
+    =
+    (fun (self: u64) ->
+        Libcrux_secrets.Traits.f_classify #u128
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u64)
+            <:
+            u128));
+    f_as_i128_pre = (fun (self: u64) -> true);
+    f_as_i128_post = (fun (self: u64) (out: i128) -> true);
+    f_as_i128
+    =
+    fun (self: u64) ->
+      Libcrux_secrets.Traits.f_classify #i128
+        #FStar.Tactics.Typeclasses.solve
+        (cast (Libcrux_secrets.Traits.f_declassify #u64 #FStar.Tactics.Typeclasses.solve self <: u64
+            )
+          <:
+          i128)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_CastOps_for_u128: t_CastOps u128 =
+  {
+    f_as_u8_pre = (fun (self: u128) -> true);
+    f_as_u8_post = (fun (self: u128) (out: u8) -> true);
+    f_as_u8
+    =
+    (fun (self: u128) ->
+        Libcrux_secrets.Traits.f_classify #u8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u128)
+            <:
+            u8));
+    f_as_i8_pre = (fun (self: u128) -> true);
+    f_as_i8_post = (fun (self: u128) (out: i8) -> true);
+    f_as_i8
+    =
+    (fun (self: u128) ->
+        Libcrux_secrets.Traits.f_classify #i8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u128)
+            <:
+            i8));
+    f_as_u16_pre = (fun (self: u128) -> true);
+    f_as_u16_post = (fun (self: u128) (out: u16) -> true);
+    f_as_u16
+    =
+    (fun (self: u128) ->
+        Libcrux_secrets.Traits.f_classify #u16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u128)
+            <:
+            u16));
+    f_as_i16_pre = (fun (self: u128) -> true);
+    f_as_i16_post = (fun (self: u128) (out: i16) -> true);
+    f_as_i16
+    =
+    (fun (self: u128) ->
+        Libcrux_secrets.Traits.f_classify #i16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u128)
+            <:
+            i16));
+    f_as_u32_pre = (fun (self: u128) -> true);
+    f_as_u32_post = (fun (self: u128) (out: u32) -> true);
+    f_as_u32
+    =
+    (fun (self: u128) ->
+        Libcrux_secrets.Traits.f_classify #u32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u128)
+            <:
+            u32));
+    f_as_i32_pre = (fun (self: u128) -> true);
+    f_as_i32_post = (fun (self: u128) (out: i32) -> true);
+    f_as_i32
+    =
+    (fun (self: u128) ->
+        Libcrux_secrets.Traits.f_classify #i32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u128)
+            <:
+            i32));
+    f_as_u64_pre = (fun (self: u128) -> true);
+    f_as_u64_post = (fun (self: u128) (out: u64) -> true);
+    f_as_u64
+    =
+    (fun (self: u128) ->
+        Libcrux_secrets.Traits.f_classify #u64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u128)
+            <:
+            u64));
+    f_as_i64_pre = (fun (self: u128) -> true);
+    f_as_i64_post = (fun (self: u128) (out: i64) -> true);
+    f_as_i64
+    =
+    (fun (self: u128) ->
+        Libcrux_secrets.Traits.f_classify #i64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #u128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                u128)
+            <:
+            i64));
+    f_as_u128_pre = (fun (self: u128) -> true);
+    f_as_u128_post = (fun (self: u128) (out: u128) -> true);
+    f_as_u128
+    =
+    (fun (self: u128) ->
+        Libcrux_secrets.Traits.f_classify #u128
+          #FStar.Tactics.Typeclasses.solve
+          (Libcrux_secrets.Traits.f_declassify #u128 #FStar.Tactics.Typeclasses.solve self <: u128));
+    f_as_i128_pre = (fun (self: u128) -> true);
+    f_as_i128_post = (fun (self: u128) (out: i128) -> true);
+    f_as_i128
+    =
+    fun (self: u128) ->
+      Libcrux_secrets.Traits.f_classify #i128
+        #FStar.Tactics.Typeclasses.solve
+        (cast (Libcrux_secrets.Traits.f_declassify #u128 #FStar.Tactics.Typeclasses.solve self
+              <:
+              u128)
+          <:
+          i128)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_CastOps_for_i8: t_CastOps i8 =
+  {
+    f_as_u8_pre = (fun (self: i8) -> true);
+    f_as_u8_post = (fun (self: i8) (out: u8) -> true);
+    f_as_u8
+    =
+    (fun (self: i8) ->
+        Libcrux_secrets.Traits.f_classify #u8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i8 #FStar.Tactics.Typeclasses.solve self <: i8
+              )
+            <:
+            u8));
+    f_as_i8_pre = (fun (self: i8) -> true);
+    f_as_i8_post = (fun (self: i8) (out: i8) -> true);
+    f_as_i8
+    =
+    (fun (self: i8) ->
+        Libcrux_secrets.Traits.f_classify #i8
+          #FStar.Tactics.Typeclasses.solve
+          (Libcrux_secrets.Traits.f_declassify #i8 #FStar.Tactics.Typeclasses.solve self <: i8));
+    f_as_u16_pre = (fun (self: i8) -> true);
+    f_as_u16_post = (fun (self: i8) (out: u16) -> true);
+    f_as_u16
+    =
+    (fun (self: i8) ->
+        Libcrux_secrets.Traits.f_classify #u16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i8 #FStar.Tactics.Typeclasses.solve self <: i8
+              )
+            <:
+            u16));
+    f_as_i16_pre = (fun (self: i8) -> true);
+    f_as_i16_post = (fun (self: i8) (out: i16) -> true);
+    f_as_i16
+    =
+    (fun (self: i8) ->
+        Libcrux_secrets.Traits.f_classify #i16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i8 #FStar.Tactics.Typeclasses.solve self <: i8
+              )
+            <:
+            i16));
+    f_as_u32_pre = (fun (self: i8) -> true);
+    f_as_u32_post = (fun (self: i8) (out: u32) -> true);
+    f_as_u32
+    =
+    (fun (self: i8) ->
+        Libcrux_secrets.Traits.f_classify #u32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i8 #FStar.Tactics.Typeclasses.solve self <: i8
+              )
+            <:
+            u32));
+    f_as_i32_pre = (fun (self: i8) -> true);
+    f_as_i32_post = (fun (self: i8) (out: i32) -> true);
+    f_as_i32
+    =
+    (fun (self: i8) ->
+        Libcrux_secrets.Traits.f_classify #i32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i8 #FStar.Tactics.Typeclasses.solve self <: i8
+              )
+            <:
+            i32));
+    f_as_u64_pre = (fun (self: i8) -> true);
+    f_as_u64_post = (fun (self: i8) (out: u64) -> true);
+    f_as_u64
+    =
+    (fun (self: i8) ->
+        Libcrux_secrets.Traits.f_classify #u64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i8 #FStar.Tactics.Typeclasses.solve self <: i8
+              )
+            <:
+            u64));
+    f_as_i64_pre = (fun (self: i8) -> true);
+    f_as_i64_post = (fun (self: i8) (out: i64) -> true);
+    f_as_i64
+    =
+    (fun (self: i8) ->
+        Libcrux_secrets.Traits.f_classify #i64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i8 #FStar.Tactics.Typeclasses.solve self <: i8
+              )
+            <:
+            i64));
+    f_as_u128_pre = (fun (self: i8) -> true);
+    f_as_u128_post = (fun (self: i8) (out: u128) -> true);
+    f_as_u128
+    =
+    (fun (self: i8) ->
+        Libcrux_secrets.Traits.f_classify #u128
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i8 #FStar.Tactics.Typeclasses.solve self <: i8
+              )
+            <:
+            u128));
+    f_as_i128_pre = (fun (self: i8) -> true);
+    f_as_i128_post = (fun (self: i8) (out: i128) -> true);
+    f_as_i128
+    =
+    fun (self: i8) ->
+      Libcrux_secrets.Traits.f_classify #i128
+        #FStar.Tactics.Typeclasses.solve
+        (cast (Libcrux_secrets.Traits.f_declassify #i8 #FStar.Tactics.Typeclasses.solve self <: i8)
+          <:
+          i128)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_CastOps_for_i16: t_CastOps i16 =
+  {
+    f_as_u8_pre = (fun (self: i16) -> true);
+    f_as_u8_post = (fun (self: i16) (out: u8) -> true);
+    f_as_u8
+    =
+    (fun (self: i16) ->
+        Libcrux_secrets.Traits.f_classify #u8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i16)
+            <:
+            u8));
+    f_as_i8_pre = (fun (self: i16) -> true);
+    f_as_i8_post = (fun (self: i16) (out: i8) -> true);
+    f_as_i8
+    =
+    (fun (self: i16) ->
+        Libcrux_secrets.Traits.f_classify #i8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i16)
+            <:
+            i8));
+    f_as_u16_pre = (fun (self: i16) -> true);
+    f_as_u16_post = (fun (self: i16) (out: u16) -> true);
+    f_as_u16
+    =
+    (fun (self: i16) ->
+        Libcrux_secrets.Traits.f_classify #u16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i16)
+            <:
+            u16));
+    f_as_i16_pre = (fun (self: i16) -> true);
+    f_as_i16_post = (fun (self: i16) (out: i16) -> true);
+    f_as_i16
+    =
+    (fun (self: i16) ->
+        Libcrux_secrets.Traits.f_classify #i16
+          #FStar.Tactics.Typeclasses.solve
+          (Libcrux_secrets.Traits.f_declassify #i16 #FStar.Tactics.Typeclasses.solve self <: i16));
+    f_as_u32_pre = (fun (self: i16) -> true);
+    f_as_u32_post = (fun (self: i16) (out: u32) -> true);
+    f_as_u32
+    =
+    (fun (self: i16) ->
+        Libcrux_secrets.Traits.f_classify #u32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i16)
+            <:
+            u32));
+    f_as_i32_pre = (fun (self: i16) -> true);
+    f_as_i32_post = (fun (self: i16) (out: i32) -> true);
+    f_as_i32
+    =
+    (fun (self: i16) ->
+        Libcrux_secrets.Traits.f_classify #i32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i16)
+            <:
+            i32));
+    f_as_u64_pre = (fun (self: i16) -> true);
+    f_as_u64_post = (fun (self: i16) (out: u64) -> true);
+    f_as_u64
+    =
+    (fun (self: i16) ->
+        Libcrux_secrets.Traits.f_classify #u64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i16)
+            <:
+            u64));
+    f_as_i64_pre = (fun (self: i16) -> true);
+    f_as_i64_post = (fun (self: i16) (out: i64) -> true);
+    f_as_i64
+    =
+    (fun (self: i16) ->
+        Libcrux_secrets.Traits.f_classify #i64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i16)
+            <:
+            i64));
+    f_as_u128_pre = (fun (self: i16) -> true);
+    f_as_u128_post = (fun (self: i16) (out: u128) -> true);
+    f_as_u128
+    =
+    (fun (self: i16) ->
+        Libcrux_secrets.Traits.f_classify #u128
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i16 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i16)
+            <:
+            u128));
+    f_as_i128_pre = (fun (self: i16) -> true);
+    f_as_i128_post = (fun (self: i16) (out: i128) -> true);
+    f_as_i128
+    =
+    fun (self: i16) ->
+      Libcrux_secrets.Traits.f_classify #i128
+        #FStar.Tactics.Typeclasses.solve
+        (cast (Libcrux_secrets.Traits.f_declassify #i16 #FStar.Tactics.Typeclasses.solve self <: i16
+            )
+          <:
+          i128)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_CastOps_for_i32: t_CastOps i32 =
+  {
+    f_as_u8_pre = (fun (self: i32) -> true);
+    f_as_u8_post = (fun (self: i32) (out: u8) -> true);
+    f_as_u8
+    =
+    (fun (self: i32) ->
+        Libcrux_secrets.Traits.f_classify #u8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i32)
+            <:
+            u8));
+    f_as_i8_pre = (fun (self: i32) -> true);
+    f_as_i8_post = (fun (self: i32) (out: i8) -> true);
+    f_as_i8
+    =
+    (fun (self: i32) ->
+        Libcrux_secrets.Traits.f_classify #i8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i32)
+            <:
+            i8));
+    f_as_u16_pre = (fun (self: i32) -> true);
+    f_as_u16_post = (fun (self: i32) (out: u16) -> true);
+    f_as_u16
+    =
+    (fun (self: i32) ->
+        Libcrux_secrets.Traits.f_classify #u16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i32)
+            <:
+            u16));
+    f_as_i16_pre = (fun (self: i32) -> true);
+    f_as_i16_post = (fun (self: i32) (out: i16) -> true);
+    f_as_i16
+    =
+    (fun (self: i32) ->
+        Libcrux_secrets.Traits.f_classify #i16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i32)
+            <:
+            i16));
+    f_as_u32_pre = (fun (self: i32) -> true);
+    f_as_u32_post = (fun (self: i32) (out: u32) -> true);
+    f_as_u32
+    =
+    (fun (self: i32) ->
+        Libcrux_secrets.Traits.f_classify #u32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i32)
+            <:
+            u32));
+    f_as_i32_pre = (fun (self: i32) -> true);
+    f_as_i32_post = (fun (self: i32) (out: i32) -> true);
+    f_as_i32
+    =
+    (fun (self: i32) ->
+        Libcrux_secrets.Traits.f_classify #i32
+          #FStar.Tactics.Typeclasses.solve
+          (Libcrux_secrets.Traits.f_declassify #i32 #FStar.Tactics.Typeclasses.solve self <: i32));
+    f_as_u64_pre = (fun (self: i32) -> true);
+    f_as_u64_post = (fun (self: i32) (out: u64) -> true);
+    f_as_u64
+    =
+    (fun (self: i32) ->
+        Libcrux_secrets.Traits.f_classify #u64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i32)
+            <:
+            u64));
+    f_as_i64_pre = (fun (self: i32) -> true);
+    f_as_i64_post = (fun (self: i32) (out: i64) -> true);
+    f_as_i64
+    =
+    (fun (self: i32) ->
+        Libcrux_secrets.Traits.f_classify #i64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i32)
+            <:
+            i64));
+    f_as_u128_pre = (fun (self: i32) -> true);
+    f_as_u128_post = (fun (self: i32) (out: u128) -> true);
+    f_as_u128
+    =
+    (fun (self: i32) ->
+        Libcrux_secrets.Traits.f_classify #u128
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i32 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i32)
+            <:
+            u128));
+    f_as_i128_pre = (fun (self: i32) -> true);
+    f_as_i128_post = (fun (self: i32) (out: i128) -> true);
+    f_as_i128
+    =
+    fun (self: i32) ->
+      Libcrux_secrets.Traits.f_classify #i128
+        #FStar.Tactics.Typeclasses.solve
+        (cast (Libcrux_secrets.Traits.f_declassify #i32 #FStar.Tactics.Typeclasses.solve self <: i32
+            )
+          <:
+          i128)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_CastOps_for_i64: t_CastOps i64 =
+  {
+    f_as_u8_pre = (fun (self: i64) -> true);
+    f_as_u8_post = (fun (self: i64) (out: u8) -> true);
+    f_as_u8
+    =
+    (fun (self: i64) ->
+        Libcrux_secrets.Traits.f_classify #u8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i64)
+            <:
+            u8));
+    f_as_i8_pre = (fun (self: i64) -> true);
+    f_as_i8_post = (fun (self: i64) (out: i8) -> true);
+    f_as_i8
+    =
+    (fun (self: i64) ->
+        Libcrux_secrets.Traits.f_classify #i8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i64)
+            <:
+            i8));
+    f_as_u16_pre = (fun (self: i64) -> true);
+    f_as_u16_post = (fun (self: i64) (out: u16) -> true);
+    f_as_u16
+    =
+    (fun (self: i64) ->
+        Libcrux_secrets.Traits.f_classify #u16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i64)
+            <:
+            u16));
+    f_as_i16_pre = (fun (self: i64) -> true);
+    f_as_i16_post = (fun (self: i64) (out: i16) -> true);
+    f_as_i16
+    =
+    (fun (self: i64) ->
+        Libcrux_secrets.Traits.f_classify #i16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i64)
+            <:
+            i16));
+    f_as_u32_pre = (fun (self: i64) -> true);
+    f_as_u32_post = (fun (self: i64) (out: u32) -> true);
+    f_as_u32
+    =
+    (fun (self: i64) ->
+        Libcrux_secrets.Traits.f_classify #u32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i64)
+            <:
+            u32));
+    f_as_i32_pre = (fun (self: i64) -> true);
+    f_as_i32_post = (fun (self: i64) (out: i32) -> true);
+    f_as_i32
+    =
+    (fun (self: i64) ->
+        Libcrux_secrets.Traits.f_classify #i32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i64)
+            <:
+            i32));
+    f_as_u64_pre = (fun (self: i64) -> true);
+    f_as_u64_post = (fun (self: i64) (out: u64) -> true);
+    f_as_u64
+    =
+    (fun (self: i64) ->
+        Libcrux_secrets.Traits.f_classify #u64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i64)
+            <:
+            u64));
+    f_as_i64_pre = (fun (self: i64) -> true);
+    f_as_i64_post = (fun (self: i64) (out: i64) -> true);
+    f_as_i64
+    =
+    (fun (self: i64) ->
+        Libcrux_secrets.Traits.f_classify #i64
+          #FStar.Tactics.Typeclasses.solve
+          (Libcrux_secrets.Traits.f_declassify #i64 #FStar.Tactics.Typeclasses.solve self <: i64));
+    f_as_u128_pre = (fun (self: i64) -> true);
+    f_as_u128_post = (fun (self: i64) (out: u128) -> true);
+    f_as_u128
+    =
+    (fun (self: i64) ->
+        Libcrux_secrets.Traits.f_classify #u128
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i64 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i64)
+            <:
+            u128));
+    f_as_i128_pre = (fun (self: i64) -> true);
+    f_as_i128_post = (fun (self: i64) (out: i128) -> true);
+    f_as_i128
+    =
+    fun (self: i64) ->
+      Libcrux_secrets.Traits.f_classify #i128
+        #FStar.Tactics.Typeclasses.solve
+        (cast (Libcrux_secrets.Traits.f_declassify #i64 #FStar.Tactics.Typeclasses.solve self <: i64
+            )
+          <:
+          i128)
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_CastOps_for_i128: t_CastOps i128 =
+  {
+    f_as_u8_pre = (fun (self: i128) -> true);
+    f_as_u8_post = (fun (self: i128) (out: u8) -> true);
+    f_as_u8
+    =
+    (fun (self: i128) ->
+        Libcrux_secrets.Traits.f_classify #u8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i128)
+            <:
+            u8));
+    f_as_i8_pre = (fun (self: i128) -> true);
+    f_as_i8_post = (fun (self: i128) (out: i8) -> true);
+    f_as_i8
+    =
+    (fun (self: i128) ->
+        Libcrux_secrets.Traits.f_classify #i8
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i128)
+            <:
+            i8));
+    f_as_u16_pre = (fun (self: i128) -> true);
+    f_as_u16_post = (fun (self: i128) (out: u16) -> true);
+    f_as_u16
+    =
+    (fun (self: i128) ->
+        Libcrux_secrets.Traits.f_classify #u16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i128)
+            <:
+            u16));
+    f_as_i16_pre = (fun (self: i128) -> true);
+    f_as_i16_post = (fun (self: i128) (out: i16) -> true);
+    f_as_i16
+    =
+    (fun (self: i128) ->
+        Libcrux_secrets.Traits.f_classify #i16
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i128)
+            <:
+            i16));
+    f_as_u32_pre = (fun (self: i128) -> true);
+    f_as_u32_post = (fun (self: i128) (out: u32) -> true);
+    f_as_u32
+    =
+    (fun (self: i128) ->
+        Libcrux_secrets.Traits.f_classify #u32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i128)
+            <:
+            u32));
+    f_as_i32_pre = (fun (self: i128) -> true);
+    f_as_i32_post = (fun (self: i128) (out: i32) -> true);
+    f_as_i32
+    =
+    (fun (self: i128) ->
+        Libcrux_secrets.Traits.f_classify #i32
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i128)
+            <:
+            i32));
+    f_as_u64_pre = (fun (self: i128) -> true);
+    f_as_u64_post = (fun (self: i128) (out: u64) -> true);
+    f_as_u64
+    =
+    (fun (self: i128) ->
+        Libcrux_secrets.Traits.f_classify #u64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i128)
+            <:
+            u64));
+    f_as_i64_pre = (fun (self: i128) -> true);
+    f_as_i64_post = (fun (self: i128) (out: i64) -> true);
+    f_as_i64
+    =
+    (fun (self: i128) ->
+        Libcrux_secrets.Traits.f_classify #i64
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i128)
+            <:
+            i64));
+    f_as_u128_pre = (fun (self: i128) -> true);
+    f_as_u128_post = (fun (self: i128) (out: u128) -> true);
+    f_as_u128
+    =
+    (fun (self: i128) ->
+        Libcrux_secrets.Traits.f_classify #u128
+          #FStar.Tactics.Typeclasses.solve
+          (cast (Libcrux_secrets.Traits.f_declassify #i128 #FStar.Tactics.Typeclasses.solve self
+                <:
+                i128)
+            <:
+            u128));
+    f_as_i128_pre = (fun (self: i128) -> true);
+    f_as_i128_post = (fun (self: i128) (out: i128) -> true);
+    f_as_i128
+    =
+    fun (self: i128) ->
+      Libcrux_secrets.Traits.f_classify #i128
+        #FStar.Tactics.Typeclasses.solve
+        (Libcrux_secrets.Traits.f_declassify #i128 #FStar.Tactics.Typeclasses.solve self <: i128)
+  }
+
+/// Best effort constant time swapping of values.
+class t_Swap (v_Self: Type0) = {
+  f_cswap_pre:v_Self -> v_Self -> u8 -> Type0;
+  f_cswap_post:v_Self -> v_Self -> u8 -> (v_Self & v_Self) -> Type0;
+  f_cswap:x0: v_Self -> x1: v_Self -> x2: u8
+    -> Prims.Pure (v_Self & v_Self)
+        (f_cswap_pre x0 x1 x2)
+        (fun result -> f_cswap_post x0 x1 x2 result)
+}
+
+/// Best effort constant time selection of values.
+class t_Select (v_Self: Type0) = {
+  f_select_pre:v_Self -> v_Self -> u8 -> Type0;
+  f_select_post:v_Self -> v_Self -> u8 -> v_Self -> Type0;
+  f_select:x0: v_Self -> x1: v_Self -> x2: u8
+    -> Prims.Pure v_Self (f_select_pre x0 x1 x2) (fun result -> f_select_post x0 x1 x2 result)
+}

--- a/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Mem_requests.fst
+++ b/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Mem_requests.fst
@@ -1,0 +1,12 @@
+module Libcrux_secrets.Mem_requests
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+/// Mark memory as secret.
+/// No-op if `valgrind_ct_test` cfg is not enabled.
+let ct_classify (#v_T: Type0) (v_val: v_T) : Prims.unit = ()
+
+/// Declassify secret memory.
+/// No-op if `valgrind_ct_test` cfg is not enabled.
+let ct_declassify (#v_T: Type0) (v_val: v_T) : Prims.unit = ()

--- a/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Traits.fst
+++ b/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Traits.fst
@@ -1,0 +1,207 @@
+module Libcrux_secrets.Traits
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 15"
+open FStar.Mul
+open Core_models
+
+/// Marker trait for scalar types (machine integers)
+class t_Scalar (v_Self: Type0) = {
+  [@@@ FStar.Tactics.Typeclasses.no_method]_super_i0:Core_models.Marker.t_Copy v_Self
+}
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let _ = fun (v_Self:Type0) {|i: t_Scalar v_Self|} -> i._super_i0
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl: t_Scalar u8 = { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_Scalar_for_u16: t_Scalar u16 = { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_Scalar_for_u32: t_Scalar u32 = { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_Scalar_for_u64: t_Scalar u64 = { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_Scalar_for_u128: t_Scalar u128 = { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_Scalar_for_i8: t_Scalar i8 = { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_Scalar_for_i16: t_Scalar i16 = { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_Scalar_for_i32: t_Scalar i32 = { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_Scalar_for_i64: t_Scalar i64 = { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_Scalar_for_i128: t_Scalar i128 = { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+/// A trait for integer operations provided by Rust for machine integers
+class t_IntOps (v_Self: Type0) = {
+  f_wrapping_add_pre:#v_T: Type0 -> {| i0: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
+    -> Type0;
+  f_wrapping_add_post:
+      #v_T: Type0 ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
+      v_Self ->
+      v_T ->
+      v_Self
+    -> Type0;
+  f_wrapping_add:
+      #v_T: Type0 ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
+      x0: v_Self ->
+      x1: v_T
+    -> Prims.Pure v_Self
+        (f_wrapping_add_pre #v_T #i0 x0 x1)
+        (fun result -> f_wrapping_add_post #v_T #i0 x0 x1 result);
+  f_wrapping_sub_pre:#v_T: Type0 -> {| i0: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
+    -> Type0;
+  f_wrapping_sub_post:
+      #v_T: Type0 ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
+      v_Self ->
+      v_T ->
+      v_Self
+    -> Type0;
+  f_wrapping_sub:
+      #v_T: Type0 ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
+      x0: v_Self ->
+      x1: v_T
+    -> Prims.Pure v_Self
+        (f_wrapping_sub_pre #v_T #i0 x0 x1)
+        (fun result -> f_wrapping_sub_post #v_T #i0 x0 x1 result);
+  f_wrapping_mul_pre:#v_T: Type0 -> {| i0: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
+    -> Type0;
+  f_wrapping_mul_post:
+      #v_T: Type0 ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
+      v_Self ->
+      v_T ->
+      v_Self
+    -> Type0;
+  f_wrapping_mul:
+      #v_T: Type0 ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
+      x0: v_Self ->
+      x1: v_T
+    -> Prims.Pure v_Self
+        (f_wrapping_mul_pre #v_T #i0 x0 x1)
+        (fun result -> f_wrapping_mul_post #v_T #i0 x0 x1 result);
+  f_wrapping_neg_pre:v_Self -> Type0;
+  f_wrapping_neg_post:v_Self -> v_Self -> Type0;
+  f_wrapping_neg:x0: v_Self
+    -> Prims.Pure v_Self (f_wrapping_neg_pre x0) (fun result -> f_wrapping_neg_post x0 result);
+  f_rotate_left_pre:v_Self -> u32 -> Type0;
+  f_rotate_left_post:v_Self -> u32 -> v_Self -> Type0;
+  f_rotate_left:x0: v_Self -> x1: u32
+    -> Prims.Pure v_Self (f_rotate_left_pre x0 x1) (fun result -> f_rotate_left_post x0 x1 result);
+  f_rotate_right_pre:v_Self -> u32 -> Type0;
+  f_rotate_right_post:v_Self -> u32 -> v_Self -> Type0;
+  f_rotate_right:x0: v_Self -> x1: u32
+    -> Prims.Pure v_Self (f_rotate_right_pre x0 x1) (fun result -> f_rotate_right_post x0 x1 result)
+}
+
+/// A trait for byte conversion operations provided by Rust for machine integers
+class t_EncodeOps (v_Self: Type0) (v_T: Type0) (v_N: usize) = {
+  f_to_le_bytes_pre:v_Self -> Type0;
+  f_to_le_bytes_post:v_Self -> t_Array v_T v_N -> Type0;
+  f_to_le_bytes:x0: v_Self
+    -> Prims.Pure (t_Array v_T v_N)
+        (f_to_le_bytes_pre x0)
+        (fun result -> f_to_le_bytes_post x0 result);
+  f_to_be_bytes_pre:v_Self -> Type0;
+  f_to_be_bytes_post:v_Self -> t_Array v_T v_N -> Type0;
+  f_to_be_bytes:x0: v_Self
+    -> Prims.Pure (t_Array v_T v_N)
+        (f_to_be_bytes_pre x0)
+        (fun result -> f_to_be_bytes_post x0 result);
+  f_from_le_bytes_pre:t_Array v_T v_N -> Type0;
+  f_from_le_bytes_post:t_Array v_T v_N -> v_Self -> Type0;
+  f_from_le_bytes:x0: t_Array v_T v_N
+    -> Prims.Pure v_Self (f_from_le_bytes_pre x0) (fun result -> f_from_le_bytes_post x0 result);
+  f_from_be_bytes_pre:t_Array v_T v_N -> Type0;
+  f_from_be_bytes_post:t_Array v_T v_N -> v_Self -> Type0;
+  f_from_be_bytes:x0: t_Array v_T v_N
+    -> Prims.Pure v_Self (f_from_be_bytes_pre x0) (fun result -> f_from_be_bytes_post x0 result)
+}
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_10: t_Scalar Core_models.Core_arch.X86.t_e_ee_m128i =
+  { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_11: t_Scalar Core_models.Core_arch.X86.t_e_ee_m256i =
+  { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_12: t_Scalar Core_models.Core_arch.X86.t_e_ee_m256 =
+  { _super_i0 = FStar.Tactics.Typeclasses.solve }
+
+/// A trait for public types that can be classified into secret types
+class t_Classify (v_Self: Type0) = {
+  f_Classified:Type0;
+  f_classify_pre:v_Self -> Type0;
+  f_classify_post:v_Self -> f_Classified -> Type0;
+  f_classify:x0: v_Self
+    -> Prims.Pure f_Classified (f_classify_pre x0) (fun result -> f_classify_post x0 result)
+}
+
+/// A trait for classifying immutable references to public types
+class t_ClassifyRef (v_Self: Type0) = {
+  f_ClassifiedRef:Type0;
+  f_classify_ref_pre:v_Self -> Type0;
+  f_classify_ref_post:v_Self -> f_ClassifiedRef -> Type0;
+  f_classify_ref:x0: v_Self
+    -> Prims.Pure f_ClassifiedRef
+        (f_classify_ref_pre x0)
+        (fun result -> f_classify_ref_post x0 result)
+}
+
+/// A trait for declassifying secret types into public types
+class t_Declassify (v_Self: Type0) = {
+  f_Declassified:Type0;
+  f_declassify_pre:v_Self -> Type0;
+  f_declassify_post:v_Self -> f_Declassified -> Type0;
+  f_declassify:x0: v_Self
+    -> Prims.Pure f_Declassified (f_declassify_pre x0) (fun result -> f_declassify_post x0 result)
+}
+
+/// A trait for declassifying references to secret types
+class t_DeclassifyRef (v_Self: Type0) = {
+  f_DeclassifiedRef:Type0;
+  f_declassify_ref_pre:v_Self -> Type0;
+  f_declassify_ref_post:v_Self -> f_DeclassifiedRef -> Type0;
+  f_declassify_ref:x0: v_Self
+    -> Prims.Pure f_DeclassifiedRef
+        (f_declassify_ref_pre x0)
+        (fun result -> f_declassify_ref_post x0 result)
+}
+
+/// A trait for classifying mutable references to public types
+class t_ClassifyRefMut (v_Self: Type0) = {
+  f_ClassifiedRefMut:Type0;
+  f_classify_ref_mut_pre:v_Self -> Type0;
+  f_classify_ref_mut_post:v_Self -> f_ClassifiedRefMut -> Type0;
+  f_classify_ref_mut:x0: v_Self
+    -> Prims.Pure f_ClassifiedRefMut
+        (f_classify_ref_mut_pre x0)
+        (fun result -> f_classify_ref_mut_post x0 result)
+}
+
+/// A trait for declassifying mutable references to secret types
+class t_DeclassifyRefMut (v_Self: Type0) = {
+  f_DeclassifiedRefMut:Type0;
+  f_declassify_ref_mut_pre:v_Self -> Type0;
+  f_declassify_ref_mut_post:v_Self -> f_DeclassifiedRefMut -> Type0;
+  f_declassify_ref_mut:x0: v_Self
+    -> Prims.Pure f_DeclassifiedRefMut
+        (f_declassify_ref_mut_pre x0)
+        (fun result -> f_declassify_ref_mut_post x0 result)
+}

--- a/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Traits.fst
+++ b/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Traits.fst
@@ -43,57 +43,57 @@ let impl_Scalar_for_i128: t_Scalar i128 = { _super_i0 = FStar.Tactics.Typeclasse
 
 /// A trait for integer operations provided by Rust for machine integers
 class t_IntOps (v_Self: Type0) = {
-  f_wrapping_add_pre:#v_T: Type0 -> {| i1: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
+  f_wrapping_add_pre:#v_T: Type0 -> {| i0: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
     -> Type0;
   f_wrapping_add_post:
       #v_T: Type0 ->
-      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
       v_Self ->
       v_T ->
       v_Self
     -> Type0;
   f_wrapping_add:
       #v_T: Type0 ->
-      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
       x0: v_Self ->
       x1: v_T
     -> Prims.Pure v_Self
-        (f_wrapping_add_pre #v_T #i1 x0 x1)
-        (fun result -> f_wrapping_add_post #v_T #i1 x0 x1 result);
-  f_wrapping_sub_pre:#v_T: Type0 -> {| i1: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
+        (f_wrapping_add_pre #v_T #i0 x0 x1)
+        (fun result -> f_wrapping_add_post #v_T #i0 x0 x1 result);
+  f_wrapping_sub_pre:#v_T: Type0 -> {| i0: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
     -> Type0;
   f_wrapping_sub_post:
       #v_T: Type0 ->
-      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
       v_Self ->
       v_T ->
       v_Self
     -> Type0;
   f_wrapping_sub:
       #v_T: Type0 ->
-      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
       x0: v_Self ->
       x1: v_T
     -> Prims.Pure v_Self
-        (f_wrapping_sub_pre #v_T #i1 x0 x1)
-        (fun result -> f_wrapping_sub_post #v_T #i1 x0 x1 result);
-  f_wrapping_mul_pre:#v_T: Type0 -> {| i1: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
+        (f_wrapping_sub_pre #v_T #i0 x0 x1)
+        (fun result -> f_wrapping_sub_post #v_T #i0 x0 x1 result);
+  f_wrapping_mul_pre:#v_T: Type0 -> {| i0: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
     -> Type0;
   f_wrapping_mul_post:
       #v_T: Type0 ->
-      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
       v_Self ->
       v_T ->
       v_Self
     -> Type0;
   f_wrapping_mul:
       #v_T: Type0 ->
-      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
       x0: v_Self ->
       x1: v_T
     -> Prims.Pure v_Self
-        (f_wrapping_mul_pre #v_T #i1 x0 x1)
-        (fun result -> f_wrapping_mul_post #v_T #i1 x0 x1 result);
+        (f_wrapping_mul_pre #v_T #i0 x0 x1)
+        (fun result -> f_wrapping_mul_post #v_T #i0 x0 x1 result);
   f_wrapping_neg_pre:v_Self -> Type0;
   f_wrapping_neg_post:v_Self -> v_Self -> Type0;
   f_wrapping_neg:x0: v_Self
@@ -146,7 +146,7 @@ let impl_12: t_Scalar Core_models.Core_arch.X86.t_e_ee_m256 =
 
 /// A trait for public types that can be classified into secret types
 class t_Classify (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_Classified:Type0;
+  f_Classified:Type0;
   f_classify_pre:v_Self -> Type0;
   f_classify_post:v_Self -> f_Classified -> Type0;
   f_classify:x0: v_Self
@@ -155,7 +155,7 @@ class t_Classify (v_Self: Type0) = {
 
 /// A trait for classifying immutable references to public types
 class t_ClassifyRef (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_ClassifiedRef:Type0;
+  f_ClassifiedRef:Type0;
   f_classify_ref_pre:v_Self -> Type0;
   f_classify_ref_post:v_Self -> f_ClassifiedRef -> Type0;
   f_classify_ref:x0: v_Self
@@ -166,7 +166,7 @@ class t_ClassifyRef (v_Self: Type0) = {
 
 /// A trait for declassifying secret types into public types
 class t_Declassify (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_Declassified:Type0;
+  f_Declassified:Type0;
   f_declassify_pre:v_Self -> Type0;
   f_declassify_post:v_Self -> f_Declassified -> Type0;
   f_declassify:x0: v_Self
@@ -175,7 +175,7 @@ class t_Declassify (v_Self: Type0) = {
 
 /// A trait for declassifying references to secret types
 class t_DeclassifyRef (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_DeclassifiedRef:Type0;
+  f_DeclassifiedRef:Type0;
   f_declassify_ref_pre:v_Self -> Type0;
   f_declassify_ref_post:v_Self -> f_DeclassifiedRef -> Type0;
   f_declassify_ref:x0: v_Self
@@ -186,7 +186,7 @@ class t_DeclassifyRef (v_Self: Type0) = {
 
 /// A trait for classifying mutable references to public types
 class t_ClassifyRefMut (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_ClassifiedRefMut:Type0;
+  f_ClassifiedRefMut:Type0;
   f_classify_ref_mut_pre:v_Self -> Type0;
   f_classify_ref_mut_post:v_Self -> f_ClassifiedRefMut -> Type0;
   f_classify_ref_mut:x0: v_Self
@@ -197,7 +197,7 @@ class t_ClassifyRefMut (v_Self: Type0) = {
 
 /// A trait for declassifying mutable references to secret types
 class t_DeclassifyRefMut (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_DeclassifiedRefMut:Type0;
+  f_DeclassifiedRefMut:Type0;
   f_declassify_ref_mut_pre:v_Self -> Type0;
   f_declassify_ref_mut_post:v_Self -> f_DeclassifiedRefMut -> Type0;
   f_declassify_ref_mut:x0: v_Self

--- a/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Traits.fst
+++ b/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Traits.fst
@@ -43,57 +43,57 @@ let impl_Scalar_for_i128: t_Scalar i128 = { _super_i0 = FStar.Tactics.Typeclasse
 
 /// A trait for integer operations provided by Rust for machine integers
 class t_IntOps (v_Self: Type0) = {
-  f_wrapping_add_pre:#v_T: Type0 -> {| i0: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
+  f_wrapping_add_pre:#v_T: Type0 -> {| i1: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
     -> Type0;
   f_wrapping_add_post:
       #v_T: Type0 ->
-      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
       v_Self ->
       v_T ->
       v_Self
     -> Type0;
   f_wrapping_add:
       #v_T: Type0 ->
-      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
       x0: v_Self ->
       x1: v_T
     -> Prims.Pure v_Self
-        (f_wrapping_add_pre #v_T #i0 x0 x1)
-        (fun result -> f_wrapping_add_post #v_T #i0 x0 x1 result);
-  f_wrapping_sub_pre:#v_T: Type0 -> {| i0: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
+        (f_wrapping_add_pre #v_T #i1 x0 x1)
+        (fun result -> f_wrapping_add_post #v_T #i1 x0 x1 result);
+  f_wrapping_sub_pre:#v_T: Type0 -> {| i1: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
     -> Type0;
   f_wrapping_sub_post:
       #v_T: Type0 ->
-      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
       v_Self ->
       v_T ->
       v_Self
     -> Type0;
   f_wrapping_sub:
       #v_T: Type0 ->
-      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
       x0: v_Self ->
       x1: v_T
     -> Prims.Pure v_Self
-        (f_wrapping_sub_pre #v_T #i0 x0 x1)
-        (fun result -> f_wrapping_sub_post #v_T #i0 x0 x1 result);
-  f_wrapping_mul_pre:#v_T: Type0 -> {| i0: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
+        (f_wrapping_sub_pre #v_T #i1 x0 x1)
+        (fun result -> f_wrapping_sub_post #v_T #i1 x0 x1 result);
+  f_wrapping_mul_pre:#v_T: Type0 -> {| i1: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
     -> Type0;
   f_wrapping_mul_post:
       #v_T: Type0 ->
-      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
       v_Self ->
       v_T ->
       v_Self
     -> Type0;
   f_wrapping_mul:
       #v_T: Type0 ->
-      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
       x0: v_Self ->
       x1: v_T
     -> Prims.Pure v_Self
-        (f_wrapping_mul_pre #v_T #i0 x0 x1)
-        (fun result -> f_wrapping_mul_post #v_T #i0 x0 x1 result);
+        (f_wrapping_mul_pre #v_T #i1 x0 x1)
+        (fun result -> f_wrapping_mul_post #v_T #i1 x0 x1 result);
   f_wrapping_neg_pre:v_Self -> Type0;
   f_wrapping_neg_post:v_Self -> v_Self -> Type0;
   f_wrapping_neg:x0: v_Self
@@ -146,7 +146,7 @@ let impl_12: t_Scalar Core_models.Core_arch.X86.t_e_ee_m256 =
 
 /// A trait for public types that can be classified into secret types
 class t_Classify (v_Self: Type0) = {
-  f_Classified:Type0;
+  [@@@ FStar.Tactics.Typeclasses.no_method]f_Classified:Type0;
   f_classify_pre:v_Self -> Type0;
   f_classify_post:v_Self -> f_Classified -> Type0;
   f_classify:x0: v_Self
@@ -155,7 +155,7 @@ class t_Classify (v_Self: Type0) = {
 
 /// A trait for classifying immutable references to public types
 class t_ClassifyRef (v_Self: Type0) = {
-  f_ClassifiedRef:Type0;
+  [@@@ FStar.Tactics.Typeclasses.no_method]f_ClassifiedRef:Type0;
   f_classify_ref_pre:v_Self -> Type0;
   f_classify_ref_post:v_Self -> f_ClassifiedRef -> Type0;
   f_classify_ref:x0: v_Self
@@ -166,7 +166,7 @@ class t_ClassifyRef (v_Self: Type0) = {
 
 /// A trait for declassifying secret types into public types
 class t_Declassify (v_Self: Type0) = {
-  f_Declassified:Type0;
+  [@@@ FStar.Tactics.Typeclasses.no_method]f_Declassified:Type0;
   f_declassify_pre:v_Self -> Type0;
   f_declassify_post:v_Self -> f_Declassified -> Type0;
   f_declassify:x0: v_Self
@@ -175,7 +175,7 @@ class t_Declassify (v_Self: Type0) = {
 
 /// A trait for declassifying references to secret types
 class t_DeclassifyRef (v_Self: Type0) = {
-  f_DeclassifiedRef:Type0;
+  [@@@ FStar.Tactics.Typeclasses.no_method]f_DeclassifiedRef:Type0;
   f_declassify_ref_pre:v_Self -> Type0;
   f_declassify_ref_post:v_Self -> f_DeclassifiedRef -> Type0;
   f_declassify_ref:x0: v_Self
@@ -186,7 +186,7 @@ class t_DeclassifyRef (v_Self: Type0) = {
 
 /// A trait for classifying mutable references to public types
 class t_ClassifyRefMut (v_Self: Type0) = {
-  f_ClassifiedRefMut:Type0;
+  [@@@ FStar.Tactics.Typeclasses.no_method]f_ClassifiedRefMut:Type0;
   f_classify_ref_mut_pre:v_Self -> Type0;
   f_classify_ref_mut_post:v_Self -> f_ClassifiedRefMut -> Type0;
   f_classify_ref_mut:x0: v_Self
@@ -197,7 +197,7 @@ class t_ClassifyRefMut (v_Self: Type0) = {
 
 /// A trait for declassifying mutable references to secret types
 class t_DeclassifyRefMut (v_Self: Type0) = {
-  f_DeclassifiedRefMut:Type0;
+  [@@@ FStar.Tactics.Typeclasses.no_method]f_DeclassifiedRefMut:Type0;
   f_declassify_ref_mut_pre:v_Self -> Type0;
   f_declassify_ref_mut_post:v_Self -> f_DeclassifiedRefMut -> Type0;
   f_declassify_ref_mut:x0: v_Self

--- a/libcrux-iot/sha3/src/impl_digest_trait.rs
+++ b/libcrux-iot/sha3/src/impl_digest_trait.rs
@@ -15,6 +15,7 @@ macro_rules! impl_hash_traits {
         #[doc = concat!("A hasher for [`",stringify!($type), "`].")]
         pub type $hasher = libcrux_traits::digest::Hasher<$len, $type>;
 
+        #[cfg_attr(hax_backend_lean, charon::exclude)]
         impl libcrux_traits::digest::arrayref::Hash<$len> for $type {
             #[inline(always)]
             fn hash(
@@ -46,6 +47,7 @@ impl_hash_traits!(Sha3_512, Sha3_512Hasher, SHA3_512_LEN, sha512_ema);
 // Implement the slice hash trait
 // This is excluded for the hax extraction
 #[cfg_attr(hax, hax_lib::exclude)]
+#[cfg_attr(hax_backend_lean, charon::exclude)]
 mod slice {
     use super::*;
 

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -2685,7 +2685,7 @@ pub(crate) fn keccak<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut 
 
     let mut start = 0;
     for _i in 0..n {
-        hax_lib::loop_invariant!(|_i: usize| { start.to_int() == _i.to_int() * RATE.to_int() });
+        hax_lib::loop_invariant!(|_i: usize| { start == _i * RATE });
 
         absorb_block::<RATE>(&mut s, &data, start);
         start += RATE;
@@ -2700,7 +2700,7 @@ pub(crate) fn keccak<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut 
         let mut offset = RATE;
         for _i in 1..blocks {
             hax_lib::loop_invariant!(|_i: usize| {
-                out.len() == outlen && offset.to_int() == _i.to_int() * RATE.to_int()
+                out.len() == outlen && offset == _i * RATE
             });
             squeeze_next_block::<RATE>(&mut s, &mut out[offset..]);
             offset += RATE;

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -206,12 +206,12 @@ impl<const RATE: usize> KeccakXofState<RATE> {
 #[inline(always)]
 #[hax_lib::requires(RATE == 168 || RATE == 144 || RATE == 136 || RATE == 104 || RATE == 72)]
 #[hax_lib::fstar::options("--z3rlimit 60")]
-fn _squeeze<const RATE: usize>(state: &mut KeccakXofState<RATE>, out: &mut [U8]) {
-    if state.sponge {
+fn _squeeze<const RATE: usize>(keccak_state: &mut KeccakXofState<RATE>, out: &mut [U8]) {
+    if keccak_state.sponge {
         // If we called `squeeze` before, call f1600 first.
         // We do it this way around so that we don't call f1600 at the end
         // when we don't need it.
-        keccakf1600(&mut state.inner);
+        keccakf1600(&mut keccak_state.inner);
     }
 
     // How many blocks do we need to squeeze out?
@@ -223,7 +223,7 @@ fn _squeeze<const RATE: usize>(state: &mut KeccakXofState<RATE>, out: &mut [U8])
     // XXX: Eurydice does not extract `core::cmp::min`, so we do
     // this instead. (cf. https://github.com/AeneasVerif/eurydice/issues/49)
     let mid = if RATE >= out_len { out_len } else { RATE };
-    state.inner.store::<RATE>(&mut out[..mid]);
+    keccak_state.inner.store::<RATE>(&mut out[..mid]);
 
     // If we got asked for more than one block, squeeze out more.
     let mut offset = mid;
@@ -232,19 +232,21 @@ fn _squeeze<const RATE: usize>(state: &mut KeccakXofState<RATE>, out: &mut [U8])
             out.len() == out_len && offset.to_int() == _k.to_int() * RATE.to_int()
         });
         // Here we know that we always have full blocks to write out.
-        keccakf1600(&mut state.inner);
-        state.inner.store::<RATE>(&mut out[offset..offset + RATE]);
+        keccakf1600(&mut keccak_state.inner);
+        keccak_state
+            .inner
+            .store::<RATE>(&mut out[offset..offset + RATE]);
         offset += RATE;
     }
 
     if last > 0 && last < out_len {
         debug_assert_eq!(last, offset);
         // Squeeze out the last partial block
-        keccakf1600(&mut state.inner);
-        state.inner.store::<RATE>(&mut out[offset..]);
+        keccakf1600(&mut keccak_state.inner);
+        keccak_state.inner.store::<RATE>(&mut out[offset..]);
     }
 
-    state.sponge = true;
+    keccak_state.sponge = true;
 }
 //// From here, everything is generic
 

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -1,6 +1,8 @@
 //! The generic SHA3 implementation that uses portable or platform specific
 //! sub-routines.
 
+#[cfg(hax)]
+use hax_lib::{ToInt, ToProp};
 use libcrux_secrets::{Classify, U8};
 #[cfg(feature = "check-secret-independence")]
 use libcrux_secrets::{Declassify, U32};
@@ -22,6 +24,7 @@ pub(crate) struct KeccakXofState<const RATE: usize> {
     sponge: bool,
 }
 
+#[hax_lib::attributes]
 impl<const RATE: usize> KeccakXofState<RATE> {
     /// An all zero block
     pub(crate) fn zero_block() -> [U8; RATE] {
@@ -48,6 +51,20 @@ impl<const RATE: usize> KeccakXofState<RATE> {
     ///
     /// This works best with relatively small `inputs`.
     #[inline(always)]
+    #[hax_lib::requires(
+        RATE > 0 &&
+        RATE % 8 == 0 &&
+        RATE <= 144 &&
+        self.buf_len < RATE &&
+        inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
+    )]
+    // #[hax_lib::requires(
+    //     RATE > 0 &&
+    //     RATE % 8 == 0 &&
+    //     RATE <= 144 &&
+    //     self.buf_len < RATE &&
+    //     inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int() &&
+    // )]
     pub(crate) fn absorb(&mut self, inputs: &[U8]) {
         let input_remainder_len = self.absorb_full(inputs);
 
@@ -56,7 +73,7 @@ impl<const RATE: usize> KeccakXofState<RATE> {
             #[cfg(not(eurydice))]
             debug_assert!(
                 self.buf_len == 0  // We consumed everything (or it was empty all along).
-                 || self.buf_len + input_remainder_len <= RATE
+                     || self.buf_len + input_remainder_len <= RATE
             );
 
             let input_len = inputs.len();
@@ -66,9 +83,23 @@ impl<const RATE: usize> KeccakXofState<RATE> {
         }
     }
 
+    #[hax_lib::requires(
+        RATE > 0 &&
+        RATE % 8 == 0 &&
+        RATE <= 144 &&
+        self.buf_len < RATE &&
+        inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
+    )]
+    #[hax_lib::ensures(|remainder|
+        remainder < RATE
+        && remainder <= inputs.len()
+        && future(self).buf_len <= RATE
+        && future(self).buf_len.to_int() + remainder.to_int() < usize::MAX.to_int()
+    )]
     fn absorb_full(&mut self, inputs: &[U8]) -> usize {
         #[cfg(not(eurydice))]
         debug_assert!(self.buf_len < RATE);
+
         // Check if there are buffered bytes to absorb first and consume them.
         let input_consumed = self.fill_buffer(inputs);
 
@@ -86,7 +117,12 @@ impl<const RATE: usize> KeccakXofState<RATE> {
         // Consume the (rest of the) input ...
         let num_blocks = input_to_consume / RATE;
         let remainder = input_to_consume % RATE;
+
+        #[cfg(hax)]
+        let _buf_len = self.buf_len;
         for i in 0..num_blocks {
+            hax_lib::loop_invariant!(|_i: usize| self.buf_len == _buf_len);
+
             // We only get in here if `input_len / RATE > 0`.
             self.inner
                 .load_block::<RATE>(inputs, input_consumed + i * RATE);
@@ -103,6 +139,15 @@ impl<const RATE: usize> KeccakXofState<RATE> {
     /// content to consume, and `0` otherwise.
     /// If `consumed > 0` is returned, `self.buf` contains a full block to be
     /// loaded.
+    #[hax_lib::requires(
+        self.buf_len <= RATE &&
+        inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
+    )]
+    #[hax_lib::ensures(|res|
+        (res <= RATE).to_prop()
+        & (future(self).buf_len <= RATE).to_prop()
+        & hax_lib::implies(res > 0, future(self).buf_len == RATE)
+    )]
     fn fill_buffer(&mut self, inputs: &[U8]) -> usize {
         let input_len = inputs.len();
         let mut consumed = 0;
@@ -124,6 +169,13 @@ impl<const RATE: usize> KeccakXofState<RATE> {
     /// The `inputs` block may be empty. Everything in the `inputs` block beyond
     /// `RATE` bytes is ignored.
     #[inline(always)]
+    #[hax_lib::requires(
+        RATE > 0 &&
+        RATE % 8 == 0 &&
+        RATE <= 144 &&
+        self.buf_len < RATE &&
+        inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
+    )]
     pub(crate) fn absorb_final<const DELIMITER: u8>(&mut self, inputs: &[U8]) {
         let input_remainder_len = self.absorb_full(inputs);
 
@@ -147,6 +199,7 @@ impl<const RATE: usize> KeccakXofState<RATE> {
 
     /// Squeeze `N` x `LEN` bytes.
     #[inline(always)]
+    #[hax_lib::requires(RATE > 0 && RATE % 8 == 0 && RATE <= 144)]
     pub(crate) fn squeeze(&mut self, out: &mut [U8]) {
         if self.sponge {
             // If we called `squeeze` before, call f1600 first.
@@ -166,9 +219,12 @@ impl<const RATE: usize> KeccakXofState<RATE> {
         let mid = if RATE >= out_len { out_len } else { RATE };
         self.inner.store::<RATE>(&mut out[..mid]);
 
-        // If we got asked for more than one block, squeeze out more.
+        // // If we got asked for more than one block, squeeze out more.
         let mut offset = mid;
-        for _ in 1..blocks {
+        for _k in 1..blocks {
+            hax_lib::loop_invariant!(|_k: usize| {
+                out.len() == out_len && offset.to_int() == _k.to_int() * RATE.to_int()
+            });
             // Here we know that we always have full blocks to write out.
             keccakf1600(&mut self.inner);
             self.inner.store::<RATE>(&mut out[offset..offset + RATE]);
@@ -188,7 +244,11 @@ impl<const RATE: usize> KeccakXofState<RATE> {
 
 //// From here, everything is generic
 
-#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
+#[cfg_attr(
+    hax_backend_lean,
+    hax_lib::lean::before("set_option maxRecDepth 1000 in")
+)]
+#[hax_lib::opaque]
 const RC_INTERLEAVED_0: [u32; 255] = [
     0x00000001, 0x00000000, 0x00000000, 0x00000000, 0x00000001, 0x00000001, 0x00000001, 0x00000001,
     0x00000000, 0x00000000, 0x00000001, 0x00000000, 0x00000001, 0x00000001, 0x00000001, 0x00000001,
@@ -224,7 +284,11 @@ const RC_INTERLEAVED_0: [u32; 255] = [
     0x00000000, 0x00000001, 0x00000001, 0x00000001, 0x00000000, 0x00000000, 0x00000000,
 ];
 
-#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
+#[cfg_attr(
+    hax_backend_lean,
+    hax_lib::lean::before("set_option maxRecDepth 1000 in")
+)]
+#[hax_lib::opaque]
 const RC_INTERLEAVED_1: [u32; 255] = [
     0x00000000, 0x00000089, 0x8000008b, 0x80008080, 0x0000008b, 0x00008000, 0x80008088, 0x80000082,
     0x0000000b, 0x0000000a, 0x00008082, 0x00008003, 0x0000808b, 0x8000000b, 0x8000008a, 0x80000081,
@@ -265,6 +329,7 @@ const RC_INTERLEAVED_1: [u32; 255] = [
 // :r !python libcrux/libcrux-sha3/codegen.py
 // ```
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_theta_c_x0_z0(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 0, 0);
     let ax_1 = s.get_with_zeta(1, 0, 0);
@@ -275,6 +340,7 @@ pub(crate) fn keccakf1600_round0_theta_c_x0_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_theta_c_x0_z1(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 0, 1);
     let ax_1 = s.get_with_zeta(1, 0, 1);
@@ -285,6 +351,7 @@ pub(crate) fn keccakf1600_round0_theta_c_x0_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_theta_c_x1_z0(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 1, 0);
     let ax_1 = s.get_with_zeta(1, 1, 0);
@@ -295,6 +362,7 @@ pub(crate) fn keccakf1600_round0_theta_c_x1_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_theta_c_x1_z1(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 1, 1);
     let ax_1 = s.get_with_zeta(1, 1, 1);
@@ -305,6 +373,7 @@ pub(crate) fn keccakf1600_round0_theta_c_x1_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_theta_c_x2_z0(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 2, 0);
     let ax_1 = s.get_with_zeta(1, 2, 0);
@@ -315,6 +384,7 @@ pub(crate) fn keccakf1600_round0_theta_c_x2_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_theta_c_x2_z1(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 2, 1);
     let ax_1 = s.get_with_zeta(1, 2, 1);
@@ -325,6 +395,7 @@ pub(crate) fn keccakf1600_round0_theta_c_x2_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_theta_c_x3_z0(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 3, 0);
     let ax_1 = s.get_with_zeta(1, 3, 0);
@@ -335,6 +406,7 @@ pub(crate) fn keccakf1600_round0_theta_c_x3_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_theta_c_x3_z1(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 3, 1);
     let ax_1 = s.get_with_zeta(1, 3, 1);
@@ -345,6 +417,7 @@ pub(crate) fn keccakf1600_round0_theta_c_x3_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_theta_c_x4_z0(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 4, 0);
     let ax_1 = s.get_with_zeta(1, 4, 0);
@@ -355,6 +428,7 @@ pub(crate) fn keccakf1600_round0_theta_c_x4_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_theta_c_x4_z1(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 4, 1);
     let ax_1 = s.get_with_zeta(1, 4, 1);
@@ -365,6 +439,7 @@ pub(crate) fn keccakf1600_round0_theta_c_x4_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_theta_d(s: &mut KeccakState) {
     // D[x] = C[x-1] XOR ROT64(C[x+1], 1)
     let c_x4_zeta0 = s.c[4][0];
@@ -400,6 +475,7 @@ pub(crate) fn keccakf1600_round0_theta_d(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_theta(s: &mut KeccakState) {
     // C[x][zeta] = A[0,x][zeta] ^ A[1,x][zeta] ^ A[2,x][zeta] ^ A[3,x][zeta] ^ A[4,x][zeta]
     // https://github.com/hacl-star/hacl-star/blob/main/specs/Spec.SHA3.fst#L28C1-L29C74
@@ -417,7 +493,11 @@ pub(crate) fn keccakf1600_round0_theta(s: &mut KeccakState) {
 }
 
 #[inline(always)]
-#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
+#[cfg_attr(
+    hax_backend_lean,
+    hax_lib::lean::before("set_option maxRecDepth 1000 in")
+)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
     #[cfg(not(feature = "full-unroll"))]
     let i = s.i;
@@ -575,7 +655,11 @@ pub(crate) fn keccakf1600_round0_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut K
 }
 
 #[inline(always)]
-#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1500 in"))]
+#[cfg_attr(
+    hax_backend_lean,
+    hax_lib::lean::before("set_option maxRecDepth 1500 in")
+)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_pi_rho_chi_2(s: &mut KeccakState) {
     {
         let (bx4, bx0) = {
@@ -772,6 +856,7 @@ pub(crate) fn keccakf1600_round0_pi_rho_chi_2(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_theta_c_x0_z0(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 0, 0);
     let ax_2 = s.get_with_zeta(2, 0, 1);
@@ -782,6 +867,7 @@ pub(crate) fn keccakf1600_round1_theta_c_x0_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_theta_c_x0_z1(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 0, 1);
     let ax_2 = s.get_with_zeta(2, 0, 0);
@@ -792,6 +878,7 @@ pub(crate) fn keccakf1600_round1_theta_c_x0_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_theta_c_x1_z0(s: &mut KeccakState) {
     let ax_1 = s.get_with_zeta(1, 1, 0);
     let ax_3 = s.get_with_zeta(3, 1, 1);
@@ -802,6 +889,7 @@ pub(crate) fn keccakf1600_round1_theta_c_x1_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_theta_c_x1_z1(s: &mut KeccakState) {
     let ax_1 = s.get_with_zeta(1, 1, 1);
     let ax_3 = s.get_with_zeta(3, 1, 0);
@@ -812,6 +900,7 @@ pub(crate) fn keccakf1600_round1_theta_c_x1_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_theta_c_x2_z0(s: &mut KeccakState) {
     let ax_2 = s.get_with_zeta(2, 2, 1);
     let ax_4 = s.get_with_zeta(4, 2, 1);
@@ -822,6 +911,7 @@ pub(crate) fn keccakf1600_round1_theta_c_x2_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_theta_c_x2_z1(s: &mut KeccakState) {
     let ax_2 = s.get_with_zeta(2, 2, 0);
     let ax_4 = s.get_with_zeta(4, 2, 0);
@@ -832,6 +922,7 @@ pub(crate) fn keccakf1600_round1_theta_c_x2_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_theta_c_x3_z0(s: &mut KeccakState) {
     let ax_3 = s.get_with_zeta(3, 3, 1);
     let ax_0 = s.get_with_zeta(0, 3, 0);
@@ -842,6 +933,7 @@ pub(crate) fn keccakf1600_round1_theta_c_x3_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_theta_c_x3_z1(s: &mut KeccakState) {
     let ax_3 = s.get_with_zeta(3, 3, 0);
     let ax_0 = s.get_with_zeta(0, 3, 1);
@@ -852,6 +944,7 @@ pub(crate) fn keccakf1600_round1_theta_c_x3_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_theta_c_x4_z0(s: &mut KeccakState) {
     let ax_4 = s.get_with_zeta(4, 4, 0);
     let ax_1 = s.get_with_zeta(1, 4, 0);
@@ -862,6 +955,7 @@ pub(crate) fn keccakf1600_round1_theta_c_x4_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_theta_c_x4_z1(s: &mut KeccakState) {
     let ax_4 = s.get_with_zeta(4, 4, 1);
     let ax_1 = s.get_with_zeta(1, 4, 1);
@@ -872,6 +966,7 @@ pub(crate) fn keccakf1600_round1_theta_c_x4_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_theta_d(s: &mut KeccakState) {
     let c_x4_zeta0 = s.c[4][0];
     let c_x1_zeta1 = s.c[1][1];
@@ -906,6 +1001,7 @@ pub(crate) fn keccakf1600_round1_theta_d(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_theta(s: &mut KeccakState) {
     keccakf1600_round1_theta_c_x0_z0(s);
     keccakf1600_round1_theta_c_x0_z1(s);
@@ -921,7 +1017,11 @@ pub(crate) fn keccakf1600_round1_theta(s: &mut KeccakState) {
 }
 
 #[inline(always)]
-#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
+#[cfg_attr(
+    hax_backend_lean,
+    hax_lib::lean::before("set_option maxRecDepth 1000 in")
+)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
     #[cfg(not(feature = "full-unroll"))]
     let i = s.i;
@@ -1079,7 +1179,11 @@ pub(crate) fn keccakf1600_round1_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut K
 }
 
 #[inline(always)]
-#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1500 in"))]
+#[cfg_attr(
+    hax_backend_lean,
+    hax_lib::lean::before("set_option maxRecDepth 1500 in")
+)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_pi_rho_chi_2(s: &mut KeccakState) {
     {
         let (bx4, bx0) = {
@@ -1276,6 +1380,7 @@ pub(crate) fn keccakf1600_round1_pi_rho_chi_2(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_theta_c_x0_z0(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 0, 0);
     let ax_4 = s.get_with_zeta(4, 0, 1);
@@ -1286,6 +1391,7 @@ pub(crate) fn keccakf1600_round2_theta_c_x0_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_theta_c_x0_z1(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 0, 1);
     let ax_4 = s.get_with_zeta(4, 0, 0);
@@ -1296,6 +1402,7 @@ pub(crate) fn keccakf1600_round2_theta_c_x0_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_theta_c_x1_z0(s: &mut KeccakState) {
     let ax_3 = s.get_with_zeta(3, 1, 1);
     let ax_2 = s.get_with_zeta(2, 1, 1);
@@ -1306,6 +1413,7 @@ pub(crate) fn keccakf1600_round2_theta_c_x1_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_theta_c_x1_z1(s: &mut KeccakState) {
     let ax_3 = s.get_with_zeta(3, 1, 0);
     let ax_2 = s.get_with_zeta(2, 1, 0);
@@ -1316,6 +1424,7 @@ pub(crate) fn keccakf1600_round2_theta_c_x1_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_theta_c_x2_z0(s: &mut KeccakState) {
     let ax_1 = s.get_with_zeta(1, 2, 1);
     let ax_0 = s.get_with_zeta(0, 2, 1);
@@ -1326,6 +1435,7 @@ pub(crate) fn keccakf1600_round2_theta_c_x2_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_theta_c_x2_z1(s: &mut KeccakState) {
     let ax_1 = s.get_with_zeta(1, 2, 0);
     let ax_0 = s.get_with_zeta(0, 2, 0);
@@ -1336,6 +1446,7 @@ pub(crate) fn keccakf1600_round2_theta_c_x2_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_theta_c_x3_z0(s: &mut KeccakState) {
     let ax_4 = s.get_with_zeta(4, 3, 1);
     let ax_3 = s.get_with_zeta(3, 3, 1);
@@ -1346,6 +1457,7 @@ pub(crate) fn keccakf1600_round2_theta_c_x3_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_theta_c_x3_z1(s: &mut KeccakState) {
     let ax_4 = s.get_with_zeta(4, 3, 0);
     let ax_3 = s.get_with_zeta(3, 3, 0);
@@ -1356,6 +1468,7 @@ pub(crate) fn keccakf1600_round2_theta_c_x3_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_theta_c_x4_z0(s: &mut KeccakState) {
     let ax_2 = s.get_with_zeta(2, 4, 1);
     let ax_1 = s.get_with_zeta(1, 4, 0);
@@ -1366,6 +1479,7 @@ pub(crate) fn keccakf1600_round2_theta_c_x4_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_theta_c_x4_z1(s: &mut KeccakState) {
     let ax_2 = s.get_with_zeta(2, 4, 0);
     let ax_1 = s.get_with_zeta(1, 4, 1);
@@ -1376,6 +1490,7 @@ pub(crate) fn keccakf1600_round2_theta_c_x4_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_theta_d(s: &mut KeccakState) {
     let c_x4_zeta0 = s.c[4][0];
     let c_x1_zeta1 = s.c[1][1];
@@ -1410,6 +1525,7 @@ pub(crate) fn keccakf1600_round2_theta_d(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_theta(s: &mut KeccakState) {
     keccakf1600_round2_theta_c_x0_z0(s);
     keccakf1600_round2_theta_c_x0_z1(s);
@@ -1425,7 +1541,11 @@ pub(crate) fn keccakf1600_round2_theta(s: &mut KeccakState) {
 }
 
 #[inline(always)]
-#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
+#[cfg_attr(
+    hax_backend_lean,
+    hax_lib::lean::before("set_option maxRecDepth 1000 in")
+)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
     #[cfg(not(feature = "full-unroll"))]
     let i = s.i;
@@ -1583,7 +1703,11 @@ pub(crate) fn keccakf1600_round2_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut K
 }
 
 #[inline(always)]
-#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1500 in"))]
+#[cfg_attr(
+    hax_backend_lean,
+    hax_lib::lean::before("set_option maxRecDepth 1500 in")
+)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_pi_rho_chi_2(s: &mut KeccakState) {
     {
         let (bx4, bx0) = {
@@ -1780,7 +1904,11 @@ pub(crate) fn keccakf1600_round2_pi_rho_chi_2(s: &mut KeccakState) {
 }
 
 #[inline(always)]
-#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
+#[cfg_attr(
+    hax_backend_lean,
+    hax_lib::lean::before("set_option maxRecDepth 1000 in")
+)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_theta_c_x0_z0(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 0, 0);
     let ax_3 = s.get_with_zeta(3, 0, 0);
@@ -1791,6 +1919,7 @@ pub(crate) fn keccakf1600_round3_theta_c_x0_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_theta_c_x0_z1(s: &mut KeccakState) {
     let ax_0 = s.get_with_zeta(0, 0, 1);
     let ax_3 = s.get_with_zeta(3, 0, 1);
@@ -1801,6 +1930,7 @@ pub(crate) fn keccakf1600_round3_theta_c_x0_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_theta_c_x1_z0(s: &mut KeccakState) {
     let ax_2 = s.get_with_zeta(2, 1, 1);
     let ax_0 = s.get_with_zeta(0, 1, 0);
@@ -1811,6 +1941,7 @@ pub(crate) fn keccakf1600_round3_theta_c_x1_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_theta_c_x1_z1(s: &mut KeccakState) {
     let ax_2 = s.get_with_zeta(2, 1, 0);
     let ax_0 = s.get_with_zeta(0, 1, 1);
@@ -1821,6 +1952,7 @@ pub(crate) fn keccakf1600_round3_theta_c_x1_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_theta_c_x2_z0(s: &mut KeccakState) {
     let ax_4 = s.get_with_zeta(4, 2, 0);
     let ax_2 = s.get_with_zeta(2, 2, 0);
@@ -1831,6 +1963,7 @@ pub(crate) fn keccakf1600_round3_theta_c_x2_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_theta_c_x2_z1(s: &mut KeccakState) {
     let ax_4 = s.get_with_zeta(4, 2, 1);
     let ax_2 = s.get_with_zeta(2, 2, 1);
@@ -1841,6 +1974,7 @@ pub(crate) fn keccakf1600_round3_theta_c_x2_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_theta_c_x3_z0(s: &mut KeccakState) {
     let ax_1 = s.get_with_zeta(1, 3, 0);
     let ax_4 = s.get_with_zeta(4, 3, 1);
@@ -1851,6 +1985,7 @@ pub(crate) fn keccakf1600_round3_theta_c_x3_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_theta_c_x3_z1(s: &mut KeccakState) {
     let ax_1 = s.get_with_zeta(1, 3, 1);
     let ax_4 = s.get_with_zeta(4, 3, 0);
@@ -1861,6 +1996,7 @@ pub(crate) fn keccakf1600_round3_theta_c_x3_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_theta_c_x4_z0(s: &mut KeccakState) {
     let ax_3 = s.get_with_zeta(3, 4, 1);
     let ax_1 = s.get_with_zeta(1, 4, 0);
@@ -1871,6 +2007,7 @@ pub(crate) fn keccakf1600_round3_theta_c_x4_z0(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_theta_c_x4_z1(s: &mut KeccakState) {
     let ax_3 = s.get_with_zeta(3, 4, 0);
     let ax_1 = s.get_with_zeta(1, 4, 1);
@@ -1881,6 +2018,7 @@ pub(crate) fn keccakf1600_round3_theta_c_x4_z1(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_theta_d(s: &mut KeccakState) {
     let c_x4_zeta0 = s.c[4][0];
     let c_x1_zeta1 = s.c[1][1];
@@ -1915,6 +2053,7 @@ pub(crate) fn keccakf1600_round3_theta_d(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_theta(s: &mut KeccakState) {
     keccakf1600_round3_theta_c_x0_z0(s);
     keccakf1600_round3_theta_c_x0_z1(s);
@@ -1930,7 +2069,11 @@ pub(crate) fn keccakf1600_round3_theta(s: &mut KeccakState) {
 }
 
 #[inline(always)]
-#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1000 in"))]
+#[cfg_attr(
+    hax_backend_lean,
+    hax_lib::lean::before("set_option maxRecDepth 1000 in")
+)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
     #[cfg(not(feature = "full-unroll"))]
     let i = s.i;
@@ -2088,7 +2231,11 @@ pub(crate) fn keccakf1600_round3_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut K
 }
 
 #[inline(always)]
-#[cfg_attr(hax, hax_lib::lean::before("set_option maxRecDepth 1500 in"))]
+#[cfg_attr(
+    hax_backend_lean,
+    hax_lib::lean::before("set_option maxRecDepth 1500 in")
+)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_pi_rho_chi_2(s: &mut KeccakState) {
     {
         let (bx4, bx0) = {
@@ -2291,6 +2438,7 @@ pub(crate) fn keccakf1600_round3_pi_rho_chi_2(s: &mut KeccakState) {
 // vs
 //   [CYCLE_MEASUREMENT libcrux SHAKE256 (PRF_ETA1_RANDOMNESS_1024)] : + 19139 cycles
 #[inline(always)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600_4rounds<const BASE_ROUND: usize>(s: &mut KeccakState) {
     keccakf1600_round0_theta(s);
     keccakf1600_round0_pi_rho_chi_1::<BASE_ROUND>(s);
@@ -2307,6 +2455,7 @@ pub(crate) fn keccakf1600_4rounds<const BASE_ROUND: usize>(s: &mut KeccakState) 
 }
 
 #[inline(never)]
+#[hax_lib::opaque]
 pub(crate) fn keccakf1600(s: &mut KeccakState) {
     #[cfg(not(feature = "full-unroll"))]
     for _ in 0..6 {
@@ -2326,12 +2475,23 @@ pub(crate) fn keccakf1600(s: &mut KeccakState) {
 }
 
 #[inline(always)]
+#[hax_lib::requires(
+    RATE % 8 == 0
+    && RATE <= 144
+    && start.to_int() + RATE.to_int() <= blocks.len().to_int()
+)]
 pub(crate) fn absorb_block<const RATE: usize>(s: &mut KeccakState, blocks: &[U8], start: usize) {
     s.load_block::<RATE>(blocks, start);
     keccakf1600(s)
 }
 
 #[inline(always)]
+#[hax_lib::requires(
+    RATE > 0
+    && RATE % 8 == 0
+    && RATE <= 144
+    && len < RATE
+    && start.to_int() + len.to_int() <= last.len().to_int())]
 pub(crate) fn absorb_final<const RATE: usize, const DELIM: u8>(
     s: &mut KeccakState,
     last: &[U8],
@@ -2352,11 +2512,13 @@ pub(crate) fn absorb_final<const RATE: usize, const DELIM: u8>(
 }
 
 #[inline(always)]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && RATE <= out.len())]
 pub(crate) fn squeeze_first_block<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
     s.store_block::<RATE>(out)
 }
 
 #[inline(always)]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && RATE <= out.len())]
 pub(crate) fn squeeze_next_block<const RATE: usize>(s: &mut KeccakState, out: &mut [U8]) {
     keccakf1600(s);
     s.store_block::<RATE>(out)
@@ -2364,6 +2526,7 @@ pub(crate) fn squeeze_next_block<const RATE: usize>(s: &mut KeccakState, out: &m
 
 #[inline(always)]
 #[cfg(feature = "unbuffered-xof")]
+#[hax_lib::opaque]
 pub(crate) fn squeeze_first_three_blocks<const RATE: usize>(s: &mut KeccakState, out: &mut [U8]) {
     squeeze_first_block::<RATE>(s, out);
     squeeze_next_block::<RATE>(s, &mut out[RATE..]);
@@ -2372,6 +2535,7 @@ pub(crate) fn squeeze_first_three_blocks<const RATE: usize>(s: &mut KeccakState,
 
 #[inline(always)]
 #[cfg(feature = "unbuffered-xof")]
+#[hax_lib::opaque]
 pub(crate) fn squeeze_first_five_blocks<const RATE: usize>(s: &mut KeccakState, out: &mut [U8]) {
     squeeze_first_block::<RATE>(s, out);
     squeeze_next_block::<RATE>(s, &mut out[RATE..]);
@@ -2381,6 +2545,7 @@ pub(crate) fn squeeze_first_five_blocks<const RATE: usize>(s: &mut KeccakState, 
 }
 
 #[inline(always)]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && out.len() <= 200)]
 pub(crate) fn squeeze_last<const RATE: usize>(mut s: KeccakState, out: &mut [U8]) {
     keccakf1600(&mut s);
     let mut b = [0u8; 200].classify();
@@ -2389,6 +2554,7 @@ pub(crate) fn squeeze_last<const RATE: usize>(mut s: KeccakState, out: &mut [U8]
 }
 
 #[inline(always)]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && out.len() <= 200)]
 pub(crate) fn squeeze_first_and_last<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
     let mut b = [0u8; 200].classify();
     s.store_block_full::<RATE>(&mut b);
@@ -2399,6 +2565,10 @@ pub(crate) fn squeeze_first_and_last<const RATE: usize>(s: &KeccakState, out: &m
 const WIDTH: usize = 200;
 
 #[inline(always)]
+#[hax_lib::requires(
+    RATE > 0 && RATE % 8 == 0 && RATE <= 144
+)]
+#[hax_lib::ensures(|_| future(out).len() == out.len())]
 pub(crate) fn keccak<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut [U8]) {
     let n = data.len() / RATE;
     let rem = data.len() % RATE;
@@ -2410,6 +2580,9 @@ pub(crate) fn keccak<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut 
     let mut s = KeccakState::new();
 
     for i in 0..n {
+        hax_lib::loop_invariant!(|i: usize| {
+            i.to_int() * RATE.to_int() + RATE.to_int() <= data.len().to_int() && out.len() == outlen
+        });
         absorb_block::<RATE>(&mut s, &data, i * RATE);
     }
 
@@ -2421,6 +2594,9 @@ pub(crate) fn keccak<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut 
         squeeze_first_block::<RATE>(&s, out);
         let mut offset = RATE;
         for _i in 1..blocks {
+            hax_lib::loop_invariant!(|_i: usize| {
+                out.len() == outlen && offset.to_int() == _i.to_int() * RATE.to_int()
+            });
             squeeze_next_block::<RATE>(&mut s, &mut out[offset..]);
             offset += RATE;
         }

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -497,366 +497,392 @@ pub(crate) fn keccakf1600_round0_theta(s: &mut KeccakState) {
 }
 
 #[inline(always)]
-#[cfg_attr(
-    hax_backend_lean,
-    hax_lib::lean::before("set_option maxRecDepth 1000 in")
-)]
 #[hax_lib::opaque]
-pub(crate) fn keccakf1600_round0_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
+pub(crate) fn keccakf1600_round0_pi_rho_chi_y0_zeta0<const BASE_ROUND: usize>(s: &mut KeccakState) {
+    let (bx0, bx1) = {
+        let a0 = s.get_with_zeta(0, 0, 0);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(1, 1, 0);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
+    };
+    let (bx2, bx3, bx4) = {
+        let a2 = s.get_with_zeta(2, 2, 1);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(3, 3, 1);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(4, 4, 0);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(22),
+            (a3 ^ d3).rotate_left(11),
+            (a4 ^ d4).rotate_left(7),
+        )
+    };
+
+    let ax0;
+    #[cfg(feature = "full-unroll")]
+    {
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 0];
+    };
     #[cfg(not(feature = "full-unroll"))]
-    let i = s.i;
     {
-        let (bx0, bx1) = {
-            let a0 = s.get_with_zeta(0, 0, 0);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(1, 1, 0);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
-        };
-        let (bx2, bx3, bx4) = {
-            let a2 = s.get_with_zeta(2, 2, 1);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(3, 3, 1);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(4, 4, 0);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(22),
-                (a3 ^ d3).rotate_left(11),
-                (a4 ^ d4).rotate_left(7),
-            )
-        };
-
-        // [hax] uninitialized variables are note supported yet in lean.
-        #[allow(unused_assignments)]
-        let mut ax0 = 0.classify();
-        #[cfg(feature = "full-unroll")]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 0];
-        };
-        #[cfg(not(feature = "full-unroll"))]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[i];
-        };
-        s.set_with_zeta(0, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(1, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(2, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(3, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(4, 4, 0, ax4);
-    }
-    {
-        let (bx0, bx1) = {
-            let a0 = s.get_with_zeta(0, 0, 1);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(1, 1, 1);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
-        };
-        let (bx2, bx3, bx4) = {
-            let a2 = s.get_with_zeta(2, 2, 0);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(3, 3, 0);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(4, 4, 1);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(21),
-                (a3 ^ d3).rotate_left(10),
-                (a4 ^ d4).rotate_left(7),
-            )
-        };
-
-        // [hax] uninitialized variables are note supported yet in lean.
-        #[allow(unused_assignments)]
-        let mut ax0 = 0.classify();
-        #[cfg(feature = "full-unroll")]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 0];
-        };
-        #[cfg(not(feature = "full-unroll"))]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[i];
-            s.i = i + 1;
-        };
-        s.set_with_zeta(0, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(1, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(2, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(3, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(4, 4, 1, ax4);
-    }
-    {
-        let (bx2, bx3) = {
-            let a0 = s.get_with_zeta(2, 0, 1);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(3, 1, 1);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(2), (a1 ^ d1).rotate_left(23))
-        };
-        let (bx4, bx0, bx1) = {
-            let a2 = s.get_with_zeta(4, 2, 1);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(0, 3, 0);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(1, 4, 0);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(31),
-                (a3 ^ d3).rotate_left(14),
-                (a4 ^ d4).rotate_left(10),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(2, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(3, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(4, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(0, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(1, 4, 0, ax4);
-    }
-    {
-        let (bx2, bx3) = {
-            let a0 = s.get_with_zeta(2, 0, 0);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(3, 1, 0);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(1), (a1 ^ d1).rotate_left(22))
-        };
-        let (bx4, bx0, bx1) = {
-            let a2 = s.get_with_zeta(4, 2, 0);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(0, 3, 1);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(1, 4, 1);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(30),
-                (a3 ^ d3).rotate_left(14),
-                (a4 ^ d4).rotate_left(10),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(2, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(3, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(4, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(0, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(1, 4, 1, ax4);
-    }
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[s.i];
+    };
+    s.set_with_zeta(0, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(1, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(2, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(3, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(4, 4, 0, ax4);
 }
 
 #[inline(always)]
-#[cfg_attr(
-    hax_backend_lean,
-    hax_lib::lean::before("set_option maxRecDepth 1500 in")
-)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round0_pi_rho_chi_y0_zeta1<const BASE_ROUND: usize>(s: &mut KeccakState) {
+    let (bx0, bx1) = {
+        let a0 = s.get_with_zeta(0, 0, 1);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(1, 1, 1);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
+    };
+    let (bx2, bx3, bx4) = {
+        let a2 = s.get_with_zeta(2, 2, 0);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(3, 3, 0);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(4, 4, 1);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(21),
+            (a3 ^ d3).rotate_left(10),
+            (a4 ^ d4).rotate_left(7),
+        )
+    };
+
+    let ax0;
+    #[cfg(feature = "full-unroll")]
+    {
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 0];
+    };
+    #[cfg(not(feature = "full-unroll"))]
+    {
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[s.i];
+        s.i = s.i + 1;
+    };
+    s.set_with_zeta(0, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(1, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(2, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(3, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(4, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round0_pi_rho_chi_y1_zeta0(s: &mut KeccakState) {
+    let (bx2, bx3) = {
+        let a0 = s.get_with_zeta(2, 0, 1);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(3, 1, 1);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(2), (a1 ^ d1).rotate_left(23))
+    };
+    let (bx4, bx0, bx1) = {
+        let a2 = s.get_with_zeta(4, 2, 1);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(0, 3, 0);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(1, 4, 0);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(31),
+            (a3 ^ d3).rotate_left(14),
+            (a4 ^ d4).rotate_left(10),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(2, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(3, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(4, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(0, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(1, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round0_pi_rho_chi_y1_zeta1(s: &mut KeccakState) {
+    let (bx2, bx3) = {
+        let a0 = s.get_with_zeta(2, 0, 0);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(3, 1, 0);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(1), (a1 ^ d1).rotate_left(22))
+    };
+    let (bx4, bx0, bx1) = {
+        let a2 = s.get_with_zeta(4, 2, 0);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(0, 3, 1);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(1, 4, 1);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(30),
+            (a3 ^ d3).rotate_left(14),
+            (a4 ^ d4).rotate_left(10),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(2, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(3, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(4, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(0, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(1, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round0_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
+    keccakf1600_round0_pi_rho_chi_y0_zeta0::<BASE_ROUND>(s);
+    keccakf1600_round0_pi_rho_chi_y0_zeta1::<BASE_ROUND>(s);
+    keccakf1600_round0_pi_rho_chi_y1_zeta0(s);
+    keccakf1600_round0_pi_rho_chi_y1_zeta1(s);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round0_pi_rho_chi_y2_zeta0(s: &mut KeccakState) {
+    let (bx4, bx0) = {
+        let a0 = s.get_with_zeta(4, 0, 0);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(0, 1, 1);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(1))
+    };
+    let (bx1, bx2, bx3) = {
+        let a2 = s.get_with_zeta(1, 2, 0);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(2, 3, 1);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(3, 4, 0);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(3),
+            (a3 ^ d3).rotate_left(13),
+            (a4 ^ d4).rotate_left(4),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(4, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(0, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(1, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(2, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(3, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round0_pi_rho_chi_y2_zeta1(s: &mut KeccakState) {
+    let (bx4, bx0) = {
+        let a0 = s.get_with_zeta(4, 0, 1);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(0, 1, 0);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(0))
+    };
+    let (bx1, bx2, bx3) = {
+        let a2 = s.get_with_zeta(1, 2, 1);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(2, 3, 0);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(3, 4, 1);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(3),
+            (a3 ^ d3).rotate_left(12),
+            (a4 ^ d4).rotate_left(4),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(4, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(0, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(1, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(2, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(3, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round0_pi_rho_chi_y3_zeta0(s: &mut KeccakState) {
+    let (bx1, bx2) = {
+        let a0 = s.get_with_zeta(1, 0, 0);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(2, 1, 0);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
+    };
+    let (bx3, bx4, bx0) = {
+        let a2 = s.get_with_zeta(3, 2, 1);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(4, 3, 0);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(0, 4, 1);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(8),
+            (a3 ^ d3).rotate_left(28),
+            (a4 ^ d4).rotate_left(14),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(1, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(2, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(3, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(4, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(0, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round0_pi_rho_chi_y3_zeta1(s: &mut KeccakState) {
+    let (bx1, bx2) = {
+        let a0 = s.get_with_zeta(1, 0, 1);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(2, 1, 1);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
+    };
+    let (bx3, bx4, bx0) = {
+        let a2 = s.get_with_zeta(3, 2, 0);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(4, 3, 1);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(0, 4, 0);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(7),
+            (a3 ^ d3).rotate_left(28),
+            (a4 ^ d4).rotate_left(13),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(1, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(2, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(3, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(4, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(0, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round0_pi_rho_chi_y4_zeta0(s: &mut KeccakState) {
+    let (bx3, bx4) = {
+        let a0 = s.get_with_zeta(3, 0, 1);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(4, 1, 0);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(21), (a1 ^ d1).rotate_left(1))
+    };
+    let (bx0, bx1, bx2) = {
+        let a2 = s.get_with_zeta(0, 2, 0);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(1, 3, 1);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(2, 4, 1);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(31),
+            (a3 ^ d3).rotate_left(28),
+            (a4 ^ d4).rotate_left(20),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(3, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(4, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(0, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(1, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(2, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round0_pi_rho_chi_y4_zeta1(s: &mut KeccakState) {
+    let (bx3, bx4) = {
+        let a0 = s.get_with_zeta(3, 0, 0);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(4, 1, 1);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(20), (a1 ^ d1).rotate_left(1))
+    };
+    let (bx0, bx1, bx2) = {
+        let a2 = s.get_with_zeta(0, 2, 1);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(1, 3, 0);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(2, 4, 0);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(31),
+            (a3 ^ d3).rotate_left(27),
+            (a4 ^ d4).rotate_left(19),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(3, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(4, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(0, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(1, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(2, 4, 0, ax4);
+}
+
+#[inline(always)]
 #[hax_lib::opaque]
 pub(crate) fn keccakf1600_round0_pi_rho_chi_2(s: &mut KeccakState) {
-    {
-        let (bx4, bx0) = {
-            let a0 = s.get_with_zeta(4, 0, 0);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(0, 1, 1);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(1))
-        };
-        let (bx1, bx2, bx3) = {
-            let a2 = s.get_with_zeta(1, 2, 0);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(2, 3, 1);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(3, 4, 0);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(3),
-                (a3 ^ d3).rotate_left(13),
-                (a4 ^ d4).rotate_left(4),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(4, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(0, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(1, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(2, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(3, 4, 0, ax4);
-    }
-    {
-        let (bx4, bx0) = {
-            let a0 = s.get_with_zeta(4, 0, 1);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(0, 1, 0);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(0))
-        };
-        let (bx1, bx2, bx3) = {
-            let a2 = s.get_with_zeta(1, 2, 1);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(2, 3, 0);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(3, 4, 1);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(3),
-                (a3 ^ d3).rotate_left(12),
-                (a4 ^ d4).rotate_left(4),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(4, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(0, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(1, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(2, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(3, 4, 1, ax4);
-    }
-    {
-        let (bx1, bx2) = {
-            let a0 = s.get_with_zeta(1, 0, 0);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(2, 1, 0);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
-        };
-        let (bx3, bx4, bx0) = {
-            let a2 = s.get_with_zeta(3, 2, 1);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(4, 3, 0);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(0, 4, 1);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(8),
-                (a3 ^ d3).rotate_left(28),
-                (a4 ^ d4).rotate_left(14),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(1, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(2, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(3, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(4, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(0, 4, 1, ax4);
-    }
-    {
-        let (bx1, bx2) = {
-            let a0 = s.get_with_zeta(1, 0, 1);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(2, 1, 1);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
-        };
-        let (bx3, bx4, bx0) = {
-            let a2 = s.get_with_zeta(3, 2, 0);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(4, 3, 1);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(0, 4, 0);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(7),
-                (a3 ^ d3).rotate_left(28),
-                (a4 ^ d4).rotate_left(13),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(1, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(2, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(3, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(4, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(0, 4, 0, ax4);
-    }
-    {
-        let (bx3, bx4) = {
-            let a0 = s.get_with_zeta(3, 0, 1);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(4, 1, 0);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(21), (a1 ^ d1).rotate_left(1))
-        };
-        let (bx0, bx1, bx2) = {
-            let a2 = s.get_with_zeta(0, 2, 0);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(1, 3, 1);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(2, 4, 1);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(31),
-                (a3 ^ d3).rotate_left(28),
-                (a4 ^ d4).rotate_left(20),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(3, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(4, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(0, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(1, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(2, 4, 1, ax4);
-    }
-    {
-        let (bx3, bx4) = {
-            let a0 = s.get_with_zeta(3, 0, 0);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(4, 1, 1);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(20), (a1 ^ d1).rotate_left(1))
-        };
-        let (bx0, bx1, bx2) = {
-            let a2 = s.get_with_zeta(0, 2, 1);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(1, 3, 0);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(2, 4, 0);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(31),
-                (a3 ^ d3).rotate_left(27),
-                (a4 ^ d4).rotate_left(19),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(3, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(4, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(0, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(1, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(2, 4, 0, ax4);
-    }
+    keccakf1600_round0_pi_rho_chi_y2_zeta0(s);
+    keccakf1600_round0_pi_rho_chi_y2_zeta1(s);
+    keccakf1600_round0_pi_rho_chi_y3_zeta0(s);
+    keccakf1600_round0_pi_rho_chi_y3_zeta1(s);
+    keccakf1600_round0_pi_rho_chi_y4_zeta0(s);
+    keccakf1600_round0_pi_rho_chi_y4_zeta1(s);
 }
 
 #[inline(always)]
@@ -1021,366 +1047,392 @@ pub(crate) fn keccakf1600_round1_theta(s: &mut KeccakState) {
 }
 
 #[inline(always)]
-#[cfg_attr(
-    hax_backend_lean,
-    hax_lib::lean::before("set_option maxRecDepth 1000 in")
-)]
 #[hax_lib::opaque]
-pub(crate) fn keccakf1600_round1_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
+pub(crate) fn keccakf1600_round1_pi_rho_chi_y0_zeta0<const BASE_ROUND: usize>(s: &mut KeccakState) {
+    let (bx0, bx1) = {
+        let a0 = s.get_with_zeta(0, 0, 0);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(3, 1, 1);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
+    };
+    let (bx2, bx3, bx4) = {
+        let a2 = s.get_with_zeta(1, 2, 1);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(4, 3, 1);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(2, 4, 1);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(22),
+            (a3 ^ d3).rotate_left(11),
+            (a4 ^ d4).rotate_left(7),
+        )
+    };
+
+    let ax0;
+    #[cfg(feature = "full-unroll")]
+    {
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 1];
+    };
     #[cfg(not(feature = "full-unroll"))]
-    let i = s.i;
     {
-        let (bx0, bx1) = {
-            let a0 = s.get_with_zeta(0, 0, 0);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(3, 1, 1);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
-        };
-        let (bx2, bx3, bx4) = {
-            let a2 = s.get_with_zeta(1, 2, 1);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(4, 3, 1);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(2, 4, 1);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(22),
-                (a3 ^ d3).rotate_left(11),
-                (a4 ^ d4).rotate_left(7),
-            )
-        };
-
-        // [hax] uninitialized variables are note supported yet in lean.
-        #[allow(unused_assignments)]
-        let mut ax0 = 0.classify();
-        #[cfg(feature = "full-unroll")]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 1];
-        };
-        #[cfg(not(feature = "full-unroll"))]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[i];
-        };
-        s.set_with_zeta(0, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(3, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(1, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(4, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(2, 4, 1, ax4);
-    }
-    {
-        let (bx0, bx1) = {
-            let a0 = s.get_with_zeta(0, 0, 1);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(3, 1, 0);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
-        };
-        let (bx2, bx3, bx4) = {
-            let a2 = s.get_with_zeta(1, 2, 0);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(4, 3, 0);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(2, 4, 0);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(21),
-                (a3 ^ d3).rotate_left(10),
-                (a4 ^ d4).rotate_left(7),
-            )
-        };
-
-        // [hax] uninitialized variables are note supported yet in lean.
-        #[allow(unused_assignments)]
-        let mut ax0 = 0.classify();
-        #[cfg(feature = "full-unroll")]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 1];
-        };
-        #[cfg(not(feature = "full-unroll"))]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[i];
-            s.i = i + 1;
-        };
-        s.set_with_zeta(0, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(3, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(1, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(4, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(2, 4, 0, ax4);
-    }
-    {
-        let (bx2, bx3) = {
-            let a0 = s.get_with_zeta(4, 0, 1);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(2, 1, 1);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(2), (a1 ^ d1).rotate_left(23))
-        };
-        let (bx4, bx0, bx1) = {
-            let a2 = s.get_with_zeta(0, 2, 1);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(3, 3, 1);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(1, 4, 0);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(31),
-                (a3 ^ d3).rotate_left(14),
-                (a4 ^ d4).rotate_left(10),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(4, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(2, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(0, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(3, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(1, 4, 0, ax4);
-    }
-    {
-        let (bx2, bx3) = {
-            let a0 = s.get_with_zeta(4, 0, 0);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(2, 1, 0);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(1), (a1 ^ d1).rotate_left(22))
-        };
-        let (bx4, bx0, bx1) = {
-            let a2 = s.get_with_zeta(0, 2, 0);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(3, 3, 0);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(1, 4, 1);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(30),
-                (a3 ^ d3).rotate_left(14),
-                (a4 ^ d4).rotate_left(10),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(4, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(2, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(0, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(3, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(1, 4, 1, ax4);
-    }
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[s.i];
+    };
+    s.set_with_zeta(0, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(3, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(1, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(4, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(2, 4, 1, ax4);
 }
 
 #[inline(always)]
-#[cfg_attr(
-    hax_backend_lean,
-    hax_lib::lean::before("set_option maxRecDepth 1500 in")
-)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round1_pi_rho_chi_y0_zeta1<const BASE_ROUND: usize>(s: &mut KeccakState) {
+    let (bx0, bx1) = {
+        let a0 = s.get_with_zeta(0, 0, 1);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(3, 1, 0);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
+    };
+    let (bx2, bx3, bx4) = {
+        let a2 = s.get_with_zeta(1, 2, 0);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(4, 3, 0);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(2, 4, 0);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(21),
+            (a3 ^ d3).rotate_left(10),
+            (a4 ^ d4).rotate_left(7),
+        )
+    };
+
+    let ax0;
+    #[cfg(feature = "full-unroll")]
+    {
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 1];
+    };
+    #[cfg(not(feature = "full-unroll"))]
+    {
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[s.i];
+        s.i = s.i + 1;
+    };
+    s.set_with_zeta(0, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(3, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(1, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(4, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(2, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round1_pi_rho_chi_y1_zeta0(s: &mut KeccakState) {
+    let (bx2, bx3) = {
+        let a0 = s.get_with_zeta(4, 0, 1);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(2, 1, 1);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(2), (a1 ^ d1).rotate_left(23))
+    };
+    let (bx4, bx0, bx1) = {
+        let a2 = s.get_with_zeta(0, 2, 1);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(3, 3, 1);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(1, 4, 0);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(31),
+            (a3 ^ d3).rotate_left(14),
+            (a4 ^ d4).rotate_left(10),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(4, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(2, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(0, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(3, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(1, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round1_pi_rho_chi_y1_zeta1(s: &mut KeccakState) {
+    let (bx2, bx3) = {
+        let a0 = s.get_with_zeta(4, 0, 0);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(2, 1, 0);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(1), (a1 ^ d1).rotate_left(22))
+    };
+    let (bx4, bx0, bx1) = {
+        let a2 = s.get_with_zeta(0, 2, 0);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(3, 3, 0);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(1, 4, 1);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(30),
+            (a3 ^ d3).rotate_left(14),
+            (a4 ^ d4).rotate_left(10),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(4, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(2, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(0, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(3, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(1, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round1_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
+    keccakf1600_round1_pi_rho_chi_y0_zeta0::<BASE_ROUND>(s);
+    keccakf1600_round1_pi_rho_chi_y0_zeta1::<BASE_ROUND>(s);
+    keccakf1600_round1_pi_rho_chi_y1_zeta0(s);
+    keccakf1600_round1_pi_rho_chi_y1_zeta1(s);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round1_pi_rho_chi_y2_zeta0(s: &mut KeccakState) {
+    let (bx4, bx0) = {
+        let a0 = s.get_with_zeta(3, 0, 1);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(1, 1, 1);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(1))
+    };
+    let (bx1, bx2, bx3) = {
+        let a2 = s.get_with_zeta(4, 2, 1);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(2, 3, 0);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(0, 4, 1);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(3),
+            (a3 ^ d3).rotate_left(13),
+            (a4 ^ d4).rotate_left(4),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(3, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(1, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(4, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(2, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(0, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round1_pi_rho_chi_y2_zeta1(s: &mut KeccakState) {
+    let (bx4, bx0) = {
+        let a0 = s.get_with_zeta(3, 0, 0);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(1, 1, 0);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(0))
+    };
+    let (bx1, bx2, bx3) = {
+        let a2 = s.get_with_zeta(4, 2, 0);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(2, 3, 1);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(0, 4, 0);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(3),
+            (a3 ^ d3).rotate_left(12),
+            (a4 ^ d4).rotate_left(4),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(3, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(1, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(4, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(2, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(0, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round1_pi_rho_chi_y3_zeta0(s: &mut KeccakState) {
+    let (bx1, bx2) = {
+        let a0 = s.get_with_zeta(2, 0, 1);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(0, 1, 1);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
+    };
+    let (bx3, bx4, bx0) = {
+        let a2 = s.get_with_zeta(3, 2, 0);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(1, 3, 1);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(4, 4, 1);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(8),
+            (a3 ^ d3).rotate_left(28),
+            (a4 ^ d4).rotate_left(14),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(2, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(0, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(3, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(1, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(4, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round1_pi_rho_chi_y3_zeta1(s: &mut KeccakState) {
+    let (bx1, bx2) = {
+        let a0 = s.get_with_zeta(2, 0, 0);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(0, 1, 0);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
+    };
+    let (bx3, bx4, bx0) = {
+        let a2 = s.get_with_zeta(3, 2, 1);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(1, 3, 0);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(4, 4, 0);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(7),
+            (a3 ^ d3).rotate_left(28),
+            (a4 ^ d4).rotate_left(13),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(2, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(0, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(3, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(1, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(4, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round1_pi_rho_chi_y4_zeta0(s: &mut KeccakState) {
+    let (bx3, bx4) = {
+        let a0 = s.get_with_zeta(1, 0, 1);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(4, 1, 0);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(21), (a1 ^ d1).rotate_left(1))
+    };
+    let (bx0, bx1, bx2) = {
+        let a2 = s.get_with_zeta(2, 2, 1);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(0, 3, 1);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(3, 4, 1);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(31),
+            (a3 ^ d3).rotate_left(28),
+            (a4 ^ d4).rotate_left(20),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(1, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(4, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(2, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(0, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(3, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round1_pi_rho_chi_y4_zeta1(s: &mut KeccakState) {
+    let (bx3, bx4) = {
+        let a0 = s.get_with_zeta(1, 0, 0);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(4, 1, 1);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(20), (a1 ^ d1).rotate_left(1))
+    };
+    let (bx0, bx1, bx2) = {
+        let a2 = s.get_with_zeta(2, 2, 0);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(0, 3, 0);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(3, 4, 0);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(31),
+            (a3 ^ d3).rotate_left(27),
+            (a4 ^ d4).rotate_left(19),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(1, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(4, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(2, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(0, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(3, 4, 0, ax4);
+}
+
+#[inline(always)]
 #[hax_lib::opaque]
 pub(crate) fn keccakf1600_round1_pi_rho_chi_2(s: &mut KeccakState) {
-    {
-        let (bx4, bx0) = {
-            let a0 = s.get_with_zeta(3, 0, 1);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(1, 1, 1);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(1))
-        };
-        let (bx1, bx2, bx3) = {
-            let a2 = s.get_with_zeta(4, 2, 1);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(2, 3, 0);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(0, 4, 1);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(3),
-                (a3 ^ d3).rotate_left(13),
-                (a4 ^ d4).rotate_left(4),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(3, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(1, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(4, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(2, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(0, 4, 1, ax4);
-    }
-    {
-        let (bx4, bx0) = {
-            let a0 = s.get_with_zeta(3, 0, 0);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(1, 1, 0);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(0))
-        };
-        let (bx1, bx2, bx3) = {
-            let a2 = s.get_with_zeta(4, 2, 0);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(2, 3, 1);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(0, 4, 0);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(3),
-                (a3 ^ d3).rotate_left(12),
-                (a4 ^ d4).rotate_left(4),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(3, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(1, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(4, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(2, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(0, 4, 0, ax4);
-    }
-    {
-        let (bx1, bx2) = {
-            let a0 = s.get_with_zeta(2, 0, 1);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(0, 1, 1);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
-        };
-        let (bx3, bx4, bx0) = {
-            let a2 = s.get_with_zeta(3, 2, 0);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(1, 3, 1);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(4, 4, 1);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(8),
-                (a3 ^ d3).rotate_left(28),
-                (a4 ^ d4).rotate_left(14),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(2, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(0, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(3, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(1, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(4, 4, 1, ax4);
-    }
-    {
-        let (bx1, bx2) = {
-            let a0 = s.get_with_zeta(2, 0, 0);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(0, 1, 0);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
-        };
-        let (bx3, bx4, bx0) = {
-            let a2 = s.get_with_zeta(3, 2, 1);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(1, 3, 0);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(4, 4, 0);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(7),
-                (a3 ^ d3).rotate_left(28),
-                (a4 ^ d4).rotate_left(13),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(2, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(0, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(3, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(1, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(4, 4, 0, ax4);
-    }
-    {
-        let (bx3, bx4) = {
-            let a0 = s.get_with_zeta(1, 0, 1);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(4, 1, 0);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(21), (a1 ^ d1).rotate_left(1))
-        };
-        let (bx0, bx1, bx2) = {
-            let a2 = s.get_with_zeta(2, 2, 1);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(0, 3, 1);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(3, 4, 1);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(31),
-                (a3 ^ d3).rotate_left(28),
-                (a4 ^ d4).rotate_left(20),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(1, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(4, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(2, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(0, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(3, 4, 1, ax4);
-    }
-    {
-        let (bx3, bx4) = {
-            let a0 = s.get_with_zeta(1, 0, 0);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(4, 1, 1);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(20), (a1 ^ d1).rotate_left(1))
-        };
-        let (bx0, bx1, bx2) = {
-            let a2 = s.get_with_zeta(2, 2, 0);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(0, 3, 0);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(3, 4, 0);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(31),
-                (a3 ^ d3).rotate_left(27),
-                (a4 ^ d4).rotate_left(19),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(1, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(4, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(2, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(0, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(3, 4, 0, ax4);
-    }
+    keccakf1600_round1_pi_rho_chi_y2_zeta0(s);
+    keccakf1600_round1_pi_rho_chi_y2_zeta1(s);
+    keccakf1600_round1_pi_rho_chi_y3_zeta0(s);
+    keccakf1600_round1_pi_rho_chi_y3_zeta1(s);
+    keccakf1600_round1_pi_rho_chi_y4_zeta0(s);
+    keccakf1600_round1_pi_rho_chi_y4_zeta1(s);
 }
 
 #[inline(always)]
@@ -1545,366 +1597,392 @@ pub(crate) fn keccakf1600_round2_theta(s: &mut KeccakState) {
 }
 
 #[inline(always)]
-#[cfg_attr(
-    hax_backend_lean,
-    hax_lib::lean::before("set_option maxRecDepth 1000 in")
-)]
 #[hax_lib::opaque]
-pub(crate) fn keccakf1600_round2_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
+pub(crate) fn keccakf1600_round2_pi_rho_chi_y0_zeta0<const BASE_ROUND: usize>(s: &mut KeccakState) {
+    let (bx0, bx1) = {
+        let a0 = s.get_with_zeta(0, 0, 0);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(2, 1, 1);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
+    };
+    let (bx2, bx3, bx4) = {
+        let a2 = s.get_with_zeta(4, 2, 0);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(1, 3, 0);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(3, 4, 1);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(22),
+            (a3 ^ d3).rotate_left(11),
+            (a4 ^ d4).rotate_left(7),
+        )
+    };
+
+    let ax0;
+    #[cfg(feature = "full-unroll")]
+    {
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 2];
+    };
     #[cfg(not(feature = "full-unroll"))]
-    let i = s.i;
     {
-        let (bx0, bx1) = {
-            let a0 = s.get_with_zeta(0, 0, 0);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(2, 1, 1);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
-        };
-        let (bx2, bx3, bx4) = {
-            let a2 = s.get_with_zeta(4, 2, 0);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(1, 3, 0);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(3, 4, 1);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(22),
-                (a3 ^ d3).rotate_left(11),
-                (a4 ^ d4).rotate_left(7),
-            )
-        };
-
-        // [hax] uninitialized variables are note supported yet in lean.
-        #[allow(unused_assignments)]
-        let mut ax0 = 0.classify();
-        #[cfg(feature = "full-unroll")]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 2];
-        };
-        #[cfg(not(feature = "full-unroll"))]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[i];
-        };
-        s.set_with_zeta(0, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(2, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(4, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(1, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(3, 4, 1, ax4);
-    }
-    {
-        let (bx0, bx1) = {
-            let a0 = s.get_with_zeta(0, 0, 1);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(2, 1, 0);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
-        };
-        let (bx2, bx3, bx4) = {
-            let a2 = s.get_with_zeta(4, 2, 1);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(1, 3, 1);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(3, 4, 0);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(21),
-                (a3 ^ d3).rotate_left(10),
-                (a4 ^ d4).rotate_left(7),
-            )
-        };
-
-        // [hax] uninitialized variables are note supported yet in lean.
-        #[allow(unused_assignments)]
-        let mut ax0 = 0.classify();
-        #[cfg(feature = "full-unroll")]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 2];
-        };
-        #[cfg(not(feature = "full-unroll"))]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[i];
-            s.i = i + 1;
-        };
-        s.set_with_zeta(0, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(2, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(4, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(1, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(3, 4, 0, ax4);
-    }
-    {
-        let (bx2, bx3) = {
-            let a0 = s.get_with_zeta(3, 0, 0);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(0, 1, 0);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(2), (a1 ^ d1).rotate_left(23))
-        };
-        let (bx4, bx0, bx1) = {
-            let a2 = s.get_with_zeta(2, 2, 0);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(4, 3, 1);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(1, 4, 0);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(31),
-                (a3 ^ d3).rotate_left(14),
-                (a4 ^ d4).rotate_left(10),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(3, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(0, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(2, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(4, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(1, 4, 0, ax4);
-    }
-    {
-        let (bx2, bx3) = {
-            let a0 = s.get_with_zeta(3, 0, 1);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(0, 1, 1);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(1), (a1 ^ d1).rotate_left(22))
-        };
-        let (bx4, bx0, bx1) = {
-            let a2 = s.get_with_zeta(2, 2, 1);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(4, 3, 0);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(1, 4, 1);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(30),
-                (a3 ^ d3).rotate_left(14),
-                (a4 ^ d4).rotate_left(10),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(3, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(0, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(2, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(4, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(1, 4, 1, ax4);
-    }
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[s.i];
+    };
+    s.set_with_zeta(0, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(2, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(4, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(1, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(3, 4, 1, ax4);
 }
 
 #[inline(always)]
-#[cfg_attr(
-    hax_backend_lean,
-    hax_lib::lean::before("set_option maxRecDepth 1500 in")
-)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round2_pi_rho_chi_y0_zeta1<const BASE_ROUND: usize>(s: &mut KeccakState) {
+    let (bx0, bx1) = {
+        let a0 = s.get_with_zeta(0, 0, 1);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(2, 1, 0);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
+    };
+    let (bx2, bx3, bx4) = {
+        let a2 = s.get_with_zeta(4, 2, 1);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(1, 3, 1);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(3, 4, 0);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(21),
+            (a3 ^ d3).rotate_left(10),
+            (a4 ^ d4).rotate_left(7),
+        )
+    };
+
+    let ax0;
+    #[cfg(feature = "full-unroll")]
+    {
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 2];
+    };
+    #[cfg(not(feature = "full-unroll"))]
+    {
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[s.i];
+        s.i = s.i + 1;
+    };
+    s.set_with_zeta(0, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(2, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(4, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(1, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(3, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round2_pi_rho_chi_y1_zeta0(s: &mut KeccakState) {
+    let (bx2, bx3) = {
+        let a0 = s.get_with_zeta(3, 0, 0);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(0, 1, 0);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(2), (a1 ^ d1).rotate_left(23))
+    };
+    let (bx4, bx0, bx1) = {
+        let a2 = s.get_with_zeta(2, 2, 0);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(4, 3, 1);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(1, 4, 0);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(31),
+            (a3 ^ d3).rotate_left(14),
+            (a4 ^ d4).rotate_left(10),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(3, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(0, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(2, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(4, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(1, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round2_pi_rho_chi_y1_zeta1(s: &mut KeccakState) {
+    let (bx2, bx3) = {
+        let a0 = s.get_with_zeta(3, 0, 1);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(0, 1, 1);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(1), (a1 ^ d1).rotate_left(22))
+    };
+    let (bx4, bx0, bx1) = {
+        let a2 = s.get_with_zeta(2, 2, 1);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(4, 3, 0);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(1, 4, 1);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(30),
+            (a3 ^ d3).rotate_left(14),
+            (a4 ^ d4).rotate_left(10),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(3, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(0, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(2, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(4, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(1, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round2_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
+    keccakf1600_round2_pi_rho_chi_y0_zeta0::<BASE_ROUND>(s);
+    keccakf1600_round2_pi_rho_chi_y0_zeta1::<BASE_ROUND>(s);
+    keccakf1600_round2_pi_rho_chi_y1_zeta0(s);
+    keccakf1600_round2_pi_rho_chi_y1_zeta1(s);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round2_pi_rho_chi_y2_zeta0(s: &mut KeccakState) {
+    let (bx4, bx0) = {
+        let a0 = s.get_with_zeta(1, 0, 1);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(3, 1, 0);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(1))
+    };
+    let (bx1, bx2, bx3) = {
+        let a2 = s.get_with_zeta(0, 2, 1);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(2, 3, 1);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(4, 4, 1);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(3),
+            (a3 ^ d3).rotate_left(13),
+            (a4 ^ d4).rotate_left(4),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(1, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(3, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(0, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(2, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(4, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round2_pi_rho_chi_y2_zeta1(s: &mut KeccakState) {
+    let (bx4, bx0) = {
+        let a0 = s.get_with_zeta(1, 0, 0);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(3, 1, 1);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(0))
+    };
+    let (bx1, bx2, bx3) = {
+        let a2 = s.get_with_zeta(0, 2, 0);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(2, 3, 0);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(4, 4, 0);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(3),
+            (a3 ^ d3).rotate_left(12),
+            (a4 ^ d4).rotate_left(4),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(1, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(3, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(0, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(2, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(4, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round2_pi_rho_chi_y3_zeta0(s: &mut KeccakState) {
+    let (bx1, bx2) = {
+        let a0 = s.get_with_zeta(4, 0, 1);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(1, 1, 1);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
+    };
+    let (bx3, bx4, bx0) = {
+        let a2 = s.get_with_zeta(3, 2, 1);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(0, 3, 1);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(2, 4, 0);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(8),
+            (a3 ^ d3).rotate_left(28),
+            (a4 ^ d4).rotate_left(14),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(4, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(1, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(3, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(0, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(2, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round2_pi_rho_chi_y3_zeta1(s: &mut KeccakState) {
+    let (bx1, bx2) = {
+        let a0 = s.get_with_zeta(4, 0, 0);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(1, 1, 0);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
+    };
+    let (bx3, bx4, bx0) = {
+        let a2 = s.get_with_zeta(3, 2, 0);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(0, 3, 0);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(2, 4, 1);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(7),
+            (a3 ^ d3).rotate_left(28),
+            (a4 ^ d4).rotate_left(13),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(4, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(1, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(3, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(0, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(2, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round2_pi_rho_chi_y4_zeta0(s: &mut KeccakState) {
+    let (bx3, bx4) = {
+        let a0 = s.get_with_zeta(2, 0, 0);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(4, 1, 0);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(21), (a1 ^ d1).rotate_left(1))
+    };
+    let (bx0, bx1, bx2) = {
+        let a2 = s.get_with_zeta(1, 2, 1);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(3, 3, 0);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(0, 4, 0);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(31),
+            (a3 ^ d3).rotate_left(28),
+            (a4 ^ d4).rotate_left(20),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(2, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(4, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(1, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(3, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(0, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round2_pi_rho_chi_y4_zeta1(s: &mut KeccakState) {
+    let (bx3, bx4) = {
+        let a0 = s.get_with_zeta(2, 0, 1);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(4, 1, 1);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(20), (a1 ^ d1).rotate_left(1))
+    };
+    let (bx0, bx1, bx2) = {
+        let a2 = s.get_with_zeta(1, 2, 0);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(3, 3, 1);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(0, 4, 1);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(31),
+            (a3 ^ d3).rotate_left(27),
+            (a4 ^ d4).rotate_left(19),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(2, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(4, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(1, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(3, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(0, 4, 1, ax4);
+}
+
+#[inline(always)]
 #[hax_lib::opaque]
 pub(crate) fn keccakf1600_round2_pi_rho_chi_2(s: &mut KeccakState) {
-    {
-        let (bx4, bx0) = {
-            let a0 = s.get_with_zeta(1, 0, 1);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(3, 1, 0);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(1))
-        };
-        let (bx1, bx2, bx3) = {
-            let a2 = s.get_with_zeta(0, 2, 1);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(2, 3, 1);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(4, 4, 1);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(3),
-                (a3 ^ d3).rotate_left(13),
-                (a4 ^ d4).rotate_left(4),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(1, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(3, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(0, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(2, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(4, 4, 1, ax4);
-    }
-    {
-        let (bx4, bx0) = {
-            let a0 = s.get_with_zeta(1, 0, 0);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(3, 1, 1);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(0))
-        };
-        let (bx1, bx2, bx3) = {
-            let a2 = s.get_with_zeta(0, 2, 0);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(2, 3, 0);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(4, 4, 0);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(3),
-                (a3 ^ d3).rotate_left(12),
-                (a4 ^ d4).rotate_left(4),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(1, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(3, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(0, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(2, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(4, 4, 0, ax4);
-    }
-    {
-        let (bx1, bx2) = {
-            let a0 = s.get_with_zeta(4, 0, 1);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(1, 1, 1);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
-        };
-        let (bx3, bx4, bx0) = {
-            let a2 = s.get_with_zeta(3, 2, 1);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(0, 3, 1);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(2, 4, 0);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(8),
-                (a3 ^ d3).rotate_left(28),
-                (a4 ^ d4).rotate_left(14),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(4, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(1, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(3, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(0, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(2, 4, 0, ax4);
-    }
-    {
-        let (bx1, bx2) = {
-            let a0 = s.get_with_zeta(4, 0, 0);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(1, 1, 0);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
-        };
-        let (bx3, bx4, bx0) = {
-            let a2 = s.get_with_zeta(3, 2, 0);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(0, 3, 0);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(2, 4, 1);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(7),
-                (a3 ^ d3).rotate_left(28),
-                (a4 ^ d4).rotate_left(13),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(4, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(1, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(3, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(0, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(2, 4, 1, ax4);
-    }
-    {
-        let (bx3, bx4) = {
-            let a0 = s.get_with_zeta(2, 0, 0);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(4, 1, 0);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(21), (a1 ^ d1).rotate_left(1))
-        };
-        let (bx0, bx1, bx2) = {
-            let a2 = s.get_with_zeta(1, 2, 1);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(3, 3, 0);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(0, 4, 0);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(31),
-                (a3 ^ d3).rotate_left(28),
-                (a4 ^ d4).rotate_left(20),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(2, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(4, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(1, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(3, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(0, 4, 0, ax4);
-    }
-    {
-        let (bx3, bx4) = {
-            let a0 = s.get_with_zeta(2, 0, 1);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(4, 1, 1);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(20), (a1 ^ d1).rotate_left(1))
-        };
-        let (bx0, bx1, bx2) = {
-            let a2 = s.get_with_zeta(1, 2, 0);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(3, 3, 1);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(0, 4, 1);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(31),
-                (a3 ^ d3).rotate_left(27),
-                (a4 ^ d4).rotate_left(19),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(2, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(4, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(1, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(3, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(0, 4, 1, ax4);
-    }
+    keccakf1600_round2_pi_rho_chi_y2_zeta0(s);
+    keccakf1600_round2_pi_rho_chi_y2_zeta1(s);
+    keccakf1600_round2_pi_rho_chi_y3_zeta0(s);
+    keccakf1600_round2_pi_rho_chi_y3_zeta1(s);
+    keccakf1600_round2_pi_rho_chi_y4_zeta0(s);
+    keccakf1600_round2_pi_rho_chi_y4_zeta1(s);
 }
 
 #[inline(always)]
@@ -2073,366 +2151,392 @@ pub(crate) fn keccakf1600_round3_theta(s: &mut KeccakState) {
 }
 
 #[inline(always)]
-#[cfg_attr(
-    hax_backend_lean,
-    hax_lib::lean::before("set_option maxRecDepth 1000 in")
-)]
 #[hax_lib::opaque]
-pub(crate) fn keccakf1600_round3_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
+pub(crate) fn keccakf1600_round3_pi_rho_chi_y0_zeta0<const BASE_ROUND: usize>(s: &mut KeccakState) {
+    let (bx0, bx1) = {
+        let a0 = s.get_with_zeta(0, 0, 0);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(0, 1, 0);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
+    };
+    let (bx2, bx3, bx4) = {
+        let a2 = s.get_with_zeta(0, 2, 0);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(0, 3, 0);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(0, 4, 0);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(22),
+            (a3 ^ d3).rotate_left(11),
+            (a4 ^ d4).rotate_left(7),
+        )
+    };
+
+    let ax0;
+    #[cfg(feature = "full-unroll")]
+    {
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 3];
+    };
     #[cfg(not(feature = "full-unroll"))]
-    let i = s.i;
     {
-        let (bx0, bx1) = {
-            let a0 = s.get_with_zeta(0, 0, 0);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(0, 1, 0);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
-        };
-        let (bx2, bx3, bx4) = {
-            let a2 = s.get_with_zeta(0, 2, 0);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(0, 3, 0);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(0, 4, 0);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(22),
-                (a3 ^ d3).rotate_left(11),
-                (a4 ^ d4).rotate_left(7),
-            )
-        };
-
-        // [hax] uninitialized variables are note supported yet in lean.
-        #[allow(unused_assignments)]
-        let mut ax0 = 0.classify();
-        #[cfg(feature = "full-unroll")]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[BASE_ROUND + 3];
-        };
-        #[cfg(not(feature = "full-unroll"))]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[i];
-        };
-        s.set_with_zeta(0, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(0, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(0, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(0, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(0, 4, 0, ax4);
-    }
-    {
-        let (bx0, bx1) = {
-            let a0 = s.get_with_zeta(0, 0, 1);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(0, 1, 1);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
-        };
-        let (bx2, bx3, bx4) = {
-            let a2 = s.get_with_zeta(0, 2, 1);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(0, 3, 1);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(0, 4, 1);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(21),
-                (a3 ^ d3).rotate_left(10),
-                (a4 ^ d4).rotate_left(7),
-            )
-        };
-
-        // [hax] uninitialized variables are note supported yet in lean.
-        #[allow(unused_assignments)]
-        let mut ax0 = 0.classify();
-        #[cfg(feature = "full-unroll")]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 3];
-        };
-        #[cfg(not(feature = "full-unroll"))]
-        {
-            ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[i];
-            s.i = i + 1;
-        };
-        s.set_with_zeta(0, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(0, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(0, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(0, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(0, 4, 1, ax4);
-    }
-    {
-        let (bx2, bx3) = {
-            let a0 = s.get_with_zeta(1, 0, 0);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(1, 1, 0);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(2), (a1 ^ d1).rotate_left(23))
-        };
-        let (bx4, bx0, bx1) = {
-            let a2 = s.get_with_zeta(1, 2, 0);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(1, 3, 0);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(1, 4, 0);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(31),
-                (a3 ^ d3).rotate_left(14),
-                (a4 ^ d4).rotate_left(10),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(1, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(1, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(1, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(1, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(1, 4, 0, ax4);
-    }
-    {
-        let (bx2, bx3) = {
-            let a0 = s.get_with_zeta(1, 0, 1);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(1, 1, 1);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(1), (a1 ^ d1).rotate_left(22))
-        };
-        let (bx4, bx0, bx1) = {
-            let a2 = s.get_with_zeta(1, 2, 1);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(1, 3, 1);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(1, 4, 1);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(30),
-                (a3 ^ d3).rotate_left(14),
-                (a4 ^ d4).rotate_left(10),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(1, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(1, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(1, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(1, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(1, 4, 1, ax4);
-    }
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_0[s.i];
+    };
+    s.set_with_zeta(0, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(0, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(0, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(0, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(0, 4, 0, ax4);
 }
 
 #[inline(always)]
-#[cfg_attr(
-    hax_backend_lean,
-    hax_lib::lean::before("set_option maxRecDepth 1500 in")
-)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round3_pi_rho_chi_y0_zeta1<const BASE_ROUND: usize>(s: &mut KeccakState) {
+    let (bx0, bx1) = {
+        let a0 = s.get_with_zeta(0, 0, 1);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(0, 1, 1);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(0), (a1 ^ d1).rotate_left(22))
+    };
+    let (bx2, bx3, bx4) = {
+        let a2 = s.get_with_zeta(0, 2, 1);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(0, 3, 1);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(0, 4, 1);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(21),
+            (a3 ^ d3).rotate_left(10),
+            (a4 ^ d4).rotate_left(7),
+        )
+    };
+
+    let ax0;
+    #[cfg(feature = "full-unroll")]
+    {
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[BASE_ROUND + 3];
+    };
+    #[cfg(not(feature = "full-unroll"))]
+    {
+        ax0 = bx0 ^ ((!bx1) & bx2) ^ RC_INTERLEAVED_1[s.i];
+        s.i = s.i + 1;
+    };
+    s.set_with_zeta(0, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(0, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(0, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(0, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(0, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round3_pi_rho_chi_y1_zeta0(s: &mut KeccakState) {
+    let (bx2, bx3) = {
+        let a0 = s.get_with_zeta(1, 0, 0);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(1, 1, 0);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(2), (a1 ^ d1).rotate_left(23))
+    };
+    let (bx4, bx0, bx1) = {
+        let a2 = s.get_with_zeta(1, 2, 0);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(1, 3, 0);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(1, 4, 0);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(31),
+            (a3 ^ d3).rotate_left(14),
+            (a4 ^ d4).rotate_left(10),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(1, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(1, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(1, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(1, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(1, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round3_pi_rho_chi_y1_zeta1(s: &mut KeccakState) {
+    let (bx2, bx3) = {
+        let a0 = s.get_with_zeta(1, 0, 1);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(1, 1, 1);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(1), (a1 ^ d1).rotate_left(22))
+    };
+    let (bx4, bx0, bx1) = {
+        let a2 = s.get_with_zeta(1, 2, 1);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(1, 3, 1);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(1, 4, 1);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(30),
+            (a3 ^ d3).rotate_left(14),
+            (a4 ^ d4).rotate_left(10),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(1, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(1, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(1, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(1, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(1, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round3_pi_rho_chi_1<const BASE_ROUND: usize>(s: &mut KeccakState) {
+    keccakf1600_round3_pi_rho_chi_y0_zeta0::<BASE_ROUND>(s);
+    keccakf1600_round3_pi_rho_chi_y0_zeta1::<BASE_ROUND>(s);
+    keccakf1600_round3_pi_rho_chi_y1_zeta0(s);
+    keccakf1600_round3_pi_rho_chi_y1_zeta1(s);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round3_pi_rho_chi_y2_zeta0(s: &mut KeccakState) {
+    let (bx4, bx0) = {
+        let a0 = s.get_with_zeta(2, 0, 0);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(2, 1, 0);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(1))
+    };
+    let (bx1, bx2, bx3) = {
+        let a2 = s.get_with_zeta(2, 2, 0);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(2, 3, 0);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(2, 4, 0);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(3),
+            (a3 ^ d3).rotate_left(13),
+            (a4 ^ d4).rotate_left(4),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(2, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(2, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(2, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(2, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(2, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round3_pi_rho_chi_y2_zeta1(s: &mut KeccakState) {
+    let (bx4, bx0) = {
+        let a0 = s.get_with_zeta(2, 0, 1);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(2, 1, 1);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(0))
+    };
+    let (bx1, bx2, bx3) = {
+        let a2 = s.get_with_zeta(2, 2, 1);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(2, 3, 1);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(2, 4, 1);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(3),
+            (a3 ^ d3).rotate_left(12),
+            (a4 ^ d4).rotate_left(4),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(2, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(2, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(2, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(2, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(2, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round3_pi_rho_chi_y3_zeta0(s: &mut KeccakState) {
+    let (bx1, bx2) = {
+        let a0 = s.get_with_zeta(3, 0, 0);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(3, 1, 0);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
+    };
+    let (bx3, bx4, bx0) = {
+        let a2 = s.get_with_zeta(3, 2, 0);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(3, 3, 0);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(3, 4, 0);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(8),
+            (a3 ^ d3).rotate_left(28),
+            (a4 ^ d4).rotate_left(14),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(3, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(3, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(3, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(3, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(3, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round3_pi_rho_chi_y3_zeta1(s: &mut KeccakState) {
+    let (bx1, bx2) = {
+        let a0 = s.get_with_zeta(3, 0, 1);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(3, 1, 1);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
+    };
+    let (bx3, bx4, bx0) = {
+        let a2 = s.get_with_zeta(3, 2, 1);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(3, 3, 1);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(3, 4, 1);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(7),
+            (a3 ^ d3).rotate_left(28),
+            (a4 ^ d4).rotate_left(13),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(3, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(3, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(3, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(3, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(3, 4, 1, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round3_pi_rho_chi_y4_zeta0(s: &mut KeccakState) {
+    let (bx3, bx4) = {
+        let a0 = s.get_with_zeta(4, 0, 0);
+        let d0 = s.d[0][1];
+        let a1 = s.get_with_zeta(4, 1, 0);
+        let d1 = s.d[1][0];
+        ((a0 ^ d0).rotate_left(21), (a1 ^ d1).rotate_left(1))
+    };
+    let (bx0, bx1, bx2) = {
+        let a2 = s.get_with_zeta(4, 2, 0);
+        let d2 = s.d[2][0];
+        let a3 = s.get_with_zeta(4, 3, 0);
+        let d3 = s.d[3][1];
+        let a4 = s.get_with_zeta(4, 4, 0);
+        let d4 = s.d[4][1];
+        (
+            (a2 ^ d2).rotate_left(31),
+            (a3 ^ d3).rotate_left(28),
+            (a4 ^ d4).rotate_left(20),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(4, 0, 0, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(4, 1, 0, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(4, 2, 0, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(4, 3, 0, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(4, 4, 0, ax4);
+}
+
+#[inline(always)]
+#[hax_lib::opaque]
+pub(crate) fn keccakf1600_round3_pi_rho_chi_y4_zeta1(s: &mut KeccakState) {
+    let (bx3, bx4) = {
+        let a0 = s.get_with_zeta(4, 0, 1);
+        let d0 = s.d[0][0];
+        let a1 = s.get_with_zeta(4, 1, 1);
+        let d1 = s.d[1][1];
+        ((a0 ^ d0).rotate_left(20), (a1 ^ d1).rotate_left(1))
+    };
+    let (bx0, bx1, bx2) = {
+        let a2 = s.get_with_zeta(4, 2, 1);
+        let d2 = s.d[2][1];
+        let a3 = s.get_with_zeta(4, 3, 1);
+        let d3 = s.d[3][0];
+        let a4 = s.get_with_zeta(4, 4, 1);
+        let d4 = s.d[4][0];
+        (
+            (a2 ^ d2).rotate_left(31),
+            (a3 ^ d3).rotate_left(27),
+            (a4 ^ d4).rotate_left(19),
+        )
+    };
+    let ax0 = bx0 ^ ((!bx1) & bx2);
+    s.set_with_zeta(4, 0, 1, ax0);
+    let ax1 = bx1 ^ ((!bx2) & bx3);
+    s.set_with_zeta(4, 1, 1, ax1);
+    let ax2 = bx2 ^ ((!bx3) & bx4);
+    s.set_with_zeta(4, 2, 1, ax2);
+    let ax3 = bx3 ^ ((!bx4) & bx0);
+    s.set_with_zeta(4, 3, 1, ax3);
+    let ax4 = bx4 ^ ((!bx0) & bx1);
+    s.set_with_zeta(4, 4, 1, ax4);
+}
+
+#[inline(always)]
 #[hax_lib::opaque]
 pub(crate) fn keccakf1600_round3_pi_rho_chi_2(s: &mut KeccakState) {
-    {
-        let (bx4, bx0) = {
-            let a0 = s.get_with_zeta(2, 0, 0);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(2, 1, 0);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(1))
-        };
-        let (bx1, bx2, bx3) = {
-            let a2 = s.get_with_zeta(2, 2, 0);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(2, 3, 0);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(2, 4, 0);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(3),
-                (a3 ^ d3).rotate_left(13),
-                (a4 ^ d4).rotate_left(4),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(2, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(2, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(2, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(2, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(2, 4, 0, ax4);
-    }
-    {
-        let (bx4, bx0) = {
-            let a0 = s.get_with_zeta(2, 0, 1);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(2, 1, 1);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(9), (a1 ^ d1).rotate_left(0))
-        };
-        let (bx1, bx2, bx3) = {
-            let a2 = s.get_with_zeta(2, 2, 1);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(2, 3, 1);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(2, 4, 1);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(3),
-                (a3 ^ d3).rotate_left(12),
-                (a4 ^ d4).rotate_left(4),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(2, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(2, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(2, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(2, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(2, 4, 1, ax4);
-    }
-    {
-        let (bx1, bx2) = {
-            let a0 = s.get_with_zeta(3, 0, 0);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(3, 1, 0);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
-        };
-        let (bx3, bx4, bx0) = {
-            let a2 = s.get_with_zeta(3, 2, 0);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(3, 3, 0);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(3, 4, 0);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(8),
-                (a3 ^ d3).rotate_left(28),
-                (a4 ^ d4).rotate_left(14),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(3, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(3, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(3, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(3, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(3, 4, 0, ax4);
-    }
-    {
-        let (bx1, bx2) = {
-            let a0 = s.get_with_zeta(3, 0, 1);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(3, 1, 1);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(18), (a1 ^ d1).rotate_left(5))
-        };
-        let (bx3, bx4, bx0) = {
-            let a2 = s.get_with_zeta(3, 2, 1);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(3, 3, 1);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(3, 4, 1);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(7),
-                (a3 ^ d3).rotate_left(28),
-                (a4 ^ d4).rotate_left(13),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(3, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(3, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(3, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(3, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(3, 4, 1, ax4);
-    }
-    {
-        let (bx3, bx4) = {
-            let a0 = s.get_with_zeta(4, 0, 0);
-            let d0 = s.d[0][1];
-            let a1 = s.get_with_zeta(4, 1, 0);
-            let d1 = s.d[1][0];
-            ((a0 ^ d0).rotate_left(21), (a1 ^ d1).rotate_left(1))
-        };
-        let (bx0, bx1, bx2) = {
-            let a2 = s.get_with_zeta(4, 2, 0);
-            let d2 = s.d[2][0];
-            let a3 = s.get_with_zeta(4, 3, 0);
-            let d3 = s.d[3][1];
-            let a4 = s.get_with_zeta(4, 4, 0);
-            let d4 = s.d[4][1];
-            (
-                (a2 ^ d2).rotate_left(31),
-                (a3 ^ d3).rotate_left(28),
-                (a4 ^ d4).rotate_left(20),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(4, 0, 0, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(4, 1, 0, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(4, 2, 0, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(4, 3, 0, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(4, 4, 0, ax4);
-    }
-    {
-        let (bx3, bx4) = {
-            let a0 = s.get_with_zeta(4, 0, 1);
-            let d0 = s.d[0][0];
-            let a1 = s.get_with_zeta(4, 1, 1);
-            let d1 = s.d[1][1];
-            ((a0 ^ d0).rotate_left(20), (a1 ^ d1).rotate_left(1))
-        };
-        let (bx0, bx1, bx2) = {
-            let a2 = s.get_with_zeta(4, 2, 1);
-            let d2 = s.d[2][1];
-            let a3 = s.get_with_zeta(4, 3, 1);
-            let d3 = s.d[3][0];
-            let a4 = s.get_with_zeta(4, 4, 1);
-            let d4 = s.d[4][0];
-            (
-                (a2 ^ d2).rotate_left(31),
-                (a3 ^ d3).rotate_left(27),
-                (a4 ^ d4).rotate_left(19),
-            )
-        };
-        let ax0 = bx0 ^ ((!bx1) & bx2);
-        s.set_with_zeta(4, 0, 1, ax0);
-        let ax1 = bx1 ^ ((!bx2) & bx3);
-        s.set_with_zeta(4, 1, 1, ax1);
-        let ax2 = bx2 ^ ((!bx3) & bx4);
-        s.set_with_zeta(4, 2, 1, ax2);
-        let ax3 = bx3 ^ ((!bx4) & bx0);
-        s.set_with_zeta(4, 3, 1, ax3);
-        let ax4 = bx4 ^ ((!bx0) & bx1);
-        s.set_with_zeta(4, 4, 1, ax4);
-    }
+    keccakf1600_round3_pi_rho_chi_y2_zeta0(s);
+    keccakf1600_round3_pi_rho_chi_y2_zeta1(s);
+    keccakf1600_round3_pi_rho_chi_y3_zeta0(s);
+    keccakf1600_round3_pi_rho_chi_y3_zeta1(s);
+    keccakf1600_round3_pi_rho_chi_y4_zeta0(s);
+    keccakf1600_round3_pi_rho_chi_y4_zeta1(s);
 }
 
 // What is interesting is that I assumed that not inlining here should be relatively cheap, because

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -86,8 +86,8 @@ impl<const RATE: usize> KeccakXofState<RATE> {
     #[hax_lib::ensures(|remainder|
         remainder < RATE
         && remainder <= inputs.len()
-        && future(self).buf_len <= RATE
         && future(self).buf_len.to_int() + remainder.to_int() < usize::MAX.to_int()
+        && future(self).buf_len < RATE
     )]
     fn absorb_full(&mut self, inputs: &[U8]) -> usize {
         #[cfg(not(eurydice))]
@@ -133,8 +133,8 @@ impl<const RATE: usize> KeccakXofState<RATE> {
     /// If `consumed > 0` is returned, `self.buf` contains a full block to be
     /// loaded.
     #[hax_lib::requires(
-        self.buf_len <= RATE &&
         inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
+        && self.buf_len < RATE 
     )]
     #[hax_lib::ensures(|res|
         (res <= RATE).to_prop()

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -2,7 +2,7 @@
 //! sub-routines.
 
 #[cfg(hax)]
-use hax_lib::{ToInt, ToProp};
+use hax_lib::ToInt;
 use libcrux_secrets::{Classify, U8};
 #[cfg(feature = "check-secret-independence")]
 use libcrux_secrets::{Declassify, U32};
@@ -55,8 +55,7 @@ impl<const RATE: usize> KeccakXofState<RATE> {
         RATE > 0 &&
         RATE % 8 == 0 &&
         RATE <= 168 &&
-        self.buf_len < RATE &&
-        inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
+        self.buf_len < RATE 
     )]
     pub(crate) fn absorb(&mut self, inputs: &[U8]) {
         let input_remainder_len = self.absorb_full(inputs);
@@ -80,13 +79,11 @@ impl<const RATE: usize> KeccakXofState<RATE> {
         RATE > 0 &&
         RATE % 8 == 0 &&
         RATE <= 168 &&
-        self.buf_len < RATE &&
-        inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
+        self.buf_len < RATE
     )]
     #[hax_lib::ensures(|remainder|
         remainder < RATE
         && remainder <= inputs.len()
-        && future(self).buf_len.to_int() + remainder.to_int() < usize::MAX.to_int()
         && future(self).buf_len < RATE
     )]
     fn absorb_full(&mut self, inputs: &[U8]) -> usize {
@@ -133,20 +130,18 @@ impl<const RATE: usize> KeccakXofState<RATE> {
     /// If `consumed > 0` is returned, `self.buf` contains a full block to be
     /// loaded.
     #[hax_lib::requires(
-        inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
-        && self.buf_len < RATE 
+        self.buf_len < RATE 
     )]
     #[hax_lib::ensures(|res|
-        (res <= RATE).to_prop()
-        & (future(self).buf_len <= RATE).to_prop()
-        & hax_lib::implies(res > 0, future(self).buf_len == RATE)
+        res <= RATE
+        && future(self).buf_len <= RATE
     )]
     fn fill_buffer(&mut self, inputs: &[U8]) -> usize {
         let input_len = inputs.len();
         let mut consumed = 0;
         if self.buf_len > 0 {
             // There's something buffered internally to consume.
-            if self.buf_len + input_len >= RATE {
+            if input_len >= RATE - self.buf_len {
                 // We have enough data when combining the internal buffer and
                 // the input.
                 consumed = RATE - self.buf_len;
@@ -166,8 +161,7 @@ impl<const RATE: usize> KeccakXofState<RATE> {
         RATE > 0 &&
         RATE % 8 == 0 &&
         RATE <= 168 &&
-        self.buf_len < RATE &&
-        inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
+        self.buf_len < RATE 
     )]
     pub(crate) fn absorb_final<const DELIMITER: u8>(&mut self, inputs: &[U8]) {
         let input_remainder_len = self.absorb_full(inputs);

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -18,7 +18,7 @@ pub(crate) struct KeccakXofState<const RATE: usize> {
     buf: [U8; RATE],
 
     // Buffered length.
-    buf_len: usize,
+    pub(crate) buf_len: usize,
 
     // Needs sponge.
     sponge: bool,
@@ -54,17 +54,10 @@ impl<const RATE: usize> KeccakXofState<RATE> {
     #[hax_lib::requires(
         RATE > 0 &&
         RATE % 8 == 0 &&
-        RATE <= 144 &&
+        RATE <= 168 &&
         self.buf_len < RATE &&
         inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
     )]
-    // #[hax_lib::requires(
-    //     RATE > 0 &&
-    //     RATE % 8 == 0 &&
-    //     RATE <= 144 &&
-    //     self.buf_len < RATE &&
-    //     inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int() &&
-    // )]
     pub(crate) fn absorb(&mut self, inputs: &[U8]) {
         let input_remainder_len = self.absorb_full(inputs);
 
@@ -86,7 +79,7 @@ impl<const RATE: usize> KeccakXofState<RATE> {
     #[hax_lib::requires(
         RATE > 0 &&
         RATE % 8 == 0 &&
-        RATE <= 144 &&
+        RATE <= 168 &&
         self.buf_len < RATE &&
         inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
     )]
@@ -172,7 +165,7 @@ impl<const RATE: usize> KeccakXofState<RATE> {
     #[hax_lib::requires(
         RATE > 0 &&
         RATE % 8 == 0 &&
-        RATE <= 144 &&
+        RATE <= 168 &&
         self.buf_len < RATE &&
         inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
     )]
@@ -199,49 +192,60 @@ impl<const RATE: usize> KeccakXofState<RATE> {
 
     /// Squeeze `N` x `LEN` bytes.
     #[inline(always)]
-    #[hax_lib::requires(RATE > 0 && RATE % 8 == 0 && RATE <= 144)]
+    #[hax_lib::requires(RATE == 168 || RATE == 144 || RATE == 136 || RATE == 104 || RATE == 72)]
+    // The code verifies with the z3rlimit specified below, but we
+    // can't use the `options` attribute in the impl block because of
+    // a hax issue. Therefore we pull out the function and put it
+    // there instead.  cf. https://github.com/cryspen/hax/issues/1698
+    // #[hax_lib::fstar::options("--z3rlimit 60")]
     pub(crate) fn squeeze(&mut self, out: &mut [U8]) {
-        if self.sponge {
-            // If we called `squeeze` before, call f1600 first.
-            // We do it this way around so that we don't call f1600 at the end
-            // when we don't need it.
-            keccakf1600(&mut self.inner);
-        }
-
-        // How many blocks do we need to squeeze out?
-        let out_len = out.len();
-        let blocks = out_len / RATE;
-        let last = out_len - (out_len % RATE);
-
-        // Squeeze out one to start with.
-        // XXX: Eurydice does not extract `core::cmp::min`, so we do
-        // this instead. (cf. https://github.com/AeneasVerif/eurydice/issues/49)
-        let mid = if RATE >= out_len { out_len } else { RATE };
-        self.inner.store::<RATE>(&mut out[..mid]);
-
-        // // If we got asked for more than one block, squeeze out more.
-        let mut offset = mid;
-        for _k in 1..blocks {
-            hax_lib::loop_invariant!(|_k: usize| {
-                out.len() == out_len && offset.to_int() == _k.to_int() * RATE.to_int()
-            });
-            // Here we know that we always have full blocks to write out.
-            keccakf1600(&mut self.inner);
-            self.inner.store::<RATE>(&mut out[offset..offset + RATE]);
-            offset += RATE;
-        }
-
-        if last > 0 && last < out_len {
-            debug_assert_eq!(last, offset);
-            // Squeeze out the last partial block
-            keccakf1600(&mut self.inner);
-            self.inner.store::<RATE>(&mut out[offset..]);
-        }
-
-        self.sponge = true;
+        _squeeze(self, out);
     }
 }
 
+#[inline(always)]
+#[hax_lib::requires(RATE == 168 || RATE == 144 || RATE == 136 || RATE == 104 || RATE == 72)]
+#[hax_lib::fstar::options("--z3rlimit 60")]
+fn _squeeze<const RATE: usize>(state: &mut KeccakXofState<RATE>, out: &mut [U8]) {
+    if state.sponge {
+        // If we called `squeeze` before, call f1600 first.
+        // We do it this way around so that we don't call f1600 at the end
+        // when we don't need it.
+        keccakf1600(&mut state.inner);
+    }
+
+    // How many blocks do we need to squeeze out?
+    let out_len = out.len();
+    let blocks = out_len / RATE;
+    let last = out_len - (out_len % RATE);
+
+    // Squeeze out one to start with.
+    // XXX: Eurydice does not extract `core::cmp::min`, so we do
+    // this instead. (cf. https://github.com/AeneasVerif/eurydice/issues/49)
+    let mid = if RATE >= out_len { out_len } else { RATE };
+    state.inner.store::<RATE>(&mut out[..mid]);
+
+    // If we got asked for more than one block, squeeze out more.
+    let mut offset = mid;
+    for _k in 1..blocks {
+        hax_lib::loop_invariant!(|_k: usize| {
+            out.len() == out_len && offset.to_int() == _k.to_int() * RATE.to_int()
+        });
+        // Here we know that we always have full blocks to write out.
+        keccakf1600(&mut state.inner);
+        state.inner.store::<RATE>(&mut out[offset..offset + RATE]);
+        offset += RATE;
+    }
+
+    if last > 0 && last < out_len {
+        debug_assert_eq!(last, offset);
+        // Squeeze out the last partial block
+        keccakf1600(&mut state.inner);
+        state.inner.store::<RATE>(&mut out[offset..]);
+    }
+
+    state.sponge = true;
+}
 //// From here, everything is generic
 
 #[cfg_attr(
@@ -2477,7 +2481,7 @@ pub(crate) fn keccakf1600(s: &mut KeccakState) {
 #[inline(always)]
 #[hax_lib::requires(
     RATE % 8 == 0
-    && RATE <= 144
+    && RATE <= 168
     && start.to_int() + RATE.to_int() <= blocks.len().to_int()
 )]
 pub(crate) fn absorb_block<const RATE: usize>(s: &mut KeccakState, blocks: &[U8], start: usize) {
@@ -2489,7 +2493,7 @@ pub(crate) fn absorb_block<const RATE: usize>(s: &mut KeccakState, blocks: &[U8]
 #[hax_lib::requires(
     RATE > 0
     && RATE % 8 == 0
-    && RATE <= 144
+    && RATE <= 168
     && len < RATE
     && start.to_int() + len.to_int() <= last.len().to_int())]
 pub(crate) fn absorb_final<const RATE: usize, const DELIM: u8>(
@@ -2512,13 +2516,15 @@ pub(crate) fn absorb_final<const RATE: usize, const DELIM: u8>(
 }
 
 #[inline(always)]
-#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && RATE <= out.len())]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && RATE <= out.len())]
+#[hax_lib::ensures(|_| future(out).len() == out.len())]
 pub(crate) fn squeeze_first_block<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
     s.store_block::<RATE>(out)
 }
 
 #[inline(always)]
-#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && RATE <= out.len())]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && RATE <= out.len())]
+#[hax_lib::ensures(|_| future(out).len() == out.len())]
 pub(crate) fn squeeze_next_block<const RATE: usize>(s: &mut KeccakState, out: &mut [U8]) {
     keccakf1600(s);
     s.store_block::<RATE>(out)
@@ -2526,7 +2532,7 @@ pub(crate) fn squeeze_next_block<const RATE: usize>(s: &mut KeccakState, out: &m
 
 #[inline(always)]
 #[cfg(feature = "unbuffered-xof")]
-#[hax_lib::opaque]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && 3 * RATE <= out.len())]
 pub(crate) fn squeeze_first_three_blocks<const RATE: usize>(s: &mut KeccakState, out: &mut [U8]) {
     squeeze_first_block::<RATE>(s, out);
     squeeze_next_block::<RATE>(s, &mut out[RATE..]);
@@ -2535,7 +2541,7 @@ pub(crate) fn squeeze_first_three_blocks<const RATE: usize>(s: &mut KeccakState,
 
 #[inline(always)]
 #[cfg(feature = "unbuffered-xof")]
-#[hax_lib::opaque]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && 5 * RATE <= out.len())]
 pub(crate) fn squeeze_first_five_blocks<const RATE: usize>(s: &mut KeccakState, out: &mut [U8]) {
     squeeze_first_block::<RATE>(s, out);
     squeeze_next_block::<RATE>(s, &mut out[RATE..]);
@@ -2545,7 +2551,7 @@ pub(crate) fn squeeze_first_five_blocks<const RATE: usize>(s: &mut KeccakState, 
 }
 
 #[inline(always)]
-#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && out.len() <= 200)]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && out.len() <= 200)]
 pub(crate) fn squeeze_last<const RATE: usize>(mut s: KeccakState, out: &mut [U8]) {
     keccakf1600(&mut s);
     let mut b = [0u8; 200].classify();
@@ -2554,7 +2560,7 @@ pub(crate) fn squeeze_last<const RATE: usize>(mut s: KeccakState, out: &mut [U8]
 }
 
 #[inline(always)]
-#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && out.len() <= 200)]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && out.len() <= 200)]
 pub(crate) fn squeeze_first_and_last<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
     let mut b = [0u8; 200].classify();
     s.store_block_full::<RATE>(&mut b);
@@ -2566,7 +2572,7 @@ const WIDTH: usize = 200;
 
 #[inline(always)]
 #[hax_lib::requires(
-    RATE > 0 && RATE % 8 == 0 && RATE <= 144
+    RATE > 0 && RATE % 8 == 0 && RATE <= 168
 )]
 #[hax_lib::ensures(|_| future(out).len() == out.len())]
 pub(crate) fn keccak<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut [U8]) {
@@ -2579,11 +2585,12 @@ pub(crate) fn keccak<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut 
 
     let mut s = KeccakState::new();
 
-    for i in 0..n {
-        hax_lib::loop_invariant!(|i: usize| {
-            i.to_int() * RATE.to_int() + RATE.to_int() <= data.len().to_int() && out.len() == outlen
-        });
-        absorb_block::<RATE>(&mut s, &data, i * RATE);
+    let mut start = 0;
+    for _i in 0..n {
+        hax_lib::loop_invariant!(|_i: usize| { start.to_int() == _i.to_int() * RATE.to_int() });
+
+        absorb_block::<RATE>(&mut s, &data, start);
+        start += RATE;
     }
 
     absorb_final::<RATE, DELIM>(&mut s, data, data.len() - rem, rem);

--- a/libcrux-iot/sha3/src/lane.rs
+++ b/libcrux-iot/sha3/src/lane.rs
@@ -113,6 +113,8 @@ impl core::fmt::Debug for Lane2U32 {
 mod interleave_tests {
     use super::*;
     use libcrux_secrets::Declassify;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
     #[test]
     fn identity() {
@@ -125,6 +127,62 @@ mod interleave_tests {
                 lane_.0.declassify(),
                 "lane_: {lane_:x?}, lane: {lane:x?}",
             )
+        }
+    }
+
+    #[test]
+    fn interleave_deinterleave_edge_cases() {
+        let cases: [[u32; 2]; 8] = [
+            [0, 0],
+            [u32::MAX, u32::MAX],
+            [u32::MAX, 0],
+            [0, u32::MAX],
+            [0x5555_5555, 0x5555_5555],
+            [0xAAAA_AAAA, 0xAAAA_AAAA],
+            [0x5555_5555, 0xAAAA_AAAA],
+            [0xDEAD_BEEF, 0x1234_5678],
+        ];
+        for v in cases {
+            let l: Lane2U32 = v.classify().into();
+            let back = l.interleave().deinterleave();
+            assert_eq!(l.0.declassify(), back.0.declassify(), "{:x?}", v);
+        }
+    }
+
+    #[test]
+    fn interleave_deinterleave_random() {
+        let mut rng = StdRng::seed_from_u64(0x1234_5678);
+        for _ in 0..1000 {
+            let v: [u32; 2] = [rng.gen(), rng.gen()];
+            let l: Lane2U32 = v.classify().into();
+            let back = l.interleave().deinterleave();
+            assert_eq!(l.0.declassify(), back.0.declassify(), "{:x?}", v);
+        }
+    }
+
+    /// Interleave a 64-bit value bit-by-bit (reference implementation): even
+    /// bits to the low 32-bit half, odd bits to the high 32-bit half. Used as
+    /// a check that the impl's `interleave` is not just self-inverse but also
+    /// implements the right bit-shuffle.
+    fn reference_interleave(v: u64) -> [u32; 2] {
+        let mut even = 0u32;
+        let mut odd = 0u32;
+        for k in 0..32 {
+            even |= (((v >> (2 * k)) & 1) as u32) << k;
+            odd |= (((v >> (2 * k + 1)) & 1) as u32) << k;
+        }
+        [even, odd]
+    }
+
+    #[test]
+    fn interleave_matches_reference() {
+        let mut rng = StdRng::seed_from_u64(0xABCD_EF01);
+        for _ in 0..500 {
+            let v: u64 = rng.gen();
+            let l: Lane2U32 = [v as u32, (v >> 32) as u32].classify().into();
+            let got = l.interleave().0.declassify();
+            let want = reference_interleave(v);
+            assert_eq!(got, want, "v={:x}", v);
         }
     }
 }

--- a/libcrux-iot/sha3/src/lane.rs
+++ b/libcrux-iot/sha3/src/lane.rs
@@ -100,6 +100,7 @@ impl From<[U32; 2]> for Lane2U32 {
 //      `Debug` which build on it have to be switched off for Eurydice.
 #[cfg(not(eurydice))]
 #[cfg_attr(hax, hax_lib::opaque)]
+#[cfg_attr(hax_backend_lean, charon::exclude)]
 impl core::fmt::Debug for Lane2U32 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use libcrux_secrets::Declassify;

--- a/libcrux-iot/sha3/src/lane.rs
+++ b/libcrux-iot/sha3/src/lane.rs
@@ -78,10 +78,12 @@ impl Lane2U32 {
     }
 }
 
+#[hax_lib::attributes]
 impl Index<usize> for Lane2U32 {
     type Output = U32;
 
     #[inline(always)]
+    #[hax_lib::requires(index < 2)]
     fn index(&self, index: usize) -> &Self::Output {
         &self.0[index]
     }

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -140,6 +140,8 @@ pub const fn digest_size(mode: Algorithm) -> usize {
 pub fn hash<const LEN: usize>(algorithm: Algorithm, payload: &[U8]) -> [U8; LEN] {
     #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
+    #[cfg(not(eurydice))]
+    debug_assert_eq!(LEN, digest_size(algorithm));
 
     let mut out = [0u8; LEN].classify();
 

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -352,8 +352,6 @@ pub fn shake256_ema(out: &mut [U8], data: &[U8]) {
 
 /// Incremental API for SHAKE XOFs
 pub mod incremental {
-    #[cfg(hax)]
-    use hax_lib::ToInt;
     use libcrux_secrets::U8;
 
     /// An unbuffered XOF state.

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -87,6 +87,7 @@ pub enum Algorithm {
     Sha512 = 4,
 }
 
+#[hax_lib::opaque]
 impl From<u32> for Algorithm {
     fn from(v: u32) -> Algorithm {
         match v {
@@ -130,11 +131,16 @@ pub const fn digest_size(mode: Algorithm) -> usize {
 /// let payload = b"Kecak is a Balinese dance.";
 /// let digest: [u8; digest_size(Algorithm::Sha256)] = hash(Algorithm::Sha256, payload);
 /// ```
+#[hax_lib::requires(payload.len() <= u32::MAX as usize && LEN == digest_size(algorithm))]
 pub fn hash<const LEN: usize>(algorithm: Algorithm, payload: &[U8]) -> [U8; LEN] {
     #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
 
     let mut out = [0u8; LEN].classify();
+
+    // We have to work around a hax issue with implicit array
+    // conversion here.
+    // cf. https://github.com/cryspen/hax/issues/1983
     #[cfg(hax)]
     match algorithm {
         Algorithm::Sha224 => sha224_ema(&mut out[..], payload),
@@ -158,8 +164,13 @@ pub use hash as sha3;
 ///
 /// Preconditions:
 /// - `payload` is at most `u32::MAX` bytes long
+#[hax_lib::requires(payload.len() <= u32::MAX as usize)]
 pub fn sha224(payload: &[U8]) -> [U8; SHA3_224_DIGEST_SIZE] {
-    let mut out = [0u8; 28].classify();
+    let mut out = [0u8; SHA3_224_DIGEST_SIZE].classify();
+
+    // We have to work around a hax issue with implicit array
+    // conversion here.
+    // cf. https://github.com/cryspen/hax/issues/1983
     #[cfg(hax)]
     sha224_ema(&mut out[..], payload);
     #[cfg(not(hax))]
@@ -172,6 +183,7 @@ pub fn sha224(payload: &[U8]) -> [U8; SHA3_224_DIGEST_SIZE] {
 /// Preconditions:
 /// - `payload` is at most `u32::MAX` bytes long
 /// - `digest` is exactly [`SHA3_224_DIGEST_SIZE`] bytes long
+#[hax_lib::requires(payload.len() <= u32::MAX as usize && digest.len() == SHA3_224_DIGEST_SIZE)]
 pub fn sha224_ema(digest: &mut [U8], payload: &[U8]) {
     #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
@@ -185,12 +197,17 @@ pub fn sha224_ema(digest: &mut [U8], payload: &[U8]) {
 ///
 /// Preconditions:
 /// - `payload` is at most `u32::MAX` bytes long
-pub fn sha256(data: &[U8]) -> [U8; SHA3_256_DIGEST_SIZE] {
-    let mut out = [0u8; 32].classify();
+#[hax_lib::requires(payload.len() <= u32::MAX as usize)]
+pub fn sha256(payload: &[U8]) -> [U8; SHA3_256_DIGEST_SIZE] {
+    let mut out = [0u8; SHA3_256_DIGEST_SIZE].classify();
+
+    // We have to work around a hax issue with implicit array
+    // conversion here.
+    // cf. https://github.com/cryspen/hax/issues/1983
     #[cfg(hax)]
-    sha256_ema(&mut out[..], data);
+    sha256_ema(&mut out[..], payload);
     #[cfg(not(hax))]
-    sha256_ema(&mut out, data);
+    sha256_ema(&mut out, payload);
     out
 }
 
@@ -199,6 +216,7 @@ pub fn sha256(data: &[U8]) -> [U8; SHA3_256_DIGEST_SIZE] {
 /// Preconditions:
 /// - `payload` is at most `u32::MAX` bytes long
 /// - `digest` is exactly [`SHA3_256_DIGEST_SIZE`] bytes long
+#[hax_lib::requires(payload.len() <= u32::MAX as usize && digest.len() == SHA3_256_DIGEST_SIZE)]
 pub fn sha256_ema(digest: &mut [U8], payload: &[U8]) {
     #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
@@ -212,12 +230,17 @@ pub fn sha256_ema(digest: &mut [U8], payload: &[U8]) {
 ///
 /// Preconditions:
 /// - `payload` is at most `u32::MAX` bytes long
-pub fn sha384(data: &[U8]) -> [U8; SHA3_384_DIGEST_SIZE] {
-    let mut out = [0u8; 48].classify();
+#[hax_lib::requires(payload.len() <= u32::MAX as usize)]
+pub fn sha384(payload: &[U8]) -> [U8; SHA3_384_DIGEST_SIZE] {
+    let mut out = [0u8; SHA3_384_DIGEST_SIZE].classify();
+
+    // We have to work around a hax issue with implicit array
+    // conversion here.
+    // cf. https://github.com/cryspen/hax/issues/1983
     #[cfg(hax)]
-    sha384_ema(&mut out[..], data);
+    sha384_ema(&mut out[..], payload);
     #[cfg(not(hax))]
-    sha384_ema(&mut out, data);
+    sha384_ema(&mut out, payload);
     out
 }
 
@@ -226,6 +249,7 @@ pub fn sha384(data: &[U8]) -> [U8; SHA3_384_DIGEST_SIZE] {
 /// Preconditions:
 /// - `payload` is at most `u32::MAX` bytes long
 /// - `digest` is exactly [`SHA3_384_DIGEST_SIZE`] bytes long
+#[hax_lib::requires(payload.len() <= u32::MAX as usize && digest.len() == SHA3_384_DIGEST_SIZE)]
 pub fn sha384_ema(digest: &mut [U8], payload: &[U8]) {
     #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
@@ -239,12 +263,17 @@ pub fn sha384_ema(digest: &mut [U8], payload: &[U8]) {
 ///
 /// Preconditions:
 /// - `payload` is at most `u32::MAX` bytes long
-pub fn sha512(data: &[U8]) -> [U8; SHA3_512_DIGEST_SIZE] {
-    let mut out = [0u8; 64].classify();
+#[hax_lib::requires(payload.len() <= u32::MAX as usize)]
+pub fn sha512(payload: &[U8]) -> [U8; SHA3_512_DIGEST_SIZE] {
+    let mut out = [0u8; SHA3_512_DIGEST_SIZE].classify();
+
+    // We have to work around a hax issue with implicit array
+    // conversion here.
+    // cf. https://github.com/cryspen/hax/issues/1983
     #[cfg(hax)]
-    sha512_ema(&mut out[..], data);
+    sha512_ema(&mut out[..], payload);
     #[cfg(not(hax))]
-    sha512_ema(&mut out, data);
+    sha512_ema(&mut out, payload);
     out
 }
 
@@ -253,6 +282,7 @@ pub fn sha512(data: &[U8]) -> [U8; SHA3_512_DIGEST_SIZE] {
 /// Preconditions:
 /// - `payload` is at most `u32::MAX` bytes long
 /// - `digest` is exactly [`SHA3_512_DIGEST_SIZE`] bytes long
+#[hax_lib::requires(payload.len() <= u32::MAX as usize && digest.len() == SHA3_512_DIGEST_SIZE)]
 pub fn sha512_ema(digest: &mut [U8], payload: &[U8]) {
     #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
@@ -266,8 +296,13 @@ pub fn sha512_ema(digest: &mut [U8], payload: &[U8]) {
 ///
 /// Preconditions:
 /// - `BYTES` is at most `u32::MAX as usize`
+#[hax_lib::requires(BYTES <= u32::MAX as usize)]
 pub fn shake128<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     let mut out = [0u8; BYTES].classify();
+
+    // We have to work around a hax issue with implicit array
+    // conversion here.
+    // cf. https://github.com/cryspen/hax/issues/1983
     #[cfg(hax)]
     keccakx1::<168, 0x1fu8>(data, &mut out[..]);
     #[cfg(not(hax))]
@@ -281,6 +316,7 @@ pub fn shake128<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
 ///
 /// Preconditions:
 /// - `out` is at most `u32::MAX` bytes long
+#[hax_lib::requires(out.len() <= u32::MAX as usize)]
 pub fn shake128_ema(out: &mut [U8], data: &[U8]) {
     keccakx1::<168, 0x1fu8>(data, out);
 }
@@ -289,8 +325,13 @@ pub fn shake128_ema(out: &mut [U8], data: &[U8]) {
 ///
 /// Preconditions:
 /// - `BYTES` is at most `u32::MAX as usize`
+#[hax_lib::requires(BYTES <= u32::MAX as usize)]
 pub fn shake256<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
     let mut out = [0u8; BYTES].classify();
+
+    // We have to work around a hax issue with implicit array
+    // conversion here.
+    // cf. https://github.com/cryspen/hax/issues/1983
     #[cfg(hax)]
     keccakx1::<136, 0x1fu8>(data, &mut out[..]);
     #[cfg(not(hax))]
@@ -304,12 +345,15 @@ pub fn shake256<const BYTES: usize>(data: &[U8]) -> [U8; BYTES] {
 ///
 /// Preconditions:
 /// - `out` is at most `u32::MAX` bytes long
+#[hax_lib::requires(out.len() <= u32::MAX as usize)]
 pub fn shake256_ema(out: &mut [U8], data: &[U8]) {
     keccakx1::<136, 0x1fu8>(data, out);
 }
 
 /// Incremental API for SHAKE XOFs
 pub mod incremental {
+    #[cfg(hax)]
+    use hax_lib::ToInt;
     use libcrux_secrets::U8;
 
     /// An unbuffered XOF state.
@@ -345,6 +389,7 @@ pub mod incremental {
 
     /// Interface for an input-buffering Extendable Output Function
     /// (XOF)
+    #[hax_lib::attributes]
     pub trait Xof<const RATE: usize>: private::Sealed {
         /// Create new buffered XOF state.
         ///
@@ -386,17 +431,25 @@ pub mod incremental {
         fn squeeze(&mut self, out: &mut [U8]);
     }
 
+    #[hax_lib::attributes]
     impl Xof<168> for Shake128Xof {
         fn new() -> Self {
             Self {
                 state: KeccakXofState::<168>::new(),
             }
         }
-
+        #[hax_lib::requires(
+            self.state.buf_len < 168
+            && input.len().to_int() + self.state.buf_len.to_int() <= usize::MAX.to_int()
+        )]
         fn absorb(&mut self, input: &[U8]) {
             self.state.absorb(input);
         }
 
+        #[hax_lib::requires(
+            self.state.buf_len < 168
+            && input.len().to_int() + self.state.buf_len.to_int() <= usize::MAX.to_int()
+        )]
         fn absorb_final(&mut self, input: &[U8]) {
             self.state.absorb_final::<0x1fu8>(input);
         }
@@ -406,6 +459,7 @@ pub mod incremental {
         }
     }
 
+    #[hax_lib::attributes]
     impl Xof<136> for Shake256Xof {
         fn new() -> Self {
             Self {
@@ -413,10 +467,18 @@ pub mod incremental {
             }
         }
 
+        #[hax_lib::requires(
+            self.state.buf_len < 136
+            && input.len().to_int() + self.state.buf_len.to_int() <= usize::MAX.to_int()
+        )]
         fn absorb(&mut self, input: &[U8]) {
             self.state.absorb(input);
         }
 
+        #[hax_lib::requires(
+            self.state.buf_len < 136
+            && input.len().to_int() + self.state.buf_len.to_int() <= usize::MAX.to_int()
+        )]
         fn absorb_final(&mut self, input: &[U8]) {
             self.state.absorb_final::<0x1fu8>(input);
         }
@@ -438,24 +500,28 @@ pub mod incremental {
 
     /// Absorb
     #[cfg(feature = "unbuffered-xof")]
+    #[hax_lib::requires(data0.len() < 168)]
     pub fn shake128_absorb_final(s: &mut UnbufferedXofState, data0: &[U8]) {
         absorb_final::<168, 0x1fu8>(&mut s.state, data0, 0, data0.len());
     }
 
     /// Squeeze three blocks
     #[cfg(feature = "unbuffered-xof")]
+    #[hax_lib::requires(out0.len() >= 3 * 168)]
     pub fn shake128_squeeze_first_three_blocks(s: &mut UnbufferedXofState, out0: &mut [U8]) {
         squeeze_first_three_blocks::<168>(&mut s.state, out0)
     }
 
     /// Squeeze five blocks
     #[cfg(feature = "unbuffered-xof")]
+    #[hax_lib::requires(out0.len() >= 5 * 168)]
     pub fn shake128_squeeze_first_five_blocks(s: &mut UnbufferedXofState, out0: &mut [U8]) {
         squeeze_first_five_blocks::<168>(&mut s.state, out0)
     }
 
     /// Squeeze another block
     #[cfg(feature = "unbuffered-xof")]
+    #[hax_lib::requires(out0.len() >= 168)]
     pub fn shake128_squeeze_next_block(s: &mut UnbufferedXofState, out0: &mut [U8]) {
         squeeze_next_block::<168>(&mut s.state, out0)
     }
@@ -471,23 +537,29 @@ pub mod incremental {
 
     /// Absorb some data for SHAKE-256 for the last time
     #[cfg(feature = "unbuffered-xof")]
+    #[hax_lib::requires(data.len() < 136)]
     pub fn shake256_absorb_final(s: &mut UnbufferedXofState, data: &[U8]) {
         absorb_final::<136, 0x1fu8>(&mut s.state, data, 0, data.len());
     }
 
     /// Squeeze the first SHAKE-256 block
     #[cfg(feature = "unbuffered-xof")]
+    #[hax_lib::requires(out.len() >= 136)]
     pub fn shake256_squeeze_first_block(s: &mut UnbufferedXofState, out: &mut [U8]) {
         squeeze_first_block::<136>(&s.state, out)
     }
 
     /// Squeeze the next SHAKE-256 block
     #[cfg(feature = "unbuffered-xof")]
+    #[hax_lib::requires(out.len() >= 136)]
     pub fn shake256_squeeze_next_block(s: &mut UnbufferedXofState, out: &mut [U8]) {
         squeeze_next_block::<136>(&mut s.state, out)
     }
 }
 
+#[hax_lib::requires(
+    RATE > 0 && RATE % 8 == 0 && RATE <= 168
+)]
 pub(crate) fn keccakx1<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut [U8]) {
     keccak::keccak::<RATE, DELIM>(data, out)
 }

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -438,18 +438,12 @@ pub mod incremental {
                 state: KeccakXofState::<168>::new(),
             }
         }
-        #[hax_lib::requires(
-            self.state.buf_len < 168
-            && input.len().to_int() + self.state.buf_len.to_int() <= usize::MAX.to_int()
-        )]
+        #[hax_lib::requires(self.state.buf_len < 168)]
         fn absorb(&mut self, input: &[U8]) {
             self.state.absorb(input);
         }
 
-        #[hax_lib::requires(
-            self.state.buf_len < 168
-            && input.len().to_int() + self.state.buf_len.to_int() <= usize::MAX.to_int()
-        )]
+        #[hax_lib::requires(self.state.buf_len < 168)]
         fn absorb_final(&mut self, input: &[U8]) {
             self.state.absorb_final::<0x1fu8>(input);
         }
@@ -469,16 +463,12 @@ pub mod incremental {
 
         #[hax_lib::requires(
             self.state.buf_len < 136
-            && input.len().to_int() + self.state.buf_len.to_int() <= usize::MAX.to_int()
         )]
         fn absorb(&mut self, input: &[U8]) {
             self.state.absorb(input);
         }
 
-        #[hax_lib::requires(
-            self.state.buf_len < 136
-            && input.len().to_int() + self.state.buf_len.to_int() <= usize::MAX.to_int()
-        )]
+        #[hax_lib::requires(self.state.buf_len < 136)]
         fn absorb_final(&mut self, input: &[U8]) {
             self.state.absorb_final::<0x1fu8>(input);
         }

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -49,6 +49,8 @@
 #![no_std]
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
+#![cfg_attr(hax_backend_lean, feature(register_tool))]
+#![cfg_attr(hax_backend_lean, register_tool(charon))]
 
 use libcrux_secrets::{Classify, U8};
 

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -87,15 +87,20 @@ pub enum Algorithm {
     Sha512 = 4,
 }
 
-#[hax_lib::opaque]
-impl From<u32> for Algorithm {
-    fn from(v: u32) -> Algorithm {
+/// Error returned when a `u32` does not correspond to an [`Algorithm`].
+#[cfg_attr(not(eurydice), derive(Copy, Clone, Debug, PartialEq))]
+pub struct UnknownAlgorithm;
+
+impl TryFrom<u32> for Algorithm {
+    type Error = UnknownAlgorithm;
+
+    fn try_from(v: u32) -> Result<Algorithm, Self::Error> {
         match v {
-            1 => Algorithm::Sha224,
-            2 => Algorithm::Sha256,
-            3 => Algorithm::Sha384,
-            4 => Algorithm::Sha512,
-            _ => panic!(),
+            1 => Ok(Algorithm::Sha224),
+            2 => Ok(Algorithm::Sha256),
+            3 => Ok(Algorithm::Sha384),
+            4 => Ok(Algorithm::Sha512),
+            _ => Err(UnknownAlgorithm),
         }
     }
 }

--- a/libcrux-iot/sha3/src/state.rs
+++ b/libcrux-iot/sha3/src/state.rs
@@ -15,6 +15,7 @@ pub(crate) struct KeccakState {
     pub(super) i: usize,
 }
 
+#[hax_lib::attributes]
 impl KeccakState {
     #[inline(always)]
     pub(crate) fn new() -> Self {
@@ -27,47 +28,56 @@ impl KeccakState {
     }
 
     #[inline(always)]
+    #[hax_lib::requires(i < 5 && j < 5 && zeta < 2)]
     pub(crate) fn get_with_zeta(&self, i: usize, j: usize, zeta: usize) -> U32 {
         self.st[5 * j + i][zeta]
     }
 
     #[inline(always)]
+    #[hax_lib::requires(i < 5 && j < 5 && zeta < 2)]
     pub(crate) fn set_with_zeta(&mut self, i: usize, j: usize, zeta: usize, v: U32) {
         self.st[5 * j + i].0[zeta] = v
     }
 
     #[inline(always)]
+    #[hax_lib::requires(i < 5 && j < 5)]
     pub(crate) fn get_lane(&self, i: usize, j: usize) -> Lane2U32 {
         self.st[5 * j + i]
     }
 
     #[inline(always)]
+    #[hax_lib::requires(i < 5 && j < 5)]
     pub(crate) fn set_lane(&mut self, i: usize, j: usize, lane: Lane2U32) {
         self.st[5 * j + i] = lane
     }
 
     #[inline(always)]
+    #[hax_lib::requires(i < 5 && j < 2)]
     pub(crate) fn set_lane_value(&mut self, i: usize, j: usize, value: U32) {
         // XXX: We can't implement IndexMut for `Lane2U32` because of hax
         self.c[i].0[j] = value
     }
 
     #[inline(always)]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && start <= 200 && start + RATE + 7 <= blocks.len())]
     pub(crate) fn load_block<const RATE: usize>(&mut self, blocks: &[U8], start: usize) {
         load_block_2u32::<RATE>(self, blocks, start)
     }
 
     #[inline(always)]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && RATE <= out.len())]
     pub(crate) fn store_block<const RATE: usize>(&self, out: &mut [U8]) {
         store_block_2u32::<RATE>(self, out)
     }
 
     #[inline(always)]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && start <= 200 && start + RATE + 7 <= 200)]
     pub(crate) fn load_block_full<const RATE: usize>(&mut self, blocks: &[U8; 200], start: usize) {
         load_block_full_2u32::<RATE>(self, blocks, start)
     }
 
     #[inline(always)]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 200)]
     pub(crate) fn store_block_full<const RATE: usize>(&self, out: &mut [U8; 200]) {
         store_block_full_2u32::<RATE>(self, out);
     }
@@ -75,14 +85,19 @@ impl KeccakState {
     /// `out` has the exact size we want here. It must be less than or equal to
     /// `RATE`.
     #[inline(always)]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && out.len() <= RATE)]
     pub(crate) fn store<const RATE: usize>(self, out: &mut [U8]) {
         #[cfg(not(any(eurydice, hax)))]
         debug_assert!(out.len() <= RATE, "{} > {}", out.len(), RATE);
+
+        #[cfg(hax)]
+        let _out_len = out.len();
 
         let num_full_blocks = out.len() / 8;
         let last_block_len = out.len() % 8;
 
         for i in 0..num_full_blocks {
+            hax_lib::loop_invariant!(|i: usize| out.len() == _out_len);
             let lane = self.get_lane(i / 5, i % 5).deinterleave();
             out[i * 8..i * 8 + 4].copy_from_slice(&lane[0].to_le_bytes());
             out[i * 8 + 4..i * 8 + 8].copy_from_slice(&lane[1].to_le_bytes());
@@ -109,6 +124,7 @@ impl KeccakState {
     }
 }
 
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && start <= 200 && start + RATE + 7 <= blocks.len())]
 #[inline(always)]
 fn load_block_2u32<const RATE: usize>(state: &mut KeccakState, blocks: &[U8], start: usize) {
     #[cfg(not(eurydice))]
@@ -131,6 +147,7 @@ fn load_block_2u32<const RATE: usize>(state: &mut KeccakState, blocks: &[U8], st
     }
 }
 
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && start <= 200 && start + RATE + 7 <= 200)]
 #[inline(always)]
 fn load_block_full_2u32<const RATE: usize>(
     state: &mut KeccakState,
@@ -140,15 +157,20 @@ fn load_block_full_2u32<const RATE: usize>(
     load_block_2u32::<RATE>(state, blocks, start);
 }
 
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && RATE <= out.len())]
 #[inline(always)]
 fn store_block_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
+    #[cfg(hax)]
+    let _out_len = out.len();
     for i in 0..RATE / 8 {
+        hax_lib::loop_invariant!(|i: usize| out.len() == _out_len);
         let lane = s.get_lane(i / 5, i % 5).deinterleave();
         out[8 * i..8 * i + 4].copy_from_slice(&lane[0].to_le_bytes());
         out[8 * i + 4..8 * i + 8].copy_from_slice(&lane[1].to_le_bytes());
     }
 }
 
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 200)]
 #[inline(always)]
 fn store_block_full_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8; 200]) {
     // `out[..]` is a workaround for https://github.com/cryspen/hax/issues/1983

--- a/libcrux-iot/sha3/src/state.rs
+++ b/libcrux-iot/sha3/src/state.rs
@@ -132,20 +132,17 @@ impl KeccakState {
 fn load_block_2u32<const RATE: usize>(keccak_state: &mut KeccakState, blocks: &[U8], start: usize) {
     #[cfg(not(eurydice))]
     debug_assert!(RATE <= blocks.len() && RATE % 8 == 0);
-    let mut state_flat = [Lane2U32::zero(); 25];
     for i in 0..RATE / 8 {
         let offset = start + 8 * i;
         // Perform `u64::from_le_bytes` on our 32-bit representation:
         let a = U32::from_le_bytes(blocks[offset..offset + 4].try_into().unwrap());
         let b = U32::from_le_bytes(blocks[offset + 4..offset + 8].try_into().unwrap());
-        state_flat[i] = Lane2U32::from([a, b]).interleave();
-    }
-    for i in 0..RATE / 8 {
+        let lane = Lane2U32::from([a, b]).interleave();
         let got = keccak_state.get_lane(i / 5, i % 5);
         keccak_state.set_lane(
             i / 5,
             i % 5,
-            Lane2U32::from_ints([got[0] ^ state_flat[i][0], got[1] ^ state_flat[i][1]]),
+            Lane2U32::from_ints([got[0] ^ lane[0], got[1] ^ lane[1]]),
         );
     }
 }

--- a/libcrux-iot/sha3/src/state.rs
+++ b/libcrux-iot/sha3/src/state.rs
@@ -101,35 +101,35 @@ impl KeccakState {
 
         for i in 0..num_full_blocks {
             hax_lib::loop_invariant!(|i: usize| out.len() == _out_len);
-            let lane = self.get_lane(i / 5, i % 5).deinterleave();
-            out[i * 8..i * 8 + 4].copy_from_slice(&lane[0].to_le_bytes());
-            out[i * 8 + 4..i * 8 + 8].copy_from_slice(&lane[1].to_le_bytes());
+            let keccak_lane = self.get_lane(i / 5, i % 5).deinterleave();
+            out[i * 8..i * 8 + 4].copy_from_slice(&keccak_lane[0].to_le_bytes());
+            out[i * 8 + 4..i * 8 + 8].copy_from_slice(&keccak_lane[1].to_le_bytes());
         }
 
         if last_block_len > 4 {
-            let lane = self
+            let keccak_lane = self
                 .get_lane(num_full_blocks / 5, num_full_blocks % 5)
                 .deinterleave();
             let last_half_block_len = last_block_len - 4;
 
             out[num_full_blocks * 8..num_full_blocks * 8 + 4]
-                .copy_from_slice(&lane[0].to_le_bytes());
+                .copy_from_slice(&keccak_lane[0].to_le_bytes());
             out[num_full_blocks * 8 + 4..num_full_blocks * 8 + last_block_len]
-                .copy_from_slice(&lane[1].to_le_bytes()[0..last_half_block_len]);
+                .copy_from_slice(&keccak_lane[1].to_le_bytes()[0..last_half_block_len]);
         } else if last_block_len > 0 {
-            let lane = self
+            let keccak_lane = self
                 .get_lane(num_full_blocks / 5, num_full_blocks % 5)
                 .deinterleave();
 
             out[num_full_blocks * 8..num_full_blocks * 8 + last_block_len]
-                .copy_from_slice(&lane[0].to_le_bytes()[0..last_block_len]);
+                .copy_from_slice(&keccak_lane[0].to_le_bytes()[0..last_block_len]);
         }
     }
 }
 
 #[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && start.to_int() + RATE.to_int() <= blocks.len().to_int())]
 #[inline(always)]
-fn load_block_2u32<const RATE: usize>(state: &mut KeccakState, blocks: &[U8], start: usize) {
+fn load_block_2u32<const RATE: usize>(keccak_state: &mut KeccakState, blocks: &[U8], start: usize) {
     #[cfg(not(eurydice))]
     debug_assert!(RATE <= blocks.len() && RATE % 8 == 0);
     let mut state_flat = [Lane2U32::zero(); 25];
@@ -141,8 +141,8 @@ fn load_block_2u32<const RATE: usize>(state: &mut KeccakState, blocks: &[U8], st
         state_flat[i] = Lane2U32::from([a, b]).interleave();
     }
     for i in 0..RATE / 8 {
-        let got = state.get_lane(i / 5, i % 5);
-        state.set_lane(
+        let got = keccak_state.get_lane(i / 5, i % 5);
+        keccak_state.set_lane(
             i / 5,
             i % 5,
             Lane2U32::from_ints([got[0] ^ state_flat[i][0], got[1] ^ state_flat[i][1]]),
@@ -153,11 +153,11 @@ fn load_block_2u32<const RATE: usize>(state: &mut KeccakState, blocks: &[U8], st
 #[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && start.to_int() + RATE.to_int() <= 200.to_int())]
 #[inline(always)]
 fn load_block_full_2u32<const RATE: usize>(
-    state: &mut KeccakState,
+    keccak_state: &mut KeccakState,
     blocks: &[U8; 200],
     start: usize,
 ) {
-    load_block_2u32::<RATE>(state, blocks, start);
+    load_block_2u32::<RATE>(keccak_state, blocks, start);
 }
 
 #[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && RATE <= out.len())]
@@ -167,9 +167,9 @@ fn store_block_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
     let _out_len = out.len();
     for i in 0..RATE / 8 {
         hax_lib::loop_invariant!(|i: usize| out.len() == _out_len);
-        let lane = s.get_lane(i / 5, i % 5).deinterleave();
-        out[8 * i..8 * i + 4].copy_from_slice(&lane[0].to_le_bytes());
-        out[8 * i + 4..8 * i + 8].copy_from_slice(&lane[1].to_le_bytes());
+        let keccak_lane = s.get_lane(i / 5, i % 5).deinterleave();
+        out[8 * i..8 * i + 4].copy_from_slice(&keccak_lane[0].to_le_bytes());
+        out[8 * i + 4..8 * i + 8].copy_from_slice(&keccak_lane[1].to_le_bytes());
     }
 }
 

--- a/libcrux-iot/sha3/src/state.rs
+++ b/libcrux-iot/sha3/src/state.rs
@@ -61,25 +61,25 @@ impl KeccakState {
     }
 
     #[inline(always)]
-    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && start.to_int() + RATE.to_int() <= blocks.len().to_int())]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && start.to_int() + RATE.to_int() <= blocks.len().to_int())]
     pub(crate) fn load_block<const RATE: usize>(&mut self, blocks: &[U8], start: usize) {
         load_block_2u32::<RATE>(self, blocks, start)
     }
 
     #[inline(always)]
-    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && RATE <= out.len())]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && RATE <= out.len())]
     pub(crate) fn store_block<const RATE: usize>(&self, out: &mut [U8]) {
         store_block_2u32::<RATE>(self, out)
     }
 
     #[inline(always)]
-    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && start <= 200 && start + RATE <= 144)]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && start <= 200 && start + RATE <= 168)]
     pub(crate) fn load_block_full<const RATE: usize>(&mut self, blocks: &[U8; 200], start: usize) {
         load_block_full_2u32::<RATE>(self, blocks, start)
     }
 
     #[inline(always)]
-    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 144)]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 168)]
     pub(crate) fn store_block_full<const RATE: usize>(&self, out: &mut [U8; 200]) {
         store_block_full_2u32::<RATE>(self, out);
     }
@@ -87,7 +87,7 @@ impl KeccakState {
     /// `out` has the exact size we want here. It must be less than or equal to
     /// `RATE`.
     #[inline(always)]
-    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && out.len() <= RATE)]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && out.len() <= RATE)]
     #[hax_lib::ensures(|_| future(out).len() == out.len())]
     pub(crate) fn store<const RATE: usize>(self, out: &mut [U8]) {
         #[cfg(not(any(eurydice, hax)))]
@@ -127,7 +127,7 @@ impl KeccakState {
     }
 }
 
-#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && start.to_int() + RATE.to_int() <= blocks.len().to_int())]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && start.to_int() + RATE.to_int() <= blocks.len().to_int())]
 #[inline(always)]
 fn load_block_2u32<const RATE: usize>(state: &mut KeccakState, blocks: &[U8], start: usize) {
     #[cfg(not(eurydice))]
@@ -150,7 +150,7 @@ fn load_block_2u32<const RATE: usize>(state: &mut KeccakState, blocks: &[U8], st
     }
 }
 
-#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && start.to_int() + RATE.to_int() <= 200.to_int())]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && start.to_int() + RATE.to_int() <= 200.to_int())]
 #[inline(always)]
 fn load_block_full_2u32<const RATE: usize>(
     state: &mut KeccakState,
@@ -160,7 +160,7 @@ fn load_block_full_2u32<const RATE: usize>(
     load_block_2u32::<RATE>(state, blocks, start);
 }
 
-#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && RATE <= out.len())]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 168 && RATE <= out.len())]
 #[inline(always)]
 fn store_block_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
     #[cfg(hax)]
@@ -173,7 +173,7 @@ fn store_block_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
     }
 }
 
-#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144)]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 168)]
 #[inline(always)]
 fn store_block_full_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8; 200]) {
     // `out[..]` is a workaround for https://github.com/cryspen/hax/issues/1983

--- a/libcrux-iot/sha3/src/state.rs
+++ b/libcrux-iot/sha3/src/state.rs
@@ -9,7 +9,7 @@ use crate::lane::Lane2U32;
 use crate::{FromLeBytes, ToLeBytes};
 
 #[derive(Clone, Copy)]
-#[cfg_attr(not(eurydice), derive(Debug))]
+#[cfg_attr(not(any(eurydice, hax_backend_lean)), derive(Debug))]
 pub(crate) struct KeccakState {
     pub(super) st: [Lane2U32; 25],
     pub(super) c: [Lane2U32; 5],

--- a/libcrux-iot/sha3/src/state.rs
+++ b/libcrux-iot/sha3/src/state.rs
@@ -1,3 +1,5 @@
+#[cfg(hax)]
+use hax_lib::ToInt;
 #[cfg(feature = "check-secret-independence")]
 use libcrux_secrets::{Classify, Declassify};
 use libcrux_secrets::{U32, U8};
@@ -59,25 +61,25 @@ impl KeccakState {
     }
 
     #[inline(always)]
-    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && start <= 200 && start + RATE + 7 <= blocks.len())]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && start.to_int() + RATE.to_int() <= blocks.len().to_int())]
     pub(crate) fn load_block<const RATE: usize>(&mut self, blocks: &[U8], start: usize) {
         load_block_2u32::<RATE>(self, blocks, start)
     }
 
     #[inline(always)]
-    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && RATE <= out.len())]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && RATE <= out.len())]
     pub(crate) fn store_block<const RATE: usize>(&self, out: &mut [U8]) {
         store_block_2u32::<RATE>(self, out)
     }
 
     #[inline(always)]
-    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && start <= 200 && start + RATE + 7 <= 200)]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && start <= 200 && start + RATE <= 144)]
     pub(crate) fn load_block_full<const RATE: usize>(&mut self, blocks: &[U8; 200], start: usize) {
         load_block_full_2u32::<RATE>(self, blocks, start)
     }
 
     #[inline(always)]
-    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 200)]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 144)]
     pub(crate) fn store_block_full<const RATE: usize>(&self, out: &mut [U8; 200]) {
         store_block_full_2u32::<RATE>(self, out);
     }
@@ -85,7 +87,8 @@ impl KeccakState {
     /// `out` has the exact size we want here. It must be less than or equal to
     /// `RATE`.
     #[inline(always)]
-    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && out.len() <= RATE)]
+    #[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && out.len() <= RATE)]
+    #[hax_lib::ensures(|_| future(out).len() == out.len())]
     pub(crate) fn store<const RATE: usize>(self, out: &mut [U8]) {
         #[cfg(not(any(eurydice, hax)))]
         debug_assert!(out.len() <= RATE, "{} > {}", out.len(), RATE);
@@ -124,7 +127,7 @@ impl KeccakState {
     }
 }
 
-#[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && start <= 200 && start + RATE + 7 <= blocks.len())]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && start.to_int() + RATE.to_int() <= blocks.len().to_int())]
 #[inline(always)]
 fn load_block_2u32<const RATE: usize>(state: &mut KeccakState, blocks: &[U8], start: usize) {
     #[cfg(not(eurydice))]
@@ -147,7 +150,7 @@ fn load_block_2u32<const RATE: usize>(state: &mut KeccakState, blocks: &[U8], st
     }
 }
 
-#[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && start <= 200 && start + RATE + 7 <= 200)]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && start.to_int() + RATE.to_int() <= 200.to_int())]
 #[inline(always)]
 fn load_block_full_2u32<const RATE: usize>(
     state: &mut KeccakState,
@@ -157,7 +160,7 @@ fn load_block_full_2u32<const RATE: usize>(
     load_block_2u32::<RATE>(state, blocks, start);
 }
 
-#[hax_lib::requires(RATE % 8 == 0 && RATE <= 200 && RATE <= out.len())]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144 && RATE <= out.len())]
 #[inline(always)]
 fn store_block_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
     #[cfg(hax)]
@@ -170,7 +173,7 @@ fn store_block_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8]) {
     }
 }
 
-#[hax_lib::requires(RATE % 8 == 0 && RATE <= 200)]
+#[hax_lib::requires(RATE % 8 == 0 && RATE <= 144)]
 #[inline(always)]
 fn store_block_full_2u32<const RATE: usize>(s: &KeccakState, out: &mut [U8; 200]) {
     // `out[..]` is a workaround for https://github.com/cryspen/hax/issues/1983


### PR DESCRIPTION
This PR provides runtime safety annotations for SHA3, leaving the Keccak permutation functions opaque, to be handled by Lean.

This uses hax at the same revision that is pinned in #147 (currently `7b4bd97058e0fcbf9135b76297ca91942f2327a6`).

I've also taken the Rust code changes (excluding tool annotations and specs) from #147 and already incorporated them here.