### PR TITLE
[SHA3] Panic Freedom annotation improvements

### DIFF
--- a/c/combined/generated/code_gen.txt
+++ b/c/combined/generated/code_gen.txt
@@ -3,4 +3,4 @@ Charon: e656e17bff6ca5efac8ab6919b9b74cb9a8dd8ad
 Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
 Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
 F*: unset
-Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+Libcrux: dirty

--- a/c/combined/generated/internal/libcrux_iot_sha3.h
+++ b/c/combined/generated/internal/libcrux_iot_sha3.h
@@ -120,7 +120,7 @@ libcrux_iot_sha3_keccak_fill_buffer_f0_60(
   size_t consumed = (size_t)0U;
   if (self->buf_len > (size_t)0U)
   {
-    if (self->buf_len + input_len >= (size_t)168U)
+    if (input_len >= (size_t)168U - self->buf_len)
     {
       consumed = (size_t)168U - self->buf_len;
       Eurydice_slice_copy(Eurydice_array_to_subslice_from_mut_5f0(&self->buf, self->buf_len),
@@ -368,7 +368,7 @@ libcrux_iot_sha3_state_store_18_60(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(&self,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -383,7 +383,8 @@ libcrux_iot_sha3_state_store_18_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -396,13 +397,14 @@ libcrux_iot_sha3_state_store_18_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
   if (last_block_len > (size_t)4U)
   {
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(&self,
           num_full_blocks / (size_t)5U,
           num_full_blocks % (size_t)5U));
@@ -418,7 +420,8 @@ libcrux_iot_sha3_state_store_18_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____2, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____3 =
@@ -431,7 +434,8 @@ libcrux_iot_sha3_state_store_18_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____3,
       Eurydice_array_to_subslice_shared_d41(&lvalue,
         (KRML_CLITERAL(core_ops_range_Range_87){ .start = (size_t)0U, .end = last_half_block_len })),
@@ -440,7 +444,7 @@ libcrux_iot_sha3_state_store_18_60(
   else if (last_block_len > (size_t)0U)
   {
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(&self,
           num_full_blocks / (size_t)5U,
           num_full_blocks % (size_t)5U));
@@ -455,12 +459,62 @@ libcrux_iot_sha3_state_store_18_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____4,
       Eurydice_array_to_subslice_shared_d41(&lvalue,
         (KRML_CLITERAL(core_ops_range_Range_87){ .start = (size_t)0U, .end = last_block_len })),
       uint8_t);
   }
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak._squeeze
+with const generics
+- RATE= 168
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak__squeeze_60(
+  libcrux_iot_sha3_keccak_KeccakXofState_31 *state,
+  Eurydice_mut_borrow_slice_u8 out
+)
+{
+  if (state->sponge)
+  {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+  }
+  size_t out_len = out.meta;
+  size_t blocks = out_len / (size_t)168U;
+  size_t last = out_len - out_len % (size_t)168U;
+  size_t mid;
+  if ((size_t)168U >= out_len)
+  {
+    mid = out_len;
+  }
+  else
+  {
+    mid = (size_t)168U;
+  }
+  libcrux_iot_sha3_state_store_18_60(state->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
+  size_t offset = mid;
+  for (size_t i = (size_t)1U; i < blocks; i++)
+  {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+    libcrux_iot_sha3_state_store_18_60(state->inner,
+      Eurydice_slice_subslice_mut_c8(out,
+        (KRML_CLITERAL(core_ops_range_Range_87){ .start = offset, .end = offset + (size_t)168U })));
+    offset += (size_t)168U;
+  }
+  if (last > (size_t)0U)
+  {
+    if (last < out_len)
+    {
+      libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+      libcrux_iot_sha3_state_store_18_60(state->inner,
+        Eurydice_slice_subslice_from_mut_6d(out, offset));
+    }
+  }
+  state->sponge = true;
 }
 
 /**
@@ -480,42 +534,7 @@ libcrux_iot_sha3_keccak_squeeze_f0_60(
   Eurydice_mut_borrow_slice_u8 out
 )
 {
-  if (self->sponge)
-  {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-  }
-  size_t out_len = out.meta;
-  size_t blocks = out_len / (size_t)168U;
-  size_t last = out_len - out_len % (size_t)168U;
-  size_t mid;
-  if ((size_t)168U >= out_len)
-  {
-    mid = out_len;
-  }
-  else
-  {
-    mid = (size_t)168U;
-  }
-  libcrux_iot_sha3_state_store_18_60(self->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
-  size_t offset = mid;
-  for (size_t i = (size_t)1U; i < blocks; i++)
-  {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-    libcrux_iot_sha3_state_store_18_60(self->inner,
-      Eurydice_slice_subslice_mut_c8(out,
-        (KRML_CLITERAL(core_ops_range_Range_87){ .start = offset, .end = offset + (size_t)168U })));
-    offset += (size_t)168U;
-  }
-  if (last > (size_t)0U)
-  {
-    if (last < out_len)
-    {
-      libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-      libcrux_iot_sha3_state_store_18_60(self->inner,
-        Eurydice_slice_subslice_from_mut_6d(out, offset));
-    }
-  }
-  self->sponge = true;
+  libcrux_iot_sha3_keccak__squeeze_60(self, out);
 }
 
 /**
@@ -582,9 +601,21 @@ static inline uint32_t libcrux_iot_sha3_from_c3(libcrux_iot_sha3_Algorithm v)
 }
 
 /**
-This function found in impl {core::convert::From<u32> for libcrux_iot_sha3::Algorithm}
+A monomorphic instance of core.result.Result
+with types libcrux_iot_sha3_Algorithm, ()
+
 */
-static inline libcrux_iot_sha3_Algorithm libcrux_iot_sha3_from_c2(uint32_t v)
+typedef struct core_result_Result_20_s
+{
+  core_result_Result_8e_tags tag;
+  libcrux_iot_sha3_Algorithm f0;
+}
+core_result_Result_20;
+
+/**
+This function found in impl {core::convert::TryFrom<u32, libcrux_iot_sha3::UnknownAlgorithm> for libcrux_iot_sha3::Algorithm}
+*/
+static inline core_result_Result_20 libcrux_iot_sha3_try_from_72(uint32_t v)
 {
   switch (v)
   {
@@ -594,23 +625,46 @@ static inline libcrux_iot_sha3_Algorithm libcrux_iot_sha3_from_c2(uint32_t v)
       }
     case 2U:
       {
-        return libcrux_iot_sha3_Algorithm_Sha256;
+        return
+          (
+            KRML_CLITERAL(core_result_Result_20){
+              .tag = core_result_Ok,
+              .f0 = libcrux_iot_sha3_Algorithm_Sha256
+            }
+          );
       }
     case 3U:
       {
-        return libcrux_iot_sha3_Algorithm_Sha384;
+        return
+          (
+            KRML_CLITERAL(core_result_Result_20){
+              .tag = core_result_Ok,
+              .f0 = libcrux_iot_sha3_Algorithm_Sha384
+            }
+          );
       }
     case 4U:
       {
-        return libcrux_iot_sha3_Algorithm_Sha512;
+        return
+          (
+            KRML_CLITERAL(core_result_Result_20){
+              .tag = core_result_Ok,
+              .f0 = libcrux_iot_sha3_Algorithm_Sha512
+            }
+          );
       }
     default:
       {
-        KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__, "panic!");
-        KRML_HOST_EXIT(255U);
+        return (KRML_CLITERAL(core_result_Result_20){ .tag = core_result_Err });
       }
   }
-  return libcrux_iot_sha3_Algorithm_Sha224;
+  return
+    (
+      KRML_CLITERAL(core_result_Result_20){
+        .tag = core_result_Ok,
+        .f0 = libcrux_iot_sha3_Algorithm_Sha224
+      }
+    );
 }
 
 #if defined(__cplusplus)

--- a/c/combined/generated/libcrux_iot_mldsa87_portable.h
+++ b/c/combined/generated/libcrux_iot_mldsa87_portable.h
@@ -51,7 +51,7 @@ libcrux_iot_ml_dsa_ml_dsa_87_portable_generate_key_pair(Eurydice_arr_ec randomne
  and is a byte string of length at most 255 bytes. It
  may also be empty.
 */
-static inline core_result_Result_20
+static inline core_result_Result_200
 libcrux_iot_ml_dsa_ml_dsa_87_portable_sign(
   const Eurydice_arr_e2 *signing_key,
   Eurydice_borrow_slice_u8 message,
@@ -97,7 +97,7 @@ libcrux_iot_ml_dsa_ml_dsa_87_portable_sign_mut(
  and is a byte string of length at most 255 bytes. It
  may also be empty.
 */
-static inline core_result_Result_20
+static inline core_result_Result_200
 libcrux_iot_ml_dsa_ml_dsa_87_portable_sign_pre_hashed_shake128(
   const Eurydice_arr_e2 *signing_key,
   Eurydice_borrow_slice_u8 message,

--- a/c/combined/generated/libcrux_iot_mldsa_portable.h
+++ b/c/combined/generated/libcrux_iot_mldsa_portable.h
@@ -10888,7 +10888,7 @@ A monomorphic instance of core.result.Result
 with types libcrux_iot_ml_dsa_types_MLDSASignature_06, libcrux_iot_ml_dsa_types_SigningError
 
 */
-typedef struct core_result_Result_20_s
+typedef struct core_result_Result_200_s
 {
   core_result_Result_8e_tags tag;
   union {
@@ -10897,7 +10897,7 @@ typedef struct core_result_Result_20_s
   }
   val;
 }
-core_result_Result_20;
+core_result_Result_200;
 
 /**
  Init with zero
@@ -11347,7 +11347,7 @@ with types libcrux_iot_ml_dsa_simd_portable_vector_type_Coefficients, libcrux_io
 with const generics
 
 */
-static KRML_MUSTINLINE core_result_Result_20
+static KRML_MUSTINLINE core_result_Result_200
 libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_c4(
   Eurydice_borrow_slice_u8 signing_key,
   Eurydice_borrow_slice_u8 message,
@@ -11363,12 +11363,12 @@ libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_c4(
       context,
       randomness,
       &signature);
-  core_result_Result_20 uu____1;
+  core_result_Result_200 uu____1;
   if (uu____0.tag == core_result_Ok)
   {
     uu____1 =
       (
-        KRML_CLITERAL(core_result_Result_20){
+        KRML_CLITERAL(core_result_Result_200){
           .tag = core_result_Ok,
           .val = { .case_Ok = signature }
         }
@@ -11378,7 +11378,7 @@ libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_c4(
   {
     libcrux_iot_ml_dsa_types_SigningError e = uu____0.f0;
     uu____1 =
-      (KRML_CLITERAL(core_result_Result_20){ .tag = core_result_Err, .val = { .case_Err = e } });
+      (KRML_CLITERAL(core_result_Result_200){ .tag = core_result_Err, .val = { .case_Err = e } });
   }
   return uu____1;
 }
@@ -11386,7 +11386,7 @@ libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_c4(
 /**
  Sign.
 */
-static inline core_result_Result_20
+static inline core_result_Result_200
 libcrux_iot_ml_dsa_ml_dsa_generic_instantiations_portable_ml_dsa_87_sign(
   const Eurydice_arr_e2 *signing_key,
   Eurydice_borrow_slice_u8 message,
@@ -11494,7 +11494,7 @@ with types libcrux_iot_ml_dsa_simd_portable_vector_type_Coefficients, libcrux_io
 with const generics
 
 */
-static KRML_MUSTINLINE core_result_Result_20
+static KRML_MUSTINLINE core_result_Result_200
 libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_pre_hashed_36(
   Eurydice_borrow_slice_u8 signing_key,
   Eurydice_borrow_slice_u8 message,
@@ -11512,12 +11512,12 @@ libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_pre_hashed_36(
       pre_hash_buffer,
       randomness,
       &signature);
-  core_result_Result_20 uu____1;
+  core_result_Result_200 uu____1;
   if (uu____0.tag == core_result_Ok)
   {
     uu____1 =
       (
-        KRML_CLITERAL(core_result_Result_20){
+        KRML_CLITERAL(core_result_Result_200){
           .tag = core_result_Ok,
           .val = { .case_Ok = signature }
         }
@@ -11527,7 +11527,7 @@ libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_pre_hashed_36(
   {
     libcrux_iot_ml_dsa_types_SigningError e = uu____0.f0;
     uu____1 =
-      (KRML_CLITERAL(core_result_Result_20){ .tag = core_result_Err, .val = { .case_Err = e } });
+      (KRML_CLITERAL(core_result_Result_200){ .tag = core_result_Err, .val = { .case_Err = e } });
   }
   return uu____1;
 }
@@ -11535,7 +11535,7 @@ libcrux_iot_ml_dsa_ml_dsa_generic_ml_dsa_87_sign_pre_hashed_36(
 /**
  Sign (pre-hashed).
 */
-static inline core_result_Result_20
+static inline core_result_Result_200
 libcrux_iot_ml_dsa_ml_dsa_generic_instantiations_portable_ml_dsa_87_sign_pre_hashed_shake128(
   const Eurydice_arr_e2 *signing_key,
   Eurydice_borrow_slice_u8 message,

--- a/c/combined/generated/libcrux_iot_mlkem768_portable.h
+++ b/c/combined/generated/libcrux_iot_mlkem768_portable.h
@@ -6275,16 +6275,18 @@ libcrux_iot_ml_kem_serialize_deserialize_ring_elements_reduced_51(
   Eurydice_dst_ref_mut_2f deserialized_pk
 )
 {
+  Eurydice_borrow_slice_u8
+  public_key0 = libcrux_secrets_int_classify_public_classify_ref_6d_90(public_key);
   for
   (size_t
     i = (size_t)0U;
-    i < public_key.meta / LIBCRUX_IOT_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT;
+    i < public_key0.meta / LIBCRUX_IOT_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT;
     i++)
   {
     size_t i0 = i;
     Eurydice_borrow_slice_u8
     ring_element =
-      Eurydice_slice_subslice_shared_c8(public_key,
+      Eurydice_slice_subslice_shared_c8(public_key0,
         (
           KRML_CLITERAL(core_ops_range_Range_87){
             .start = i0 * LIBCRUX_IOT_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT,
@@ -6292,7 +6294,7 @@ libcrux_iot_ml_kem_serialize_deserialize_ring_elements_reduced_51(
               LIBCRUX_IOT_ML_KEM_CONSTANTS_BYTES_PER_RING_ELEMENT
           }
         ));
-    libcrux_iot_ml_kem_serialize_deserialize_to_reduced_ring_element_a7(libcrux_secrets_int_classify_public_classify_ref_6d_90(ring_element),
+    libcrux_iot_ml_kem_serialize_deserialize_to_reduced_ring_element_a7(ring_element,
       &deserialized_pk.ptr[i0]);
   }
 }

--- a/c/combined/generated/libcrux_iot_sha3.h
+++ b/c/combined/generated/libcrux_iot_sha3.h
@@ -441,210 +441,337 @@ libcrux_iot_sha3_state_set_with_zeta_18(
 #define LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1 ((KRML_CLITERAL(Eurydice_arr_030){ .data = { 0U, 137U, 2147483787U, 2147516544U, 139U, 32768U, 2147516552U, 2147483778U, 11U, 10U, 32898U, 32771U, 32907U, 2147483659U, 2147483786U, 2147483777U, 2147483777U, 2147483656U, 131U, 2147516419U, 2147516552U, 2147483784U, 32768U, 2147516546U, 2147516553U, 2147516547U, 2147483649U, 2147516418U, 2147483785U, 130U, 2147483656U, 137U, 2147483656U, 0U, 131U, 2147516544U, 8U, 2147483776U, 2147516544U, 2U, 2147516555U, 8U, 2147483657U, 32779U, 2147516546U, 2147516416U, 32776U, 32897U, 2147516553U, 2147516553U, 2147516426U, 138U, 130U, 2147483650U, 32898U, 32896U, 2147483659U, 2147483651U, 10U, 32769U, 2147483779U, 32899U, 139U, 32778U, 2147483779U, 32778U, 2147483648U, 2147483786U, 2147483656U, 10U, 32904U, 8U, 2147483651U, 0U, 10U, 32779U, 2147516552U, 2147483659U, 2147483776U, 2147516554U, 32777U, 3U, 2147483651U, 137U, 2147483777U, 2147483787U, 2147516419U, 2147516427U, 32776U, 32776U, 32770U, 9U, 2147516545U, 32906U, 2147516426U, 128U, 32905U, 32906U, 2147516553U, 2147516416U, 32897U, 2147516426U, 9U, 2147516418U, 2147483658U, 2147516418U, 2147483648U, 2147483657U, 32904U, 2U, 2147516424U, 2147516552U, 2147483649U, 2147516555U, 2U, 2147516418U, 2147483779U, 32905U, 32896U, 2147483778U, 136U, 2147516554U, 32906U, 2147516547U, 2147483659U, 2147483657U, 32769U, 2147483785U, 136U, 2147516419U, 2147516417U, 3U, 2147483776U, 2147516425U, 2147483785U, 11U, 131U, 2147516425U, 2147483779U, 32768U, 2147516427U, 32770U, 3U, 2147483786U, 2147483650U, 32769U, 2147483648U, 2147483651U, 131U, 2147516554U, 32771U, 32776U, 32907U, 2147483778U, 1U, 32769U, 2147483658U, 2147516424U, 2147516427U, 32897U, 2147516547U, 2147483778U, 130U, 2147483777U, 2147483650U, 32904U, 139U, 32899U, 8U, 2147483786U, 2147483787U, 2147516554U, 32896U, 2147483784U, 32899U, 2U, 2147516545U, 32771U, 32897U, 2147516416U, 32770U, 138U, 1U, 32898U, 32906U, 2147516416U, 32907U, 2147483649U, 2147516545U, 32777U, 138U, 136U, 2147516425U, 2147483658U, 2147516555U, 139U, 32905U, 32771U, 32770U, 128U, 32778U, 2147483658U, 2147516545U, 32896U, 2147483649U, 2147516424U, 2147516546U, 2147516426U, 3U, 2147483657U, 32898U, 32777U, 128U, 32899U, 129U, 1U, 32779U, 2147516417U, 128U, 32768U, 2147516417U, 9U, 2147516555U, 129U, 130U, 2147483787U, 2147516425U, 2147483648U, 2147483776U, 2147516419U, 2147516546U, 2147516547U, 2147483784U, 32905U, 32777U, 9U, 2147516424U, 2147516417U, 138U, 11U, 137U, 2147483650U, 32779U, 2147516427U, 32907U, 2147483784U, 32778U, 2147483785U, 1U, 32904U, 129U, 136U, 2147516544U, 129U, 11U } }))
 
 static KRML_MUSTINLINE void
-libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
 {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)
     };
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
     };
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
+    };
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+    };
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
+    };
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
+    };
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____2 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)
     };
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____3 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
     };
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____4 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____5 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)
     };
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-      .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-      .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-      .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)
     };
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____8 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-      .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____9 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-      .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-      .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)
     };
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____10 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
   uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
@@ -652,25 +779,36 @@ libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(libcrux_iot_sha3_state_K
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____11 =
+  uu____1 =
     {
       .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
       .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
       .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)
     };
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax44);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+{
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(s);
 }
 
 static KRML_MUSTINLINE void
@@ -865,210 +1003,337 @@ libcrux_iot_sha3_keccak_keccakf1600_round1_theta(libcrux_iot_sha3_state_KeccakSt
 }
 
 static KRML_MUSTINLINE void
-libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
 {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)
     };
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
     };
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
+    };
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+    };
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
+    };
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
+    };
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____2 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)
     };
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____3 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
     };
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____4 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____5 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)
     };
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-      .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-      .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-      .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)
     };
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____8 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-      .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____9 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-      .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-      .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)
     };
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____10 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
   uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
