### PR TITLE
[sha3] remove unused cavp

### DIFF
--- a/libcrux-iot/Cargo.toml
+++ b/libcrux-iot/Cargo.toml
@@ -17,7 +17,6 @@ libcrux-secrets = { version = "0.0.5" }
 libcrux-macros = { version = "0.0.3" }
 libcrux-traits = { version = "0.0.6" }
 
-cavp = { version = "0.0.2" }
 hax-lib = { version = "0.3.6" }
 
 

--- a/libcrux-iot/sha3/Cargo.toml
+++ b/libcrux-iot/sha3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libcrux-iot-sha3"
 description = "Libcrux-IoT SHA-3 implementation"
-exclude = ["/c.sh", "/c.yaml", "/tests/tv", "tests/cavp.rs"]
+exclude = ["/c.sh", "/c.yaml"]
 publish = false
 
 readme.workspace = true

--- a/libcrux-iot/sha3/Cargo.toml
+++ b/libcrux-iot/sha3/Cargo.toml
@@ -38,7 +38,6 @@ check-secret-independence = ["libcrux-secrets/check-secret-independence", "libcr
 criterion = "0.5.1"
 hex = "0.4.3"
 rand = "0.8.5"
-cavp.workspace = true #{ version = "0.0.2-beta.2", path = "../cavp" }
 pretty_env_logger = "0.5.0"
 libcrux-kats = { workspace = true, features = ["sha3"] }
 


### PR DESCRIPTION
Cavp is unused since #144 but was still added as a dependency.

I also cleaned up the sha3 Cargo.toml exclude field a little.