@@ -1076,25 +1341,36 @@ libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(libcrux_iot_sha3_state_K
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____11 =
+  uu____1 =
     {
       .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
       .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
       .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)
     };
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax44);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+{
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(s);
 }
 
 static KRML_MUSTINLINE void
@@ -1289,210 +1565,337 @@ libcrux_iot_sha3_keccak_keccakf1600_round2_theta(libcrux_iot_sha3_state_KeccakSt
 }
 
 static KRML_MUSTINLINE void
-libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
 {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)
     };
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
     };
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
+    };
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+    };
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
+    };
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
+    };
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____2 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)
     };
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____3 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
     };
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____4 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____5 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)
     };
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-      .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-      .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-      .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)
     };
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____8 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-      .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____9 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-      .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-      .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)
     };
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____10 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
   uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
@@ -1500,25 +1903,36 @@ libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(libcrux_iot_sha3_state_K
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____11 =
+  uu____1 =
     {
       .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
       .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
       .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)
     };
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax44);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+{
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(s);
 }
 
 static KRML_MUSTINLINE void
@@ -1713,210 +2127,337 @@ libcrux_iot_sha3_keccak_keccakf1600_round3_theta(libcrux_iot_sha3_state_KeccakSt
 }
 
 static KRML_MUSTINLINE void
-libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
 {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)
     };
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
     };
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
+    };
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+    };
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
+    };
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
+    };
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____2 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)
     };
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____3 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)
     };
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____4 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____5 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)
     };
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-      .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)
     };
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-      .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-      .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)
     };
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
-  uu____8 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-      .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____9 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-      .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-      .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)
     };
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____10 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)
     };
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
   uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
@@ -1924,25 +2465,137 @@ libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(libcrux_iot_sha3_state_K
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
-  uu____11 =
+  uu____1 =
     {
       .fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
       .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
       .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)
     };
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax44);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax4);
+}
+
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(libcrux_iot_sha3_state_KeccakState *s)
+{
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(s);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
+    };
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
+    };
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax4);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2
+  uu____0 =
+    {
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
+    };
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3
+  uu____1 =
+    {
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
+    };
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax4);
 }
 
 /**
@@ -1955,162 +2608,111 @@ libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_56(
   libcrux_iot_sha3_state_KeccakState *s
 )
 {
-  size_t i = s->i;
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
     };
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
     };
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____2 =
-    {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)
-    };
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3
-  uu____3 =
-    {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)
-    };
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____4 =
-    {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)
-    };
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3
-  uu____5 =
-    {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)
-    };
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax4);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
     };
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
     };
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U, ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax42);
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax4);
 }
 
 /**
@@ -2123,162 +2725,111 @@ libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_56(
   libcrux_iot_sha3_state_KeccakState *s
 )
 {
-  size_t i = s->i;
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
     };
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
     };
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____2 =
-    {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)
-    };
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3
-  uu____3 =
-    {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)
-    };
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____4 =
-    {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)
-    };
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3
-  uu____5 =
-    {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)
-    };
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax4);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
     };
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
     };
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U, ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U, ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax42);
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax4);
 }
 
 /**
@@ -2291,162 +2842,111 @@ libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_56(
   libcrux_iot_sha3_state_KeccakState *s
 )
 {
-  size_t i = s->i;
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
   uint32_t_x2
   uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
     };
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
   uint32_t_x3
   uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
     };
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____2 =
-    {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)
-    };
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3
-  uu____3 =
-    {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)
-    };
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____4 =
-    {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)
-    };
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3
-  uu____5 =
-    {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)
-    };
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax4);
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1
+with const generics
+- BASE_ROUND= 0
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(
+  libcrux_iot_sha3_state_KeccakState *s
+)
+{
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
   uint32_t_x2
-  uu____6 =
+  uu____0 =
     {
-      .fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+      .fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
       .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
     };
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U);
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
   uint32_t_x3
-  uu____7 =
+  uu____1 =
     {
-      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
+      .fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+      .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+      .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)
     };
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U, ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U, ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U, ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax42);
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax4);
 }
 
 /**
@@ -2459,162 +2959,10 @@ libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_56(
   libcrux_iot_sha3_state_KeccakState *s
 )
 {
-  size_t i = s->i;
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2
-  uu____0 =
-    {
-      .fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-      .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)
-    };
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3
-  uu____1 =
-    {
-      .fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-      .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-      .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)
-    };
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U, ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U, ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U, ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U, ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U, ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____2 =
-    {
-      .fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-      .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)
-    };
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3
-  uu____3 =
-    {
-      .fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-      .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-      .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)
-    };
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^ LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U, ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U, ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U, ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U, ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U, ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2
-  uu____4 =
-    {
-      .fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-      .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)
-    };
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3
-  uu____5 =
-    {
-      .fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-      .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-      .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)
-    };
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U, ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U, ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U, ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U, ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U, ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2
-  uu____6 =
-    {
-      .fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-      .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)
-    };
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3
-  uu____7 =
-    {
-      .fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-      .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-      .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)
-    };
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U, ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U, ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U, ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U, ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U, ax42);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(s);
 }
 
 /**
@@ -2656,7 +3004,7 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_2u32_b2(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   Eurydice_borrow_slice_u8 blocks,
   size_t start
 )
@@ -2711,8 +3059,8 @@ libcrux_iot_sha3_state_load_block_2u32_b2(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    got = libcrux_iot_sha3_state_get_lane_18(state, i0 / (size_t)5U, i0 % (size_t)5U);
-    libcrux_iot_sha3_state_set_lane_18(state,
+    got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(keccak_state,
       i0 / (size_t)5U,
       i0 % (size_t)5U,
       libcrux_iot_sha3_lane_from_ints_8d((
@@ -2737,12 +3085,12 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_full_2u32_b2(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   const Eurydice_arr_5c *blocks,
   size_t start
 )
 {
-  libcrux_iot_sha3_state_load_block_2u32_b2(state,
+  libcrux_iot_sha3_state_load_block_2u32_b2(keccak_state,
     Eurydice_array_to_slice_shared_15(blocks),
     start);
 }
@@ -2858,7 +3206,7 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_2u32_60(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   Eurydice_borrow_slice_u8 blocks,
   size_t start
 )
@@ -2913,8 +3261,8 @@ libcrux_iot_sha3_state_load_block_2u32_60(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    got = libcrux_iot_sha3_state_get_lane_18(state, i0 / (size_t)5U, i0 % (size_t)5U);
-    libcrux_iot_sha3_state_set_lane_18(state,
+    got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(keccak_state,
       i0 / (size_t)5U,
       i0 % (size_t)5U,
       libcrux_iot_sha3_lane_from_ints_8d((
@@ -2973,12 +3321,12 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_full_2u32_60(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   const Eurydice_arr_5c *blocks,
   size_t start
 )
 {
-  libcrux_iot_sha3_state_load_block_2u32_60(state,
+  libcrux_iot_sha3_state_load_block_2u32_60(keccak_state,
     Eurydice_array_to_slice_shared_15(blocks),
     start);
 }
@@ -3050,7 +3398,7 @@ libcrux_iot_sha3_state_store_block_2u32_60(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(s,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -3065,7 +3413,8 @@ libcrux_iot_sha3_state_store_block_2u32_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -3078,7 +3427,8 @@ libcrux_iot_sha3_state_store_block_2u32_60(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
 }
@@ -3225,10 +3575,11 @@ libcrux_iot_sha3_keccak_keccak_37(
   size_t blocks = outlen / (size_t)168U;
   size_t last = outlen - outlen % (size_t)168U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++)
   {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_60(&s, data, i0 * (size_t)168U);
+    libcrux_iot_sha3_keccak_absorb_block_60(&s, data, start);
+    start += (size_t)168U;
   }
   libcrux_iot_sha3_keccak_absorb_final_37(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U)
@@ -3394,7 +3745,7 @@ libcrux_iot_sha3_state_store_block_2u32_b2(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(s,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -3409,7 +3760,8 @@ libcrux_iot_sha3_state_store_block_2u32_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -3422,7 +3774,8 @@ libcrux_iot_sha3_state_store_block_2u32_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
 }
@@ -3569,10 +3922,11 @@ libcrux_iot_sha3_keccak_keccak_22(
   size_t blocks = outlen / (size_t)136U;
   size_t last = outlen - outlen % (size_t)136U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++)
   {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, i0 * (size_t)136U);
+    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, start);
+    start += (size_t)136U;
   }
   libcrux_iot_sha3_keccak_absorb_final_22(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U)
@@ -3673,7 +4027,7 @@ libcrux_iot_sha3_keccak_fill_buffer_f0_b2(
   size_t consumed = (size_t)0U;
   if (self->buf_len > (size_t)0U)
   {
-    if (self->buf_len + input_len >= (size_t)136U)
+    if (input_len >= (size_t)136U - self->buf_len)
     {
       consumed = (size_t)136U - self->buf_len;
       Eurydice_slice_copy(Eurydice_array_to_subslice_from_mut_5f(&self->buf, self->buf_len),
@@ -3921,7 +4275,7 @@ libcrux_iot_sha3_state_store_18_b2(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(&self,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -3936,7 +4290,8 @@ libcrux_iot_sha3_state_store_18_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -3949,13 +4304,14 @@ libcrux_iot_sha3_state_store_18_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
   if (last_block_len > (size_t)4U)
   {
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(&self,
           num_full_blocks / (size_t)5U,
           num_full_blocks % (size_t)5U));
@@ -3971,7 +4327,8 @@ libcrux_iot_sha3_state_store_18_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____2, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____3 =
@@ -3984,7 +4341,8 @@ libcrux_iot_sha3_state_store_18_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____3,
       Eurydice_array_to_subslice_shared_d41(&lvalue,
         (KRML_CLITERAL(core_ops_range_Range_87){ .start = (size_t)0U, .end = last_half_block_len })),
@@ -3993,7 +4351,7 @@ libcrux_iot_sha3_state_store_18_b2(
   else if (last_block_len > (size_t)0U)
   {
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(&self,
           num_full_blocks / (size_t)5U,
           num_full_blocks % (size_t)5U));
@@ -4008,12 +4366,62 @@ libcrux_iot_sha3_state_store_18_b2(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____4,
       Eurydice_array_to_subslice_shared_d41(&lvalue,
         (KRML_CLITERAL(core_ops_range_Range_87){ .start = (size_t)0U, .end = last_block_len })),
       uint8_t);
   }
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak._squeeze
+with const generics
+- RATE= 136
+*/
+static KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak__squeeze_b2(
+  libcrux_iot_sha3_keccak_KeccakXofState_bd *state,
+  Eurydice_mut_borrow_slice_u8 out
+)
+{
+  if (state->sponge)
+  {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+  }
+  size_t out_len = out.meta;
+  size_t blocks = out_len / (size_t)136U;
+  size_t last = out_len - out_len % (size_t)136U;
+  size_t mid;
+  if ((size_t)136U >= out_len)
+  {
+    mid = out_len;
+  }
+  else
+  {
+    mid = (size_t)136U;
+  }
+  libcrux_iot_sha3_state_store_18_b2(state->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
+  size_t offset = mid;
+  for (size_t i = (size_t)1U; i < blocks; i++)
+  {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+    libcrux_iot_sha3_state_store_18_b2(state->inner,
+      Eurydice_slice_subslice_mut_c8(out,
+        (KRML_CLITERAL(core_ops_range_Range_87){ .start = offset, .end = offset + (size_t)136U })));
+    offset += (size_t)136U;
+  }
+  if (last > (size_t)0U)
+  {
+    if (last < out_len)
+    {
+      libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+      libcrux_iot_sha3_state_store_18_b2(state->inner,
+        Eurydice_slice_subslice_from_mut_6d(out, offset));
+    }
+  }
+  state->sponge = true;
 }
 
 /**
@@ -4033,42 +4441,7 @@ libcrux_iot_sha3_keccak_squeeze_f0_b2(
   Eurydice_mut_borrow_slice_u8 out
 )
 {
-  if (self->sponge)
-  {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-  }
-  size_t out_len = out.meta;
-  size_t blocks = out_len / (size_t)136U;
-  size_t last = out_len - out_len % (size_t)136U;
-  size_t mid;
-  if ((size_t)136U >= out_len)
-  {
-    mid = out_len;
-  }
-  else
-  {
-    mid = (size_t)136U;
-  }
-  libcrux_iot_sha3_state_store_18_b2(self->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
-  size_t offset = mid;
-  for (size_t i = (size_t)1U; i < blocks; i++)
-  {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-    libcrux_iot_sha3_state_store_18_b2(self->inner,
-      Eurydice_slice_subslice_mut_c8(out,
-        (KRML_CLITERAL(core_ops_range_Range_87){ .start = offset, .end = offset + (size_t)136U })));
-    offset += (size_t)136U;
-  }
-  if (last > (size_t)0U)
-  {
-    if (last < out_len)
-    {
-      libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-      libcrux_iot_sha3_state_store_18_b2(self->inner,
-        Eurydice_slice_subslice_from_mut_6d(out, offset));
-    }
-  }
-  self->sponge = true;
+  libcrux_iot_sha3_keccak__squeeze_b2(self, out);
 }
 
 /**
@@ -4093,7 +4466,7 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_2u32_c6(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   Eurydice_borrow_slice_u8 blocks,
   size_t start
 )
@@ -4148,8 +4521,8 @@ libcrux_iot_sha3_state_load_block_2u32_c6(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    got = libcrux_iot_sha3_state_get_lane_18(state, i0 / (size_t)5U, i0 % (size_t)5U);
-    libcrux_iot_sha3_state_set_lane_18(state,
+    got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(keccak_state,
       i0 / (size_t)5U,
       i0 % (size_t)5U,
       libcrux_iot_sha3_lane_from_ints_8d((
@@ -4208,12 +4581,12 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_full_2u32_c6(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   const Eurydice_arr_5c *blocks,
   size_t start
 )
 {
-  libcrux_iot_sha3_state_load_block_2u32_c6(state,
+  libcrux_iot_sha3_state_load_block_2u32_c6(keccak_state,
     Eurydice_array_to_slice_shared_15(blocks),
     start);
 }
@@ -4285,7 +4658,7 @@ libcrux_iot_sha3_state_store_block_2u32_c6(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(s,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -4300,7 +4673,8 @@ libcrux_iot_sha3_state_store_block_2u32_c6(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -4313,7 +4687,8 @@ libcrux_iot_sha3_state_store_block_2u32_c6(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
 }
@@ -4460,10 +4835,11 @@ libcrux_iot_sha3_keccak_keccak_dc(
   size_t blocks = outlen / (size_t)72U;
   size_t last = outlen - outlen % (size_t)72U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++)
   {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_c6(&s, data, i0 * (size_t)72U);
+    libcrux_iot_sha3_keccak_absorb_block_c6(&s, data, start);
+    start += (size_t)72U;
   }
   libcrux_iot_sha3_keccak_absorb_final_dc(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U)
@@ -4567,10 +4943,11 @@ libcrux_iot_sha3_keccak_keccak_220(
   size_t blocks = outlen / (size_t)136U;
   size_t last = outlen - outlen % (size_t)136U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++)
   {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, i0 * (size_t)136U);
+    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, start);
+    start += (size_t)136U;
   }
   libcrux_iot_sha3_keccak_absorb_final_220(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U)
@@ -4659,7 +5036,7 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_2u32_9e(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   Eurydice_borrow_slice_u8 blocks,
   size_t start
 )
@@ -4714,8 +5091,8 @@ libcrux_iot_sha3_state_load_block_2u32_9e(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    got = libcrux_iot_sha3_state_get_lane_18(state, i0 / (size_t)5U, i0 % (size_t)5U);
-    libcrux_iot_sha3_state_set_lane_18(state,
+    got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(keccak_state,
       i0 / (size_t)5U,
       i0 % (size_t)5U,
       libcrux_iot_sha3_lane_from_ints_8d((
@@ -4774,12 +5151,12 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_full_2u32_9e(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   const Eurydice_arr_5c *blocks,
   size_t start
 )
 {
-  libcrux_iot_sha3_state_load_block_2u32_9e(state,
+  libcrux_iot_sha3_state_load_block_2u32_9e(keccak_state,
     Eurydice_array_to_slice_shared_15(blocks),
     start);
 }
@@ -4851,7 +5228,7 @@ libcrux_iot_sha3_state_store_block_2u32_9e(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(s,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -4866,7 +5243,8 @@ libcrux_iot_sha3_state_store_block_2u32_9e(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -4879,7 +5257,8 @@ libcrux_iot_sha3_state_store_block_2u32_9e(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
 }
@@ -5026,10 +5405,11 @@ libcrux_iot_sha3_keccak_keccak_3a(
   size_t blocks = outlen / (size_t)144U;
   size_t last = outlen - outlen % (size_t)144U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++)
   {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_9e(&s, data, i0 * (size_t)144U);
+    libcrux_iot_sha3_keccak_absorb_block_9e(&s, data, start);
+    start += (size_t)144U;
   }
   libcrux_iot_sha3_keccak_absorb_final_3a(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U)
@@ -5088,7 +5468,7 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_2u32_53(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   Eurydice_borrow_slice_u8 blocks,
   size_t start
 )
@@ -5143,8 +5523,8 @@ libcrux_iot_sha3_state_load_block_2u32_53(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    got = libcrux_iot_sha3_state_get_lane_18(state, i0 / (size_t)5U, i0 % (size_t)5U);
-    libcrux_iot_sha3_state_set_lane_18(state,
+    got = libcrux_iot_sha3_state_get_lane_18(keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(keccak_state,
       i0 / (size_t)5U,
       i0 % (size_t)5U,
       libcrux_iot_sha3_lane_from_ints_8d((
@@ -5203,12 +5583,12 @@ with const generics
 */
 static KRML_MUSTINLINE void
 libcrux_iot_sha3_state_load_block_full_2u32_53(
-  libcrux_iot_sha3_state_KeccakState *state,
+  libcrux_iot_sha3_state_KeccakState *keccak_state,
   const Eurydice_arr_5c *blocks,
   size_t start
 )
 {
-  libcrux_iot_sha3_state_load_block_2u32_53(state,
+  libcrux_iot_sha3_state_load_block_2u32_53(keccak_state,
     Eurydice_array_to_slice_shared_15(blocks),
     start);
 }
@@ -5280,7 +5660,7 @@ libcrux_iot_sha3_state_store_block_2u32_53(
   {
     size_t i0 = i;
     Eurydice_arr_a0
-    lane =
+    keccak_lane =
       libcrux_iot_sha3_lane_deinterleave_8d(libcrux_iot_sha3_state_get_lane_18(s,
           i0 / (size_t)5U,
           i0 % (size_t)5U));
@@ -5295,7 +5675,8 @@ libcrux_iot_sha3_state_store_block_2u32_53(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue0 = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+    lvalue0 =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0), uint8_t);
     Eurydice_mut_borrow_slice_u8
     uu____1 =
@@ -5308,7 +5689,8 @@ libcrux_iot_sha3_state_store_block_2u32_53(
         ));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4
-    lvalue = core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+    lvalue =
+      core_num__u32__to_le_bytes(libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue), uint8_t);
   }
 }
@@ -5455,10 +5837,11 @@ libcrux_iot_sha3_keccak_keccak_dc0(
   size_t blocks = outlen / (size_t)104U;
   size_t last = outlen - outlen % (size_t)104U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++)
   {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_53(&s, data, i0 * (size_t)104U);
+    libcrux_iot_sha3_keccak_absorb_block_53(&s, data, start);
+    start += (size_t)104U;
   }
   libcrux_iot_sha3_keccak_absorb_final_dc0(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U)
@@ -5533,14 +5916,14 @@ static inline Eurydice_arr_a2 libcrux_iot_sha3_sha224(Eurydice_borrow_slice_u8 p
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-static inline Eurydice_arr_ec libcrux_iot_sha3_sha256(Eurydice_borrow_slice_u8 data)
+static inline Eurydice_arr_ec libcrux_iot_sha3_sha256(Eurydice_borrow_slice_u8 payload)
 {
   Eurydice_arr_ec
   out =
     libcrux_secrets_int_public_integers_classify_27_4b((
         KRML_CLITERAL(Eurydice_arr_ec){ .data = { 0U } }
       ));
-  libcrux_iot_sha3_sha256_ema(Eurydice_array_to_slice_mut_01(&out), data);
+  libcrux_iot_sha3_sha256_ema(Eurydice_array_to_slice_mut_01(&out), payload);
   return out;
 }
 
@@ -5550,14 +5933,14 @@ static inline Eurydice_arr_ec libcrux_iot_sha3_sha256(Eurydice_borrow_slice_u8 d
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-static inline Eurydice_arr_65 libcrux_iot_sha3_sha384(Eurydice_borrow_slice_u8 data)
+static inline Eurydice_arr_65 libcrux_iot_sha3_sha384(Eurydice_borrow_slice_u8 payload)
 {
   Eurydice_arr_65
   out =
     libcrux_secrets_int_public_integers_classify_27_69((
         KRML_CLITERAL(Eurydice_arr_65){ .data = { 0U } }
       ));
-  libcrux_iot_sha3_sha384_ema(Eurydice_array_to_slice_mut_9f(&out), data);
+  libcrux_iot_sha3_sha384_ema(Eurydice_array_to_slice_mut_9f(&out), payload);
   return out;
 }
 
@@ -5567,14 +5950,14 @@ static inline Eurydice_arr_65 libcrux_iot_sha3_sha384(Eurydice_borrow_slice_u8 d
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-static inline Eurydice_arr_c7 libcrux_iot_sha3_sha512(Eurydice_borrow_slice_u8 data)
+static inline Eurydice_arr_c7 libcrux_iot_sha3_sha512(Eurydice_borrow_slice_u8 payload)
 {
   Eurydice_arr_c7
   out =
     libcrux_secrets_int_public_integers_classify_27_56((
         KRML_CLITERAL(Eurydice_arr_c7){ .data = { 0U } }
       ));
-  libcrux_iot_sha3_sha512_ema(Eurydice_array_to_slice_mut_17(&out), data);
+  libcrux_iot_sha3_sha512_ema(Eurydice_array_to_slice_mut_17(&out), payload);
   return out;
 }
 

--- a/c/sha3/extracted/code_gen.txt
+++ b/c/sha3/extracted/code_gen.txt
@@ -3,4 +3,4 @@ Charon: e656e17bff6ca5efac8ab6919b9b74cb9a8dd8ad
 Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
 Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
 F*: unset
-Libcrux: dirty
+Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d

--- a/c/sha3/extracted/code_gen.txt
+++ b/c/sha3/extracted/code_gen.txt
@@ -3,4 +3,4 @@ Charon: e656e17bff6ca5efac8ab6919b9b74cb9a8dd8ad
 Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
 Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
 F*: unset
-Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+Libcrux: dirty

--- a/c/sha3/extracted/header.txt
+++ b/c/sha3/extracted/header.txt
@@ -8,5 +8,5 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */

--- a/c/sha3/extracted/header.txt
+++ b/c/sha3/extracted/header.txt
@@ -8,5 +8,5 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */

--- a/c/sha3/extracted/internal/libcrux_iot_core.h
+++ b/c/sha3/extracted/internal/libcrux_iot_core.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */
 
 #ifndef internal_libcrux_iot_core_H

--- a/c/sha3/extracted/internal/libcrux_iot_core.h
+++ b/c/sha3/extracted/internal/libcrux_iot_core.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */
 
 #ifndef internal_libcrux_iot_core_H
@@ -42,16 +42,6 @@ typedef struct core_ops_range_Range_87_s {
 This function found in impl {libcrux_secrets::int::CastOps for u32}
 */
 uint64_t libcrux_secrets_int_as_u64_b8(uint32_t self);
-
-/**
-This function found in impl {libcrux_secrets::traits::Classify<T> for T}
-*/
-/**
-A monomorphic instance of libcrux_secrets.int.public_integers.classify_27
-with types uint32_t
-
-*/
-uint32_t libcrux_secrets_int_public_integers_classify_27_df(uint32_t self);
 
 /**
 This function found in impl {libcrux_secrets::int::CastOps for u64}

--- a/c/sha3/extracted/internal/libcrux_iot_sha3.h
+++ b/c/sha3/extracted/internal/libcrux_iot_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */
 
 #ifndef internal_libcrux_iot_sha3_H
@@ -249,6 +249,30 @@ void libcrux_iot_sha3_state_set_with_zeta_18(
           2147483784U, 32778U,      2147483785U, 1U,          32904U,      \
           129U,        136U,        2147516544U, 129U,        11U}}))
 
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
 void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(
     libcrux_iot_sha3_state_KeccakState *s);
 
@@ -286,6 +310,30 @@ void libcrux_iot_sha3_keccak_keccakf1600_round1_theta_d(
     libcrux_iot_sha3_state_KeccakState *s);
 
 void libcrux_iot_sha3_keccak_keccakf1600_round1_theta(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(
     libcrux_iot_sha3_state_KeccakState *s);
 
 void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(
@@ -327,6 +375,30 @@ void libcrux_iot_sha3_keccak_keccakf1600_round2_theta_d(
 void libcrux_iot_sha3_keccak_keccakf1600_round2_theta(
     libcrux_iot_sha3_state_KeccakState *s);
 
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
 void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(
     libcrux_iot_sha3_state_KeccakState *s);
 
@@ -366,7 +438,49 @@ void libcrux_iot_sha3_keccak_keccakf1600_round3_theta_d(
 void libcrux_iot_sha3_keccak_keccakf1600_round3_theta(
     libcrux_iot_sha3_state_KeccakState *s);
 
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
 void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -379,6 +493,24 @@ void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_56(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
 - BASE_ROUND= 0
 */
@@ -387,10 +519,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_56(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 - BASE_ROUND= 0
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -422,8 +590,8 @@ with const generics
 - RATE= 144
 */
 void libcrux_iot_sha3_state_load_block_2u32_9e(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -452,8 +620,8 @@ with const generics
 - RATE= 144
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_9e(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -575,8 +743,8 @@ with const generics
 - RATE= 136
 */
 void libcrux_iot_sha3_state_load_block_2u32_b2(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -605,8 +773,8 @@ with const generics
 - RATE= 136
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_b2(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -728,8 +896,8 @@ with const generics
 - RATE= 104
 */
 void libcrux_iot_sha3_state_load_block_2u32_53(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -758,8 +926,8 @@ with const generics
 - RATE= 104
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_53(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -881,8 +1049,8 @@ with const generics
 - RATE= 72
 */
 void libcrux_iot_sha3_state_load_block_2u32_c6(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -911,8 +1079,8 @@ with const generics
 - RATE= 72
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_c6(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -1034,8 +1202,8 @@ with const generics
 - RATE= 168
 */
 void libcrux_iot_sha3_state_load_block_2u32_60(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -1064,8 +1232,8 @@ with const generics
 - RATE= 168
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_60(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -1381,6 +1549,15 @@ void libcrux_iot_sha3_state_store_18_b2(libcrux_iot_sha3_state_KeccakState self,
                                         Eurydice_mut_borrow_slice_u8 out);
 
 /**
+A monomorphic instance of libcrux_iot_sha3.keccak._squeeze
+with const generics
+- RATE= 136
+*/
+void libcrux_iot_sha3_keccak__squeeze_b2(
+    libcrux_iot_sha3_keccak_KeccakXofState_bd *state,
+    Eurydice_mut_borrow_slice_u8 out);
+
+/**
  Squeeze `N` x `LEN` bytes.
 */
 /**
@@ -1548,6 +1725,15 @@ void libcrux_iot_sha3_state_store_18_60(libcrux_iot_sha3_state_KeccakState self,
                                         Eurydice_mut_borrow_slice_u8 out);
 
 /**
+A monomorphic instance of libcrux_iot_sha3.keccak._squeeze
+with const generics
+- RATE= 168
+*/
+void libcrux_iot_sha3_keccak__squeeze_60(
+    libcrux_iot_sha3_keccak_KeccakXofState_31 *state,
+    Eurydice_mut_borrow_slice_u8 out);
+
+/**
  Squeeze `N` x `LEN` bytes.
 */
 /**
@@ -1592,10 +1778,20 @@ for u32}
 uint32_t from_c3(Algorithm v);
 
 /**
-This function found in impl {core::convert::From<u32> for
-libcrux_iot_sha3::Algorithm}
+A monomorphic instance of core.result.Result
+with types libcrux_iot_sha3_Algorithm, ()
+
 */
-Algorithm from_c2(uint32_t v);
+typedef struct core_result_Result_20_s {
+  core_result_Result_c7_tags tag;
+  Algorithm f0;
+} core_result_Result_20;
+
+/**
+This function found in impl {core::convert::TryFrom<u32,
+libcrux_iot_sha3::UnknownAlgorithm> for libcrux_iot_sha3::Algorithm}
+*/
+core_result_Result_20 try_from_72(uint32_t v);
 
 #if defined(__cplusplus)
 }

--- a/c/sha3/extracted/internal/libcrux_iot_sha3.h
+++ b/c/sha3/extracted/internal/libcrux_iot_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */
 
 #ifndef internal_libcrux_iot_sha3_H

--- a/c/sha3/extracted/libcrux_iot_core.c
+++ b/c/sha3/extracted/libcrux_iot_core.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */
 
 #include "internal/libcrux_iot_core.h"

--- a/c/sha3/extracted/libcrux_iot_core.c
+++ b/c/sha3/extracted/libcrux_iot_core.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */
 
 #include "internal/libcrux_iot_core.h"
@@ -48,9 +48,7 @@ A monomorphic instance of libcrux_secrets.int.public_integers.classify_27
 with types uint32_t
 
 */
-uint32_t libcrux_secrets_int_public_integers_classify_27_df(uint32_t self) {
-  return self;
-}
+static KRML_MUSTINLINE uint32_t classify_27_df(uint32_t self) { return self; }
 
 /**
 This function found in impl {libcrux_secrets::traits::Declassify<T> for T}
@@ -66,8 +64,7 @@ static KRML_MUSTINLINE uint64_t declassify_d8_49(uint64_t self) { return self; }
 This function found in impl {libcrux_secrets::int::CastOps for u64}
 */
 uint32_t libcrux_secrets_int_as_u32_a3(uint64_t self) {
-  return libcrux_secrets_int_public_integers_classify_27_df(
-      (uint32_t)declassify_d8_49(self));
+  return classify_27_df((uint32_t)declassify_d8_49(self));
 }
 
 /**

--- a/c/sha3/extracted/libcrux_iot_core.h
+++ b/c/sha3/extracted/libcrux_iot_core.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */
 
 #ifndef libcrux_iot_core_H

--- a/c/sha3/extracted/libcrux_iot_core.h
+++ b/c/sha3/extracted/libcrux_iot_core.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */
 
 #ifndef libcrux_iot_core_H

--- a/c/sha3/extracted/libcrux_iot_sha3.c
+++ b/c/sha3/extracted/libcrux_iot_sha3.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */
 
 #include "internal/libcrux_iot_sha3.h"
@@ -411,218 +411,334 @@ typedef struct uint32_t_x3_s {
   uint32_t thd;
 } uint32_t_x3;
 
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(
     libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)};
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)};
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
                                           ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
                                           ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
                                           ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
                                           ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)};
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)};
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)};
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)};
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-                         .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)};
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-                         .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-                         .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)};
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____8 = {.fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-                         .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)};
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____9 = {.fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-                         .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-                         .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)};
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
-                                          ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
-                                          ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____10 = {.fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
-                          .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
@@ -632,27 +748,37 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
                                                         (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____11 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
-                          .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
-                          .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
-                                          ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax44);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(s);
 }
 
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_theta_c_x0_z0(
@@ -874,218 +1000,334 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_theta(
   libcrux_iot_sha3_keccak_keccakf1600_round1_theta_d(s);
 }
 
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(
     libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
                                                         (size_t)0U, (size_t)1U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)};
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)};
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
                                           ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
                                           ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
                                           ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
                                           ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)};
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)};
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)};
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)};
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-                         .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)};
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-                         .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-                         .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)};
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
-                                          ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____8 = {.fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-                         .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)};
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____9 = {.fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-                         .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-                         .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)};
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
-                                          ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____10 = {.fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
-                          .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
                                                         (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
@@ -1095,27 +1337,37 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
                                                         (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____11 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
-                          .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
-                          .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
-                                          ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax44);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(s);
 }
 
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_theta_c_x0_z0(
@@ -1337,218 +1589,334 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_theta(
   libcrux_iot_sha3_keccak_keccakf1600_round2_theta_d(s);
 }
 
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(
     libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)0U, (size_t)1U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)};
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)};
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
                                           ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
                                           ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
                                           ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
                                           ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)};
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)};
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)};
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)};
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-                         .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)};
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-                         .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-                         .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)};
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
-                                          ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____8 = {.fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-                         .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)};
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____9 = {.fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-                         .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-                         .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)};
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
-                                          ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
-                                          ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____10 = {.fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
-                          .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
@@ -1558,27 +1926,37 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____11 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
-                          .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
-                          .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
                                           ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
-                                          ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax44);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(s);
 }
 
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_theta_c_x0_z0(
@@ -1800,918 +2178,64 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_theta(
   libcrux_iot_sha3_keccak_keccakf1600_round3_theta_d(s);
 }
 
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(
     libcrux_iot_sha3_state_KeccakState *s) {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)};
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)};
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)};
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)};
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)};
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)};
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-                         .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)};
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-                         .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-                         .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)};
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
-                                          ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____8 = {.fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-                         .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)};
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____9 = {.fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-                         .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-                         .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)};
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
-                                          ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
-                                          ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)1U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____10 = {.fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
-                          .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)2U, (size_t)1U);
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)3U, (size_t)1U);
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)4U, (size_t)1U);
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____11 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
-                          .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
-                          .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
-                                          ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax44);
-}
-
-/**
-A monomorphic instance of
-libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
-- BASE_ROUND= 0
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_56(
-    libcrux_iot_sha3_state_KeccakState *s) {
-  size_t i = s->i;
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
-                                                        (size_t)1U, (size_t)0U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)3U, (size_t)1U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
                          .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
                          .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
-}
-
-/**
-A monomorphic instance of
-libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
-- BASE_ROUND= 0
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_56(
-    libcrux_iot_sha3_state_KeccakState *s) {
-  size_t i = s->i;
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)1U, (size_t)0U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
-                                                        (size_t)3U, (size_t)0U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
-}
-
-/**
-A monomorphic instance of
-libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
-- BASE_ROUND= 0
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_56(
-    libcrux_iot_sha3_state_KeccakState *s) {
-  size_t i = s->i;
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)1U, (size_t)1U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)3U, (size_t)0U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
-}
-
-/**
-A monomorphic instance of
-libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_1 with const generics
-- BASE_ROUND= 0
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_56(
-    libcrux_iot_sha3_state_KeccakState *s) {
-  size_t i = s->i;
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[i];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[i];
-  s->i = i + (size_t)1U;
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
@@ -2721,27 +2245,779 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_56(
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
                          .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
                          .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[s->i];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 = (bx0 ^ (~bx1 & bx2)) ^
+                 LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[s->i];
+  s->i++;
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_1 with const generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(s);
 }
 
 /**
@@ -2815,8 +3091,8 @@ with const generics
 - RATE= 144
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_9e(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
   Eurydice_arr_c0 state_flat;
   Eurydice_arr_a0 repeat_expression[25U];
   for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
@@ -2856,9 +3132,9 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_9e(
   for (size_t i = (size_t)0U; i < (size_t)144U / (size_t)8U; i++) {
     size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U);
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U,
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
             .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
                          libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
@@ -2901,10 +3177,10 @@ with const generics
 - RATE= 144
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_9e(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_9e(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -2958,7 +3234,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_9e(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)144U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -2967,7 +3243,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_9e(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -2976,7 +3252,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_9e(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -3092,9 +3368,10 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_3a(
   size_t blocks = outlen / (size_t)144U;
   size_t last = outlen - outlen % (size_t)144U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++) {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_9e(&s, data, i0 * (size_t)144U);
+    libcrux_iot_sha3_keccak_absorb_block_9e(&s, data, start);
+    start += (size_t)144U;
   }
   libcrux_iot_sha3_keccak_absorb_final_3a(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U) {
@@ -3143,8 +3420,8 @@ with const generics
 - RATE= 136
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_b2(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
   Eurydice_arr_c0 state_flat;
   Eurydice_arr_a0 repeat_expression[25U];
   for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
@@ -3184,9 +3461,9 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_b2(
   for (size_t i = (size_t)0U; i < (size_t)136U / (size_t)8U; i++) {
     size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U);
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U,
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
             .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
                          libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
@@ -3229,10 +3506,10 @@ with const generics
 - RATE= 136
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_b2(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_b2(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -3286,7 +3563,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_b2(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)136U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -3295,7 +3572,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_b2(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -3304,7 +3581,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_b2(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -3420,9 +3697,10 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_22(
   size_t blocks = outlen / (size_t)136U;
   size_t last = outlen - outlen % (size_t)136U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++) {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, i0 * (size_t)136U);
+    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, start);
+    start += (size_t)136U;
   }
   libcrux_iot_sha3_keccak_absorb_final_22(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U) {
@@ -3471,8 +3749,8 @@ with const generics
 - RATE= 104
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_53(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
   Eurydice_arr_c0 state_flat;
   Eurydice_arr_a0 repeat_expression[25U];
   for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
@@ -3512,9 +3790,9 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_53(
   for (size_t i = (size_t)0U; i < (size_t)104U / (size_t)8U; i++) {
     size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U);
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U,
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
             .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
                          libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
@@ -3557,10 +3835,10 @@ with const generics
 - RATE= 104
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_53(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_53(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -3614,7 +3892,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_53(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)104U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -3623,7 +3901,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_53(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -3632,7 +3910,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_53(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -3748,9 +4026,10 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_dc(
   size_t blocks = outlen / (size_t)104U;
   size_t last = outlen - outlen % (size_t)104U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++) {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_53(&s, data, i0 * (size_t)104U);
+    libcrux_iot_sha3_keccak_absorb_block_53(&s, data, start);
+    start += (size_t)104U;
   }
   libcrux_iot_sha3_keccak_absorb_final_dc(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U) {
@@ -3799,8 +4078,8 @@ with const generics
 - RATE= 72
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_c6(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
   Eurydice_arr_c0 state_flat;
   Eurydice_arr_a0 repeat_expression[25U];
   for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
@@ -3840,9 +4119,9 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_c6(
   for (size_t i = (size_t)0U; i < (size_t)72U / (size_t)8U; i++) {
     size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U);
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U,
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
             .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
                          libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
@@ -3885,10 +4164,10 @@ with const generics
 - RATE= 72
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_c6(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_c6(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -3942,7 +4221,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_c6(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)72U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -3951,7 +4230,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_c6(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -3960,7 +4239,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_c6(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -4076,9 +4355,10 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_dc0(
   size_t blocks = outlen / (size_t)72U;
   size_t last = outlen - outlen % (size_t)72U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++) {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_c6(&s, data, i0 * (size_t)72U);
+    libcrux_iot_sha3_keccak_absorb_block_c6(&s, data, start);
+    start += (size_t)72U;
   }
   libcrux_iot_sha3_keccak_absorb_final_dc0(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U) {
@@ -4140,10 +4420,10 @@ Eurydice_arr_a2 sha224(Eurydice_borrow_slice_u8 payload) {
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 data) {
+Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 payload) {
   Eurydice_arr_ec out = libcrux_secrets_int_public_integers_classify_27_4b(
       (KRML_CLITERAL(Eurydice_arr_ec){.data = {0U}}));
-  sha256_ema(Eurydice_array_to_slice_mut_01(&out), data);
+  sha256_ema(Eurydice_array_to_slice_mut_01(&out), payload);
   return out;
 }
 
@@ -4153,10 +4433,10 @@ Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 data) {
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 data) {
+Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 payload) {
   Eurydice_arr_65 out = libcrux_secrets_int_public_integers_classify_27_69(
       (KRML_CLITERAL(Eurydice_arr_65){.data = {0U}}));
-  sha384_ema(Eurydice_array_to_slice_mut_9f(&out), data);
+  sha384_ema(Eurydice_array_to_slice_mut_9f(&out), payload);
   return out;
 }
 
@@ -4166,10 +4446,10 @@ Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 data) {
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_c7 sha512(Eurydice_borrow_slice_u8 data) {
+Eurydice_arr_c7 sha512(Eurydice_borrow_slice_u8 payload) {
   Eurydice_arr_c7 out = libcrux_secrets_int_public_integers_classify_27_56(
       (KRML_CLITERAL(Eurydice_arr_c7){.data = {0U}}));
-  sha512_ema(Eurydice_array_to_slice_mut_17(&out), data);
+  sha512_ema(Eurydice_array_to_slice_mut_17(&out), payload);
   return out;
 }
 
@@ -4179,8 +4459,8 @@ with const generics
 - RATE= 168
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_60(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
   Eurydice_arr_c0 state_flat;
   Eurydice_arr_a0 repeat_expression[25U];
   for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
@@ -4220,9 +4500,9 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_60(
   for (size_t i = (size_t)0U; i < (size_t)168U / (size_t)8U; i++) {
     size_t i0 = i;
     Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U);
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
     libcrux_iot_sha3_state_set_lane_18(
-        state, i0 / (size_t)5U, i0 % (size_t)5U,
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
         libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
             .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
                          libcrux_iot_sha3_lane_index_cc(&state_flat.data[i0],
@@ -4265,10 +4545,10 @@ with const generics
 - RATE= 168
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_60(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_60(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -4322,7 +4602,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_60(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)168U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -4331,7 +4611,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_60(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -4340,7 +4620,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_60(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -4456,9 +4736,10 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_37(
   size_t blocks = outlen / (size_t)168U;
   size_t last = outlen - outlen % (size_t)168U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++) {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_60(&s, data, i0 * (size_t)168U);
+    libcrux_iot_sha3_keccak_absorb_block_60(&s, data, start);
+    start += (size_t)168U;
   }
   libcrux_iot_sha3_keccak_absorb_final_37(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U) {
@@ -4543,9 +4824,10 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_220(
   size_t blocks = outlen / (size_t)136U;
   size_t last = outlen - outlen % (size_t)136U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   for (size_t i = (size_t)0U; i < n; i++) {
-    size_t i0 = i;
-    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, i0 * (size_t)136U);
+    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, start);
+    start += (size_t)136U;
   }
   libcrux_iot_sha3_keccak_absorb_final_220(&s, data, data.meta - rem, rem);
   if (blocks == (size_t)0U) {
@@ -4612,7 +4894,7 @@ size_t libcrux_iot_sha3_keccak_fill_buffer_f0_b2(
   size_t input_len = inputs.meta;
   size_t consumed = (size_t)0U;
   if (self->buf_len > (size_t)0U) {
-    if (self->buf_len + input_len >= (size_t)136U) {
+    if (input_len >= (size_t)136U - self->buf_len) {
       consumed = (size_t)136U - self->buf_len;
       Eurydice_slice_copy(
           Eurydice_array_to_subslice_from_mut_5f(&self->buf, self->buf_len),
@@ -4830,7 +5112,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
   size_t last_block_len = out.meta % (size_t)8U;
   for (size_t i = (size_t)0U; i < num_full_blocks; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(&self, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -4839,7 +5121,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
             .start = i0 * (size_t)8U, .end = i0 * (size_t)8U + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -4848,12 +5130,12 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
                  .end = i0 * (size_t)8U + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
   if (last_block_len > (size_t)4U) {
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(&self, num_full_blocks / (size_t)5U,
                                            num_full_blocks % (size_t)5U));
     size_t last_half_block_len = last_block_len - (size_t)4U;
@@ -4863,7 +5145,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
                  .end = num_full_blocks * (size_t)8U + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____2, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____3 = Eurydice_slice_subslice_mut_c8(
@@ -4872,7 +5154,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
                  .end = num_full_blocks * (size_t)8U + last_block_len}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(
         uu____3,
         Eurydice_array_to_subslice_shared_d41(
@@ -4880,7 +5162,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
                          .start = (size_t)0U, .end = last_half_block_len})),
         uint8_t);
   } else if (last_block_len > (size_t)0U) {
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(&self, num_full_blocks / (size_t)5U,
                                            num_full_blocks % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____4 = Eurydice_slice_subslice_mut_c8(
@@ -4889,7 +5171,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
                  .end = num_full_blocks * (size_t)8U + last_block_len}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(
         uu____4,
         Eurydice_array_to_subslice_shared_d41(
@@ -4897,6 +5179,48 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_b2(
                          .start = (size_t)0U, .end = last_block_len})),
         uint8_t);
   }
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak._squeeze
+with const generics
+- RATE= 136
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak__squeeze_b2(
+    libcrux_iot_sha3_keccak_KeccakXofState_bd *state,
+    Eurydice_mut_borrow_slice_u8 out) {
+  if (state->sponge) {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+  }
+  size_t out_len = out.meta;
+  size_t blocks = out_len / (size_t)136U;
+  size_t last = out_len - out_len % (size_t)136U;
+  size_t mid;
+  if ((size_t)136U >= out_len) {
+    mid = out_len;
+  } else {
+    mid = (size_t)136U;
+  }
+  libcrux_iot_sha3_state_store_18_b2(
+      state->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
+  size_t offset = mid;
+  for (size_t i = (size_t)1U; i < blocks; i++) {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+    libcrux_iot_sha3_state_store_18_b2(
+        state->inner,
+        Eurydice_slice_subslice_mut_c8(
+            out, (KRML_CLITERAL(core_ops_range_Range_87){
+                     .start = offset, .end = offset + (size_t)136U})));
+    offset += (size_t)136U;
+  }
+  if (last > (size_t)0U) {
+    if (last < out_len) {
+      libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+      libcrux_iot_sha3_state_store_18_b2(
+          state->inner, Eurydice_slice_subslice_from_mut_6d(out, offset));
+    }
+  }
+  state->sponge = true;
 }
 
 /**
@@ -4913,38 +5237,7 @@ with const generics
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_squeeze_f0_b2(
     libcrux_iot_sha3_keccak_KeccakXofState_bd *self,
     Eurydice_mut_borrow_slice_u8 out) {
-  if (self->sponge) {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-  }
-  size_t out_len = out.meta;
-  size_t blocks = out_len / (size_t)136U;
-  size_t last = out_len - out_len % (size_t)136U;
-  size_t mid;
-  if ((size_t)136U >= out_len) {
-    mid = out_len;
-  } else {
-    mid = (size_t)136U;
-  }
-  libcrux_iot_sha3_state_store_18_b2(
-      self->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
-  size_t offset = mid;
-  for (size_t i = (size_t)1U; i < blocks; i++) {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-    libcrux_iot_sha3_state_store_18_b2(
-        self->inner,
-        Eurydice_slice_subslice_mut_c8(
-            out, (KRML_CLITERAL(core_ops_range_Range_87){
-                     .start = offset, .end = offset + (size_t)136U})));
-    offset += (size_t)136U;
-  }
-  if (last > (size_t)0U) {
-    if (last < out_len) {
-      libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-      libcrux_iot_sha3_state_store_18_b2(
-          self->inner, Eurydice_slice_subslice_from_mut_6d(out, offset));
-    }
-  }
-  self->sponge = true;
+  libcrux_iot_sha3_keccak__squeeze_b2(self, out);
 }
 
 /**
@@ -4983,7 +5276,7 @@ size_t libcrux_iot_sha3_keccak_fill_buffer_f0_60(
   size_t input_len = inputs.meta;
   size_t consumed = (size_t)0U;
   if (self->buf_len > (size_t)0U) {
-    if (self->buf_len + input_len >= (size_t)168U) {
+    if (input_len >= (size_t)168U - self->buf_len) {
       consumed = (size_t)168U - self->buf_len;
       Eurydice_slice_copy(
           Eurydice_array_to_subslice_from_mut_5f0(&self->buf, self->buf_len),
@@ -5201,7 +5494,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
   size_t last_block_len = out.meta % (size_t)8U;
   for (size_t i = (size_t)0U; i < num_full_blocks; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(&self, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -5210,7 +5503,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
             .start = i0 * (size_t)8U, .end = i0 * (size_t)8U + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -5219,12 +5512,12 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
                  .end = i0 * (size_t)8U + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
   if (last_block_len > (size_t)4U) {
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(&self, num_full_blocks / (size_t)5U,
                                            num_full_blocks % (size_t)5U));
     size_t last_half_block_len = last_block_len - (size_t)4U;
@@ -5234,7 +5527,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
                  .end = num_full_blocks * (size_t)8U + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____2, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____3 = Eurydice_slice_subslice_mut_c8(
@@ -5243,7 +5536,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
                  .end = num_full_blocks * (size_t)8U + last_block_len}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(
         uu____3,
         Eurydice_array_to_subslice_shared_d41(
@@ -5251,7 +5544,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
                          .start = (size_t)0U, .end = last_half_block_len})),
         uint8_t);
   } else if (last_block_len > (size_t)0U) {
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(&self, num_full_blocks / (size_t)5U,
                                            num_full_blocks % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____4 = Eurydice_slice_subslice_mut_c8(
@@ -5260,7 +5553,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
                  .end = num_full_blocks * (size_t)8U + last_block_len}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(
         uu____4,
         Eurydice_array_to_subslice_shared_d41(
@@ -5268,6 +5561,48 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_18_60(
                          .start = (size_t)0U, .end = last_block_len})),
         uint8_t);
   }
+}
+
+/**
+A monomorphic instance of libcrux_iot_sha3.keccak._squeeze
+with const generics
+- RATE= 168
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak__squeeze_60(
+    libcrux_iot_sha3_keccak_KeccakXofState_31 *state,
+    Eurydice_mut_borrow_slice_u8 out) {
+  if (state->sponge) {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+  }
+  size_t out_len = out.meta;
+  size_t blocks = out_len / (size_t)168U;
+  size_t last = out_len - out_len % (size_t)168U;
+  size_t mid;
+  if ((size_t)168U >= out_len) {
+    mid = out_len;
+  } else {
+    mid = (size_t)168U;
+  }
+  libcrux_iot_sha3_state_store_18_60(
+      state->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
+  size_t offset = mid;
+  for (size_t i = (size_t)1U; i < blocks; i++) {
+    libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+    libcrux_iot_sha3_state_store_18_60(
+        state->inner,
+        Eurydice_slice_subslice_mut_c8(
+            out, (KRML_CLITERAL(core_ops_range_Range_87){
+                     .start = offset, .end = offset + (size_t)168U})));
+    offset += (size_t)168U;
+  }
+  if (last > (size_t)0U) {
+    if (last < out_len) {
+      libcrux_iot_sha3_keccak_keccakf1600(&state->inner);
+      libcrux_iot_sha3_state_store_18_60(
+          state->inner, Eurydice_slice_subslice_from_mut_6d(out, offset));
+    }
+  }
+  state->sponge = true;
 }
 
 /**
@@ -5284,38 +5619,7 @@ with const generics
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_squeeze_f0_60(
     libcrux_iot_sha3_keccak_KeccakXofState_31 *self,
     Eurydice_mut_borrow_slice_u8 out) {
-  if (self->sponge) {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-  }
-  size_t out_len = out.meta;
-  size_t blocks = out_len / (size_t)168U;
-  size_t last = out_len - out_len % (size_t)168U;
-  size_t mid;
-  if ((size_t)168U >= out_len) {
-    mid = out_len;
-  } else {
-    mid = (size_t)168U;
-  }
-  libcrux_iot_sha3_state_store_18_60(
-      self->inner, Eurydice_slice_subslice_to_mut_72(out, mid));
-  size_t offset = mid;
-  for (size_t i = (size_t)1U; i < blocks; i++) {
-    libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-    libcrux_iot_sha3_state_store_18_60(
-        self->inner,
-        Eurydice_slice_subslice_mut_c8(
-            out, (KRML_CLITERAL(core_ops_range_Range_87){
-                     .start = offset, .end = offset + (size_t)168U})));
-    offset += (size_t)168U;
-  }
-  if (last > (size_t)0U) {
-    if (last < out_len) {
-      libcrux_iot_sha3_keccak_keccakf1600(&self->inner);
-      libcrux_iot_sha3_state_store_18_60(
-          self->inner, Eurydice_slice_subslice_from_mut_6d(out, offset));
-    }
-  }
-  self->sponge = true;
+  libcrux_iot_sha3_keccak__squeeze_60(self, out);
 }
 
 /**
@@ -5374,28 +5678,30 @@ uint32_t from_c3(Algorithm v) {
 }
 
 /**
-This function found in impl {core::convert::From<u32> for
-libcrux_iot_sha3::Algorithm}
+This function found in impl {core::convert::TryFrom<u32,
+libcrux_iot_sha3::UnknownAlgorithm> for libcrux_iot_sha3::Algorithm}
 */
-Algorithm from_c2(uint32_t v) {
+core_result_Result_20 try_from_72(uint32_t v) {
   switch (v) {
     case 1U: {
       break;
     }
     case 2U: {
-      return libcrux_iot_sha3_Algorithm_Sha256;
+      return (KRML_CLITERAL(core_result_Result_20){
+          .tag = core_result_Ok, .f0 = libcrux_iot_sha3_Algorithm_Sha256});
     }
     case 3U: {
-      return libcrux_iot_sha3_Algorithm_Sha384;
+      return (KRML_CLITERAL(core_result_Result_20){
+          .tag = core_result_Ok, .f0 = libcrux_iot_sha3_Algorithm_Sha384});
     }
     case 4U: {
-      return libcrux_iot_sha3_Algorithm_Sha512;
+      return (KRML_CLITERAL(core_result_Result_20){
+          .tag = core_result_Ok, .f0 = libcrux_iot_sha3_Algorithm_Sha512});
     }
     default: {
-      KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
-                        "panic!");
-      KRML_HOST_EXIT(255U);
+      return (KRML_CLITERAL(core_result_Result_20){.tag = core_result_Err});
     }
   }
-  return libcrux_iot_sha3_Algorithm_Sha224;
+  return (KRML_CLITERAL(core_result_Result_20){
+      .tag = core_result_Ok, .f0 = libcrux_iot_sha3_Algorithm_Sha224});
 }

--- a/c/sha3/extracted/libcrux_iot_sha3.c
+++ b/c/sha3/extracted/libcrux_iot_sha3.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */
 
 #include "internal/libcrux_iot_sha3.h"

--- a/c/sha3/extracted/libcrux_iot_sha3.h
+++ b/c/sha3/extracted/libcrux_iot_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: dirty
  */
 
 #ifndef libcrux_iot_sha3_H
@@ -77,7 +77,7 @@ Eurydice_arr_a2 sha224(Eurydice_borrow_slice_u8 payload);
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 data);
+Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 payload);
 
 /**
  Returns SHA3-384 digest of input payload.
@@ -85,7 +85,7 @@ Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 data);
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 data);
+Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 payload);
 
 /**
  Returns SHA3-512 digest of input payload.
@@ -93,7 +93,7 @@ Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 data);
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_c7 sha512(Eurydice_borrow_slice_u8 data);
+Eurydice_arr_c7 sha512(Eurydice_borrow_slice_u8 payload);
 
 /**
  Writes SHAKE-128 digest of input payload to externally allocated buffer.

--- a/c/sha3/extracted/libcrux_iot_sha3.h
+++ b/c/sha3/extracted/libcrux_iot_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: dirty
+ * Libcrux: 13da43b0743fda614a8594c77db10c3da11f539d
  */
 
 #ifndef libcrux_iot_sha3_H

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Incremental.Bundle.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Incremental.Bundle.fst
@@ -187,16 +187,7 @@ let impl_3: t_Xof t_Shake128Xof (mk_usize 168) =
     f_absorb_pre
     =
     (fun (self_: t_Shake128Xof) (input: t_Slice u8) ->
-        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 168 &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 input <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len
-            <:
-            Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int));
+        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 168);
     f_absorb_post = (fun (self: t_Shake128Xof) (input: t_Slice u8) (out: t_Shake128Xof) -> true);
     f_absorb
     =
@@ -213,16 +204,7 @@ let impl_3: t_Xof t_Shake128Xof (mk_usize 168) =
     f_absorb_final_pre
     =
     (fun (self_: t_Shake128Xof) (input: t_Slice u8) ->
-        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 168 &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 input <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len
-            <:
-            Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int));
+        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 168);
     f_absorb_final_post
     =
     (fun (self: t_Shake128Xof) (input: t_Slice u8) (out: t_Shake128Xof) -> true);
@@ -272,16 +254,7 @@ let impl_4: t_Xof t_Shake256Xof (mk_usize 136) =
     f_absorb_pre
     =
     (fun (self_: t_Shake256Xof) (input: t_Slice u8) ->
-        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 136 &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 input <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len
-            <:
-            Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int));
+        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 136);
     f_absorb_post = (fun (self: t_Shake256Xof) (input: t_Slice u8) (out: t_Shake256Xof) -> true);
     f_absorb
     =
@@ -298,16 +271,7 @@ let impl_4: t_Xof t_Shake256Xof (mk_usize 136) =
     f_absorb_final_pre
     =
     (fun (self_: t_Shake256Xof) (input: t_Slice u8) ->
-        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 136 &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 input <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len
-            <:
-            Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int));
+        self_.f_state.Libcrux_iot_sha3.Keccak.f_buf_len <. mk_usize 136);
     f_absorb_final_post
     =
     (fun (self: t_Shake256Xof) (input: t_Slice u8) (out: t_Shake256Xof) -> true);

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
@@ -45,14 +45,14 @@ let impl__new (v_RATE: usize) (_: Prims.unit) : t_KeccakXofState v_RATE =
 let impl__fill_buffer (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t_Slice u8)
     : Prims.Pure (t_KeccakXofState v_RATE & usize)
       (requires
-        self.f_buf_len <=. v_RATE &&
         ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
             <:
             Hax_lib.Int.t_Int) +
           (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
           <:
           Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int))
+        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int) &&
+        self.f_buf_len <. v_RATE)
       (ensures
         fun temp_0_ ->
           let (self_e_future: t_KeccakXofState v_RATE), (res: usize) = temp_0_ in
@@ -852,13 +852,13 @@ let impl__absorb_full (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t
         fun temp_0_ ->
           let (self_e_future: t_KeccakXofState v_RATE), (remainder: usize) = temp_0_ in
           remainder <. v_RATE && remainder <=. (Core_models.Slice.impl__len #u8 inputs <: usize) &&
-          self_e_future.f_buf_len <=. v_RATE &&
           ((Rust_primitives.Hax.Int.from_machine self_e_future.f_buf_len <: Hax_lib.Int.t_Int) +
             (Rust_primitives.Hax.Int.from_machine remainder <: Hax_lib.Int.t_Int)
             <:
             Hax_lib.Int.t_Int) <
           (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int
-          )) =
+          ) &&
+          self_e_future.f_buf_len <. v_RATE) =
   let _:Prims.unit =
     if true
     then

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
@@ -44,26 +44,17 @@ let impl__new (v_RATE: usize) (_: Prims.unit) : t_KeccakXofState v_RATE =
 /// loaded.
 let impl__fill_buffer (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t_Slice u8)
     : Prims.Pure (t_KeccakXofState v_RATE & usize)
-      (requires
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int) &&
-        self.f_buf_len <. v_RATE)
+      (requires self.f_buf_len <. v_RATE)
       (ensures
         fun temp_0_ ->
           let (self_e_future: t_KeccakXofState v_RATE), (res: usize) = temp_0_ in
-          b2t (res <=. v_RATE <: bool) /\ b2t (self_e_future.f_buf_len <=. v_RATE <: bool) /\
-          (b2t (res >. mk_usize 0 <: bool) ==> b2t (self_e_future.f_buf_len =. v_RATE <: bool))) =
+          res <=. v_RATE && self_e_future.f_buf_len <=. v_RATE) =
   let input_len:usize = Core_models.Slice.impl__len #u8 inputs in
   let consumed:usize = mk_usize 0 in
   let (consumed: usize), (self: t_KeccakXofState v_RATE) =
     if self.f_buf_len >. mk_usize 0
     then
-      if (self.f_buf_len +! input_len <: usize) >=. v_RATE
+      if input_len >=. (v_RATE -! self.f_buf_len <: usize)
       then
         let consumed:usize = v_RATE -! self.f_buf_len in
         let self:t_KeccakXofState v_RATE =
@@ -840,24 +831,11 @@ let impl__absorb_full (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t
       (requires
         v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
         v_RATE <=. mk_usize 168 &&
-        self.f_buf_len <. v_RATE &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int))
+        self.f_buf_len <. v_RATE)
       (ensures
         fun temp_0_ ->
           let (self_e_future: t_KeccakXofState v_RATE), (remainder: usize) = temp_0_ in
           remainder <. v_RATE && remainder <=. (Core_models.Slice.impl__len #u8 inputs <: usize) &&
-          ((Rust_primitives.Hax.Int.from_machine self_e_future.f_buf_len <: Hax_lib.Int.t_Int) +
-            (Rust_primitives.Hax.Int.from_machine remainder <: Hax_lib.Int.t_Int)
-            <:
-            Hax_lib.Int.t_Int) <
-          (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int
-          ) &&
           self_e_future.f_buf_len <. v_RATE) =
   let _:Prims.unit =
     if true
@@ -942,14 +920,7 @@ let impl__absorb (v_RATE: usize) (self: t_KeccakXofState v_RATE) (inputs: t_Slic
       (requires
         v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
         v_RATE <=. mk_usize 168 &&
-        self.f_buf_len <. v_RATE &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int))
+        self.f_buf_len <. v_RATE)
       (fun _ -> Prims.l_True) =
   let (tmp0: t_KeccakXofState v_RATE), (out: usize) = impl__absorb_full v_RATE self inputs in
   let self:t_KeccakXofState v_RATE = tmp0 in
@@ -1021,14 +992,7 @@ let impl__absorb_final
       (requires
         v_RATE >. mk_usize 0 && (v_RATE %! mk_usize 8 <: usize) =. mk_usize 0 &&
         v_RATE <=. mk_usize 168 &&
-        self.f_buf_len <. v_RATE &&
-        ((Rust_primitives.Hax.Int.from_machine (Core_models.Slice.impl__len #u8 inputs <: usize)
-            <:
-            Hax_lib.Int.t_Int) +
-          (Rust_primitives.Hax.Int.from_machine self.f_buf_len <: Hax_lib.Int.t_Int)
-          <:
-          Hax_lib.Int.t_Int) <=
-        (Rust_primitives.Hax.Int.from_machine Core_models.Num.impl_usize__MAX <: Hax_lib.Int.t_Int))
+        self.f_buf_len <. v_RATE)
       (fun _ -> Prims.l_True) =
   let (tmp0: t_KeccakXofState v_RATE), (out: usize) = impl__absorb_full v_RATE self inputs in
   let self:t_KeccakXofState v_RATE = tmp0 in

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.Keccak.fst
@@ -1564,13 +1564,7 @@ let keccak (v_RATE: usize) (v_DELIM: u8) (data out: t_Slice u8)
       (fun temp_0_ e_i ->
           let (s: Libcrux_iot_sha3.State.t_KeccakState), (start: usize) = temp_0_ in
           let e_i:usize = e_i in
-          (Rust_primitives.Hax.Int.from_machine start <: Hax_lib.Int.t_Int) =
-          ((Rust_primitives.Hax.Int.from_machine e_i <: Hax_lib.Int.t_Int) *
-            (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
-            <:
-            Hax_lib.Int.t_Int)
-          <:
-          bool)
+          start =. (e_i *! v_RATE <: usize) <: bool)
       (s, start <: (Libcrux_iot_sha3.State.t_KeccakState & usize))
       (fun temp_0_ e_i ->
           let (s: Libcrux_iot_sha3.State.t_KeccakState), (start: usize) = temp_0_ in
@@ -1603,13 +1597,7 @@ let keccak (v_RATE: usize) (v_DELIM: u8) (data out: t_Slice u8)
               in
               let e_i:usize = e_i in
               ((Core_models.Slice.impl__len #u8 out <: usize) =. outlen <: bool) &&
-              ((Rust_primitives.Hax.Int.from_machine offset <: Hax_lib.Int.t_Int) =
-                ((Rust_primitives.Hax.Int.from_machine e_i <: Hax_lib.Int.t_Int) *
-                  (Rust_primitives.Hax.Int.from_machine v_RATE <: Hax_lib.Int.t_Int)
-                  <:
-                  Hax_lib.Int.t_Int)
-                <:
-                bool))
+              (offset =. (e_i *! v_RATE <: usize) <: bool))
           (offset, out, s <: (usize & t_Slice u8 & Libcrux_iot_sha3.State.t_KeccakState))
           (fun temp_0_ e_i ->
               let (offset: usize), (out: t_Slice u8), (s: Libcrux_iot_sha3.State.t_KeccakState) =

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.fst
@@ -422,6 +422,15 @@ let hash (v_LEN: usize) (algorithm: t_Algorithm) (payload: t_Slice u8)
       in
       ()
   in
+  let _:Prims.unit =
+    if true
+    then
+      let _:Prims.unit =
+        match v_LEN, digest_size algorithm <: (usize & usize) with
+        | left_val, right_val -> Hax_lib.v_assert (left_val =. right_val <: bool)
+      in
+      ()
+  in
   let out:t_Array u8 v_LEN =
     Libcrux_secrets.Traits.f_classify #(t_Array u8 v_LEN)
       #FStar.Tactics.Typeclasses.solve

--- a/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.fst
+++ b/libcrux-iot/sha3/proofs/fstar/extraction/Libcrux_iot_sha3.fst
@@ -44,46 +44,107 @@ let t_Algorithm_cast_to_repr (x: t_Algorithm) : u32 =
   | Algorithm_Sha384  -> anon_const_Algorithm_Sha384__anon_const_0
   | Algorithm_Sha512  -> anon_const_Algorithm_Sha512__anon_const_0
 
-let impl_2: Core_models.Clone.t_Clone t_Algorithm =
+let impl_3: Core_models.Clone.t_Clone t_Algorithm =
   { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
-val impl_1': Core_models.Marker.t_Copy t_Algorithm
+val impl_2': Core_models.Marker.t_Copy t_Algorithm
 
 unfold
-let impl_1 = impl_1'
+let impl_2 = impl_2'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
-val impl_3': Core_models.Fmt.t_Debug t_Algorithm
-
-unfold
-let impl_3 = impl_3'
-
-[@@ FStar.Tactics.Typeclasses.tcinstance]
-assume
-val impl_4': Core_models.Marker.t_StructuralPartialEq t_Algorithm
+val impl_4': Core_models.Fmt.t_Debug t_Algorithm
 
 unfold
 let impl_4 = impl_4'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
-val impl_5': Core_models.Cmp.t_PartialEq t_Algorithm t_Algorithm
+val impl_5': Core_models.Marker.t_StructuralPartialEq t_Algorithm
 
 unfold
 let impl_5 = impl_5'
 
 [@@ FStar.Tactics.Typeclasses.tcinstance]
 assume
-val impl_6': Core_models.Convert.t_From t_Algorithm u32
+val impl_6': Core_models.Cmp.t_PartialEq t_Algorithm t_Algorithm
 
 unfold
 let impl_6 = impl_6'
 
+/// Error returned when a `u32` does not correspond to an [`Algorithm`].
+type t_UnknownAlgorithm = | UnknownAlgorithm : t_UnknownAlgorithm
+
+let impl_8: Core_models.Clone.t_Clone t_UnknownAlgorithm =
+  { f_clone = (fun x -> x); f_clone_pre = (fun _ -> True); f_clone_post = (fun _ _ -> True) }
+
 [@@ FStar.Tactics.Typeclasses.tcinstance]
-let impl: Core_models.Convert.t_From u32 t_Algorithm =
+assume
+val impl_7': Core_models.Marker.t_Copy t_UnknownAlgorithm
+
+unfold
+let impl_7 = impl_7'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_9': Core_models.Fmt.t_Debug t_UnknownAlgorithm
+
+unfold
+let impl_9 = impl_9'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_10': Core_models.Marker.t_StructuralPartialEq t_UnknownAlgorithm
+
+unfold
+let impl_10 = impl_10'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+assume
+val impl_11': Core_models.Cmp.t_PartialEq t_UnknownAlgorithm t_UnknownAlgorithm
+
+unfold
+let impl_11 = impl_11'
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl: Core_models.Convert.t_TryFrom t_Algorithm u32 =
+  {
+    f_Error = t_UnknownAlgorithm;
+    f_try_from_pre = (fun (v: u32) -> true);
+    f_try_from_post
+    =
+    (fun (v: u32) (out: Core_models.Result.t_Result t_Algorithm t_UnknownAlgorithm) -> true);
+    f_try_from
+    =
+    fun (v: u32) ->
+      match v <: u32 with
+      | Rust_primitives.Integers.MkInt 1 ->
+        Core_models.Result.Result_Ok (Algorithm_Sha224 <: t_Algorithm)
+        <:
+        Core_models.Result.t_Result t_Algorithm t_UnknownAlgorithm
+      | Rust_primitives.Integers.MkInt 2 ->
+        Core_models.Result.Result_Ok (Algorithm_Sha256 <: t_Algorithm)
+        <:
+        Core_models.Result.t_Result t_Algorithm t_UnknownAlgorithm
+      | Rust_primitives.Integers.MkInt 3 ->
+        Core_models.Result.Result_Ok (Algorithm_Sha384 <: t_Algorithm)
+        <:
+        Core_models.Result.t_Result t_Algorithm t_UnknownAlgorithm
+      | Rust_primitives.Integers.MkInt 4 ->
+        Core_models.Result.Result_Ok (Algorithm_Sha512 <: t_Algorithm)
+        <:
+        Core_models.Result.t_Result t_Algorithm t_UnknownAlgorithm
+      | _ ->
+        Core_models.Result.Result_Err (UnknownAlgorithm <: t_UnknownAlgorithm)
+        <:
+        Core_models.Result.t_Result t_Algorithm t_UnknownAlgorithm
+  }
+
+[@@ FStar.Tactics.Typeclasses.tcinstance]
+let impl_1: Core_models.Convert.t_From u32 t_Algorithm =
   {
     f_from_pre = (fun (v: t_Algorithm) -> true);
     f_from_post = (fun (v: t_Algorithm) (out: u32) -> true);

--- a/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Traits.fst
+++ b/libcrux-iot/sha3/proofs/fstar/secrets/Libcrux_secrets.Traits.fst
@@ -43,57 +43,57 @@ let impl_Scalar_for_i128: t_Scalar i128 = { _super_i0 = FStar.Tactics.Typeclasse
 
 /// A trait for integer operations provided by Rust for machine integers
 class t_IntOps (v_Self: Type0) = {
-  f_wrapping_add_pre:#v_T: Type0 -> {| i1: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
+  f_wrapping_add_pre:#v_T: Type0 -> {| i0: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
     -> Type0;
   f_wrapping_add_post:
       #v_T: Type0 ->
-      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
       v_Self ->
       v_T ->
       v_Self
     -> Type0;
   f_wrapping_add:
       #v_T: Type0 ->
-      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
       x0: v_Self ->
       x1: v_T
     -> Prims.Pure v_Self
-        (f_wrapping_add_pre #v_T #i1 x0 x1)
-        (fun result -> f_wrapping_add_post #v_T #i1 x0 x1 result);
-  f_wrapping_sub_pre:#v_T: Type0 -> {| i1: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
+        (f_wrapping_add_pre #v_T #i0 x0 x1)
+        (fun result -> f_wrapping_add_post #v_T #i0 x0 x1 result);
+  f_wrapping_sub_pre:#v_T: Type0 -> {| i0: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
     -> Type0;
   f_wrapping_sub_post:
       #v_T: Type0 ->
-      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
       v_Self ->
       v_T ->
       v_Self
     -> Type0;
   f_wrapping_sub:
       #v_T: Type0 ->
-      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
       x0: v_Self ->
       x1: v_T
     -> Prims.Pure v_Self
-        (f_wrapping_sub_pre #v_T #i1 x0 x1)
-        (fun result -> f_wrapping_sub_post #v_T #i1 x0 x1 result);
-  f_wrapping_mul_pre:#v_T: Type0 -> {| i1: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
+        (f_wrapping_sub_pre #v_T #i0 x0 x1)
+        (fun result -> f_wrapping_sub_post #v_T #i0 x0 x1 result);
+  f_wrapping_mul_pre:#v_T: Type0 -> {| i0: Core_models.Convert.t_Into v_T v_Self |} -> v_Self -> v_T
     -> Type0;
   f_wrapping_mul_post:
       #v_T: Type0 ->
-      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
       v_Self ->
       v_T ->
       v_Self
     -> Type0;
   f_wrapping_mul:
       #v_T: Type0 ->
-      {| i1: Core_models.Convert.t_Into v_T v_Self |} ->
+      {| i0: Core_models.Convert.t_Into v_T v_Self |} ->
       x0: v_Self ->
       x1: v_T
     -> Prims.Pure v_Self
-        (f_wrapping_mul_pre #v_T #i1 x0 x1)
-        (fun result -> f_wrapping_mul_post #v_T #i1 x0 x1 result);
+        (f_wrapping_mul_pre #v_T #i0 x0 x1)
+        (fun result -> f_wrapping_mul_post #v_T #i0 x0 x1 result);
   f_wrapping_neg_pre:v_Self -> Type0;
   f_wrapping_neg_post:v_Self -> v_Self -> Type0;
   f_wrapping_neg:x0: v_Self
@@ -146,7 +146,7 @@ let impl_12: t_Scalar Core_models.Core_arch.X86.t_e_ee_m256 =
 
 /// A trait for public types that can be classified into secret types
 class t_Classify (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_Classified:Type0;
+  f_Classified:Type0;
   f_classify_pre:v_Self -> Type0;
   f_classify_post:v_Self -> f_Classified -> Type0;
   f_classify:x0: v_Self
@@ -155,7 +155,7 @@ class t_Classify (v_Self: Type0) = {
 
 /// A trait for classifying immutable references to public types
 class t_ClassifyRef (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_ClassifiedRef:Type0;
+  f_ClassifiedRef:Type0;
   f_classify_ref_pre:v_Self -> Type0;
   f_classify_ref_post:v_Self -> f_ClassifiedRef -> Type0;
   f_classify_ref:x0: v_Self
@@ -166,7 +166,7 @@ class t_ClassifyRef (v_Self: Type0) = {
 
 /// A trait for declassifying secret types into public types
 class t_Declassify (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_Declassified:Type0;
+  f_Declassified:Type0;
   f_declassify_pre:v_Self -> Type0;
   f_declassify_post:v_Self -> f_Declassified -> Type0;
   f_declassify:x0: v_Self
@@ -175,7 +175,7 @@ class t_Declassify (v_Self: Type0) = {
 
 /// A trait for declassifying references to secret types
 class t_DeclassifyRef (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_DeclassifiedRef:Type0;
+  f_DeclassifiedRef:Type0;
   f_declassify_ref_pre:v_Self -> Type0;
   f_declassify_ref_post:v_Self -> f_DeclassifiedRef -> Type0;
   f_declassify_ref:x0: v_Self
@@ -186,7 +186,7 @@ class t_DeclassifyRef (v_Self: Type0) = {
 
 /// A trait for classifying mutable references to public types
 class t_ClassifyRefMut (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_ClassifiedRefMut:Type0;
+  f_ClassifiedRefMut:Type0;
   f_classify_ref_mut_pre:v_Self -> Type0;
   f_classify_ref_mut_post:v_Self -> f_ClassifiedRefMut -> Type0;
   f_classify_ref_mut:x0: v_Self
@@ -197,7 +197,7 @@ class t_ClassifyRefMut (v_Self: Type0) = {
 
 /// A trait for declassifying mutable references to secret types
 class t_DeclassifyRefMut (v_Self: Type0) = {
-  [@@@ FStar.Tactics.Typeclasses.no_method]f_DeclassifiedRefMut:Type0;
+  f_DeclassifiedRefMut:Type0;
   f_declassify_ref_mut_pre:v_Self -> Type0;
   f_declassify_ref_mut_post:v_Self -> f_DeclassifiedRefMut -> Type0;
   f_declassify_ref_mut:x0: v_Self

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -2685,7 +2685,7 @@ pub(crate) fn keccak<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut 
 
     let mut start = 0;
     for _i in 0..n {
-        hax_lib::loop_invariant!(|_i: usize| { start.to_int() == _i.to_int() * RATE.to_int() });
+        hax_lib::loop_invariant!(|_i: usize| { start == _i * RATE });
 
         absorb_block::<RATE>(&mut s, &data, start);
         start += RATE;
@@ -2700,7 +2700,7 @@ pub(crate) fn keccak<const RATE: usize, const DELIM: u8>(data: &[U8], out: &mut 
         let mut offset = RATE;
         for _i in 1..blocks {
             hax_lib::loop_invariant!(|_i: usize| {
-                out.len() == outlen && offset.to_int() == _i.to_int() * RATE.to_int()
+                out.len() == outlen && offset == _i * RATE
             });
             squeeze_next_block::<RATE>(&mut s, &mut out[offset..]);
             offset += RATE;

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -86,8 +86,8 @@ impl<const RATE: usize> KeccakXofState<RATE> {
     #[hax_lib::ensures(|remainder|
         remainder < RATE
         && remainder <= inputs.len()
-        && future(self).buf_len <= RATE
         && future(self).buf_len.to_int() + remainder.to_int() < usize::MAX.to_int()
+        && future(self).buf_len < RATE
     )]
     fn absorb_full(&mut self, inputs: &[U8]) -> usize {
         #[cfg(not(eurydice))]
@@ -133,8 +133,8 @@ impl<const RATE: usize> KeccakXofState<RATE> {
     /// If `consumed > 0` is returned, `self.buf` contains a full block to be
     /// loaded.
     #[hax_lib::requires(
-        self.buf_len <= RATE &&
         inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
+        && self.buf_len < RATE 
     )]
     #[hax_lib::ensures(|res|
         (res <= RATE).to_prop()

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -2,7 +2,7 @@
 //! sub-routines.
 
 #[cfg(hax)]
-use hax_lib::{ToInt, ToProp};
+use hax_lib::ToInt;
 use libcrux_secrets::{Classify, U8};
 #[cfg(feature = "check-secret-independence")]
 use libcrux_secrets::{Declassify, U32};
@@ -55,8 +55,7 @@ impl<const RATE: usize> KeccakXofState<RATE> {
         RATE > 0 &&
         RATE % 8 == 0 &&
         RATE <= 168 &&
-        self.buf_len < RATE &&
-        inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
+        self.buf_len < RATE 
     )]
     pub(crate) fn absorb(&mut self, inputs: &[U8]) {
         let input_remainder_len = self.absorb_full(inputs);
@@ -80,13 +79,11 @@ impl<const RATE: usize> KeccakXofState<RATE> {
         RATE > 0 &&
         RATE % 8 == 0 &&
         RATE <= 168 &&
-        self.buf_len < RATE &&
-        inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
+        self.buf_len < RATE
     )]
     #[hax_lib::ensures(|remainder|
         remainder < RATE
         && remainder <= inputs.len()
-        && future(self).buf_len.to_int() + remainder.to_int() < usize::MAX.to_int()
         && future(self).buf_len < RATE
     )]
     fn absorb_full(&mut self, inputs: &[U8]) -> usize {
@@ -133,20 +130,18 @@ impl<const RATE: usize> KeccakXofState<RATE> {
     /// If `consumed > 0` is returned, `self.buf` contains a full block to be
     /// loaded.
     #[hax_lib::requires(
-        inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
-        && self.buf_len < RATE 
+        self.buf_len < RATE 
     )]
     #[hax_lib::ensures(|res|
-        (res <= RATE).to_prop()
-        & (future(self).buf_len <= RATE).to_prop()
-        & hax_lib::implies(res > 0, future(self).buf_len == RATE)
+        res <= RATE
+        && future(self).buf_len <= RATE
     )]
     fn fill_buffer(&mut self, inputs: &[U8]) -> usize {
         let input_len = inputs.len();
         let mut consumed = 0;
         if self.buf_len > 0 {
             // There's something buffered internally to consume.
-            if self.buf_len + input_len >= RATE {
+            if input_len >= RATE - self.buf_len {
                 // We have enough data when combining the internal buffer and
                 // the input.
                 consumed = RATE - self.buf_len;
@@ -166,8 +161,7 @@ impl<const RATE: usize> KeccakXofState<RATE> {
         RATE > 0 &&
         RATE % 8 == 0 &&
         RATE <= 168 &&
-        self.buf_len < RATE &&
-        inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()
+        self.buf_len < RATE 
     )]
     pub(crate) fn absorb_final<const DELIMITER: u8>(&mut self, inputs: &[U8]) {
         let input_remainder_len = self.absorb_full(inputs);

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -140,6 +140,8 @@ pub const fn digest_size(mode: Algorithm) -> usize {
 pub fn hash<const LEN: usize>(algorithm: Algorithm, payload: &[U8]) -> [U8; LEN] {
     #[cfg(not(eurydice))]
     debug_assert!(payload.len() <= u32::MAX as usize);
+    #[cfg(not(eurydice))]
+    debug_assert_eq!(LEN, digest_size(algorithm));
 
     let mut out = [0u8; LEN].classify();
 

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -352,8 +352,6 @@ pub fn shake256_ema(out: &mut [U8], data: &[U8]) {
 
 /// Incremental API for SHAKE XOFs
 pub mod incremental {
-    #[cfg(hax)]
-    use hax_lib::ToInt;
     use libcrux_secrets::U8;
 
     /// An unbuffered XOF state.

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -438,18 +438,12 @@ pub mod incremental {
                 state: KeccakXofState::<168>::new(),
             }
         }
-        #[hax_lib::requires(
-            self.state.buf_len < 168
-            && input.len().to_int() + self.state.buf_len.to_int() <= usize::MAX.to_int()
-        )]
+        #[hax_lib::requires(self.state.buf_len < 168)]
         fn absorb(&mut self, input: &[U8]) {
             self.state.absorb(input);
         }
 
-        #[hax_lib::requires(
-            self.state.buf_len < 168
-            && input.len().to_int() + self.state.buf_len.to_int() <= usize::MAX.to_int()
-        )]
+        #[hax_lib::requires(self.state.buf_len < 168)]
         fn absorb_final(&mut self, input: &[U8]) {
             self.state.absorb_final::<0x1fu8>(input);
         }
@@ -469,16 +463,12 @@ pub mod incremental {
 
         #[hax_lib::requires(
             self.state.buf_len < 136
-            && input.len().to_int() + self.state.buf_len.to_int() <= usize::MAX.to_int()
         )]
         fn absorb(&mut self, input: &[U8]) {
             self.state.absorb(input);
         }
 
-        #[hax_lib::requires(
-            self.state.buf_len < 136
-            && input.len().to_int() + self.state.buf_len.to_int() <= usize::MAX.to_int()
-        )]
+        #[hax_lib::requires(self.state.buf_len < 136)]
         fn absorb_final(&mut self, input: &[U8]) {
             self.state.absorb_final::<0x1fu8>(input);
         }

--- a/libcrux-iot/sha3/src/lib.rs
+++ b/libcrux-iot/sha3/src/lib.rs
@@ -87,15 +87,20 @@ pub enum Algorithm {
     Sha512 = 4,
 }
 
-#[hax_lib::opaque]
-impl From<u32> for Algorithm {
-    fn from(v: u32) -> Algorithm {
+/// Error returned when a `u32` does not correspond to an [`Algorithm`].
+#[cfg_attr(not(eurydice), derive(Copy, Clone, Debug, PartialEq))]
+pub struct UnknownAlgorithm;
+
+impl TryFrom<u32> for Algorithm {
+    type Error = UnknownAlgorithm;
+
+    fn try_from(v: u32) -> Result<Algorithm, Self::Error> {
         match v {
-            1 => Algorithm::Sha224,
-            2 => Algorithm::Sha256,
-            3 => Algorithm::Sha384,
-            4 => Algorithm::Sha512,
-            _ => panic!(),
+            1 => Ok(Algorithm::Sha224),
+            2 => Ok(Algorithm::Sha256),
+            3 => Ok(Algorithm::Sha384),
+            4 => Ok(Algorithm::Sha512),
+            _ => Err(UnknownAlgorithm),
         }
     }
 }


### PR DESCRIPTION
This reduces the number of hax-lib annotations required for the SHA-3 panic freedom prove to go through. 

The main change is in the second commit, which changes an if condition in `fill_buffer`.
```diff
- if self.buf_len + input_len >= RATE {
+ if input_len >= RATE - self.buf_len {
```

With the previous version, the addition could panic on overflow which required extensive requires clauses `inputs.len().to_int() + self.buf_len.to_int() <= usize::MAX.to_int()` for a large part of the call stack.

By rewriting the condition to avoid the potential overflow, we can get rid of these requires.

I've also changed the panicking `From<u32>` impl for `Algorithm` a TryFrom one. Neither of which is used in libcrux-sha3 (or any downstream crates in iot as far as I can tell), but it is good practice to have fallible conversions implement TryFrom and not From. 