### PR TITLE
[sha3] lean flake and axiom check

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,35 @@
 {
   "nodes": {
+    "aeneas": {
+      "inputs": {
+        "charon": "charon",
+        "flake-utils": [
+          "aeneas",
+          "charon",
+          "flake-utils"
+        ],
+        "fstar": "fstar",
+        "nixpkgs": [
+          "aeneas",
+          "charon",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780478365,
+        "narHash": "sha256-m5VfyF7TLRhn8IkZtx8Dyf5rjok4/YUfc7wFNdyRFZk=",
+        "owner": "cryspen",
+        "repo": "aeneas",
+        "rev": "8d2077ce4946b52d2d199fe9d2f2d520a4bf8184",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cryspen",
+        "ref": "nightly-2026.06.04",
+        "repo": "aeneas",
+        "type": "github"
+      }
+    },
     "benchmark": {
       "flake": false,
       "locked": {
@@ -26,6 +56,28 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
+        "lastModified": 1780355287,
+        "narHash": "sha256-vjKj8972p0OWx6qCBxPJmT9HjSBmLg+Khrvlc37sucQ=",
+        "owner": "aeneasverif",
+        "repo": "charon",
+        "rev": "a535e914f74db4fd9e6be7048f4233270d8945c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aeneasverif",
+        "repo": "charon",
+        "type": "github"
+      }
+    },
+    "charon_2": {
+      "inputs": {
+        "crane": "crane_2",
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3",
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
         "lastModified": 1778592754,
         "narHash": "sha256-Q+zpB/CDXaYELfdHbE/MnkBL3gn17RQgAIa2WVPaKE8=",
         "owner": "aeneasverif",
@@ -39,13 +91,13 @@
         "type": "github"
       }
     },
-    "charon_2": {
+    "charon_3": {
       "inputs": {
-        "crane": "crane_2",
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay_2"
+        "crane": "crane_3",
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": "nixpkgs_4",
+        "rust-overlay": "rust-overlay_3"
       },
       "locked": {
         "lastModified": 1749845840,
@@ -109,11 +161,11 @@
     },
     "crane_3": {
       "locked": {
-        "lastModified": 1752625801,
-        "narHash": "sha256-T1XWEFfw+iNrvlRczZS4BkaZJ5W3Z2Xp+31P2IShJj8=",
+        "lastModified": 1743700120,
+        "narHash": "sha256-8BjG/P0xnuCyVOXlYRwdI1B8nVtyYLf3oDwPSimqREY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "471f8cd756349f4e86784ea10fdc9ccb91711fca",
+        "rev": "e316f19ee058e6db50075115783be57ac549c389",
         "type": "github"
       },
       "original": {
@@ -137,6 +189,36 @@
         "type": "github"
       }
     },
+    "crane_5": {
+      "locked": {
+        "lastModified": 1752625801,
+        "narHash": "sha256-T1XWEFfw+iNrvlRczZS4BkaZJ5W3Z2Xp+31P2IShJj8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "471f8cd756349f4e86784ea10fdc9ccb91711fca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_6": {
+      "locked": {
+        "lastModified": 1752625801,
+        "narHash": "sha256-T1XWEFfw+iNrvlRczZS4BkaZJ5W3Z2Xp+31P2IShJj8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "471f8cd756349f4e86784ea10fdc9ccb91711fca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "eurydice": {
       "inputs": {
         "benchmark": [
@@ -144,7 +226,7 @@
           "libcrux",
           "benchmark"
         ],
-        "charon": "charon",
+        "charon": "charon_2",
         "crane": [
           "eurydice",
           "charon",
@@ -190,7 +272,7 @@
     },
     "eurydice_2": {
       "inputs": {
-        "charon": "charon_2",
+        "charon": "charon_3",
         "flake-utils": [
           "eurydice",
           "libcrux",
@@ -251,6 +333,21 @@
         "type": "github"
       }
     },
+    "flake-compat_3": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -286,9 +383,96 @@
         "type": "indirect"
       }
     },
+    "flake-utils_11": {
+      "inputs": {
+        "systems": "systems_11"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_12": {
+      "inputs": {
+        "systems": "systems_12"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "flake-utils_13": {
+      "inputs": {
+        "systems": "systems_13"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_14": {
+      "inputs": {
+        "systems": "systems_14"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
     "flake-utils_2": {
       "inputs": {
         "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1726560853,
@@ -304,33 +488,16 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-utils",
-        "type": "indirect"
-      }
-    },
     "flake-utils_4": {
       "inputs": {
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -344,6 +511,23 @@
         "systems": "systems_5"
       },
       "locked": {
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "flake-utils_6": {
+      "inputs": {
+        "systems": "systems_6"
+      },
+      "locked": {
         "lastModified": 1731533236,
         "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
@@ -355,23 +539,6 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "type": "github"
-      }
-    },
-    "flake-utils_6": {
-      "inputs": {
-        "systems": "systems_6"
-      },
-      "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-utils",
-        "type": "indirect"
       }
     },
     "flake-utils_7": {
@@ -397,11 +564,11 @@
         "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -429,27 +596,27 @@
     },
     "fstar": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_3"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1748199801,
-        "narHash": "sha256-clP79o0NsSjoNi59GxHxfN8lfc+5BPQyWnriYceyoHg=",
-        "owner": "fstarlang",
+        "lastModified": 1773420322,
+        "narHash": "sha256-24p4oLISFCehrfYAXORuEm6WzvWgRMhoApYnwUjSfPM=",
+        "owner": "FStarLang",
         "repo": "fstar",
-        "rev": "ff868e03ee0d16303c514ae396706ba283b328a3",
+        "rev": "7c23ae87427d49f73626f3bd045d7980f00b2685",
         "type": "github"
       },
       "original": {
-        "owner": "fstarlang",
+        "owner": "FStarLang",
         "repo": "fstar",
         "type": "github"
       }
     },
     "fstar-pinned": {
       "inputs": {
-        "flake-utils": "flake-utils_8",
-        "nixpkgs": "nixpkgs_7"
+        "flake-utils": "flake-utils_10",
+        "nixpkgs": "nixpkgs_9"
       },
       "locked": {
         "lastModified": 1759777242,
@@ -468,8 +635,27 @@
     },
     "fstar_2": {
       "inputs": {
-        "flake-utils": "flake-utils_6",
-        "nixpkgs": "nixpkgs_4"
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1748199801,
+        "narHash": "sha256-clP79o0NsSjoNi59GxHxfN8lfc+5BPQyWnriYceyoHg=",
+        "owner": "fstarlang",
+        "repo": "fstar",
+        "rev": "ff868e03ee0d16303c514ae396706ba283b328a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fstarlang",
+        "repo": "fstar",
+        "type": "github"
+      }
+    },
+    "fstar_3": {
+      "inputs": {
+        "flake-utils": "flake-utils_8",
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1742959035,
@@ -486,10 +672,30 @@
         "type": "github"
       }
     },
-    "fstar_3": {
+    "fstar_4": {
       "inputs": {
-        "flake-utils": "flake-utils_10",
-        "nixpkgs": "nixpkgs_8"
+        "flake-utils": "flake-utils_12",
+        "nixpkgs": "nixpkgs_10"
+      },
+      "locked": {
+        "lastModified": 1759777242,
+        "narHash": "sha256-PH3ylEiUS+mfFtYV+KI7xrCewkEutM1c14A+ARsyOQY=",
+        "owner": "FStarLang",
+        "repo": "FStar",
+        "rev": "7b347386330d0e5a331a220535b6f15288903234",
+        "type": "github"
+      },
+      "original": {
+        "owner": "FStarLang",
+        "ref": "v2025.10.06",
+        "repo": "FStar",
+        "type": "github"
+      }
+    },
+    "fstar_5": {
+      "inputs": {
+        "flake-utils": "flake-utils_14",
+        "nixpkgs": "nixpkgs_12"
       },
       "locked": {
         "lastModified": 1759777242,
@@ -555,15 +761,31 @@
         "type": "github"
       }
     },
+    "hacl-star_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752721968,
+        "narHash": "sha256-CyQvUUT6kFBxG/cQYEt9xPipEsOa5OQg1B9iYILnVz0=",
+        "owner": "hacl-star",
+        "repo": "hacl-star",
+        "rev": "b75b1a44f4663b369209f93fb6b5744b3a6a709b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hacl-star",
+        "repo": "hacl-star",
+        "type": "github"
+      }
+    },
     "hax": {
       "inputs": {
-        "crane": "crane_3",
-        "flake-utils": "flake-utils_5",
-        "fstar": "fstar_2",
+        "crane": "crane_4",
+        "flake-utils": "flake-utils_7",
+        "fstar": "fstar_3",
         "hacl-star": "hacl-star",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_7",
         "rust-by-examples": "rust-by-examples",
-        "rust-overlay": "rust-overlay_3"
+        "rust-overlay": "rust-overlay_4"
       },
       "locked": {
         "lastModified": 1756124197,
@@ -579,15 +801,41 @@
         "type": "github"
       }
     },
+    "hax-evit": {
+      "inputs": {
+        "crane": "crane_6",
+        "flake-utils": "flake-utils_13",
+        "fstar": "fstar_5",
+        "hacl-star": "hacl-star_3",
+        "nixpkgs": "nixpkgs_13",
+        "rust-by-examples": "rust-by-examples_3",
+        "rust-overlay": "rust-overlay_6"
+      },
+      "locked": {
+        "lastModified": 1780913075,
+        "narHash": "sha256-nMGt3i5PyTtIuqu0z9hrLfK/SARyQz8EJgK6RB8tTsk=",
+        "ref": "refs/heads/main",
+        "rev": "1f85fc13b9967080cc657863e2000ba5d4aa8647",
+        "revCount": 5992,
+        "type": "git",
+        "url": "ssh://git@github.com/cryspen/hax-evit"
+      },
+      "original": {
+        "ref": "refs/heads/main",
+        "rev": "1f85fc13b9967080cc657863e2000ba5d4aa8647",
+        "type": "git",
+        "url": "ssh://git@github.com/cryspen/hax-evit"
+      }
+    },
     "hax_2": {
       "inputs": {
-        "crane": "crane_4",
-        "flake-utils": "flake-utils_9",
-        "fstar": "fstar_3",
+        "crane": "crane_5",
+        "flake-utils": "flake-utils_11",
+        "fstar": "fstar_4",
         "hacl-star": "hacl-star_2",
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_11",
         "rust-by-examples": "rust-by-examples_2",
-        "rust-overlay": "rust-overlay_4"
+        "rust-overlay": "rust-overlay_5"
       },
       "locked": {
         "lastModified": 1768469711,
@@ -661,7 +909,7 @@
           "fstar",
           "flake-utils"
         ],
-        "fstar": "fstar",
+        "fstar": "fstar_2",
         "nixpkgs": [
           "eurydice",
           "libcrux",
@@ -688,11 +936,11 @@
         "benchmark": "benchmark",
         "circus-green": "circus-green",
         "eurydice": "eurydice_2",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_6",
         "googletest": "googletest",
         "hax": "hax",
         "json": "json",
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1774355878,
@@ -725,6 +973,68 @@
     },
     "nixpkgs_10": {
       "locked": {
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1761999846,
+        "narHash": "sha256-IYlYnp4O4dzEpL77BD/lj5NnJy2J8qbHkNSFiPBCbqo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3de8f8d73e35724bf9abef41f1bdbedda1e14a31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_12": {
+      "locked": {
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_13": {
+      "locked": {
+        "lastModified": 1761999846,
+        "narHash": "sha256-IYlYnp4O4dzEpL77BD/lj5NnJy2J8qbHkNSFiPBCbqo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3de8f8d73e35724bf9abef41f1bdbedda1e14a31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_14": {
+      "locked": {
         "lastModified": 1778869304,
         "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
@@ -739,7 +1049,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_11": {
+    "nixpkgs_15": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -757,11 +1067,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743588408,
-        "narHash": "sha256-WRZyK13yucGjwNBMOGjU8ljRJ8FYFv8MBru/bXqZUn0=",
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88efe689298b1863db0310c0a22b3ebb4d04fbc3",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
         "type": "github"
       },
       "original": {
@@ -771,6 +1081,21 @@
       }
     },
     "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1762111121,
+        "narHash": "sha256-4vhDuZ7OZaZmKKrnDpxLZZpGIJvAeMtK6FKLJYUtAdw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1743588408,
         "narHash": "sha256-WRZyK13yucGjwNBMOGjU8ljRJ8FYFv8MBru/bXqZUn0=",
@@ -785,7 +1110,22 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1743588408,
+        "narHash": "sha256-WRZyK13yucGjwNBMOGjU8ljRJ8FYFv8MBru/bXqZUn0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "88efe689298b1863db0310c0a22b3ebb4d04fbc3",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1693158576,
         "narHash": "sha256-aRTTXkYvhXosGx535iAFUaoFboUrZSYb1Ooih/auGp0=",
@@ -800,7 +1140,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1752735392,
         "narHash": "sha256-6MVfahGRB3quXdoepoHP8AvMDGOxAGzSjF+PyR8qFR0=",
@@ -815,7 +1155,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1749794982,
         "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
@@ -831,60 +1171,31 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
-      "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-unstable",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_8": {
-      "locked": {
-        "lastModified": 1759381078,
-        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-unstable",
-        "type": "indirect"
-      }
-    },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1761999846,
-        "narHash": "sha256-IYlYnp4O4dzEpL77BD/lj5NnJy2J8qbHkNSFiPBCbqo=",
-        "owner": "nixos",
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3de8f8d73e35724bf9abef41f1bdbedda1e14a31",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-25.05",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
       }
     },
     "root": {
       "inputs": {
+        "aeneas": "aeneas",
         "eurydice": "eurydice",
-        "flake-utils": "flake-utils_7",
+        "flake-utils": "flake-utils_9",
         "fstar-pinned": "fstar-pinned",
         "hax": "hax_2",
-        "nixpkgs": "nixpkgs_10",
-        "rust-overlay": "rust-overlay_5"
+        "hax-evit": "hax-evit",
+        "nixpkgs": "nixpkgs_14",
+        "rust-overlay": "rust-overlay_7"
       }
     },
     "rust-by-examples": {
@@ -919,7 +1230,46 @@
         "type": "github"
       }
     },
+    "rust-by-examples_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1751671035,
+        "narHash": "sha256-QqhvYJg9Tox5m5a4+IfAvfNhASSADs5tkE14qrNK3dM=",
+        "owner": "rust-lang",
+        "repo": "rust-by-example",
+        "rev": "e386be5f44af711854207c11fdd61bb576270b04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "repo": "rust-by-example",
+        "type": "github"
+      }
+    },
     "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "aeneas",
+          "charon",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780284119,
+        "narHash": "sha256-y2wR4Mk6D/N1ID4FZa2oUMStCUxyIoRzmgOOpLzoWmo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "51390d0bfca0a68a8c337d215a4bbeddc2ca616e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "51390d0bfca0a68a8c337d215a4bbeddc2ca616e",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
       "inputs": {
         "nixpkgs": [
           "eurydice",
@@ -942,7 +1292,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_2": {
+    "rust-overlay_3": {
       "inputs": {
         "nixpkgs": [
           "eurydice",
@@ -967,7 +1317,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_3": {
+    "rust-overlay_4": {
       "inputs": {
         "nixpkgs": [
           "eurydice",
@@ -990,7 +1340,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_4": {
+    "rust-overlay_5": {
       "inputs": {
         "nixpkgs": [
           "hax",
@@ -1011,9 +1361,30 @@
         "type": "github"
       }
     },
-    "rust-overlay_5": {
+    "rust-overlay_6": {
       "inputs": {
-        "nixpkgs": "nixpkgs_11"
+        "nixpkgs": [
+          "hax-evit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762569282,
+        "narHash": "sha256-vINZAJpXQTZd5cfh06Rcw7hesH7sGSvi+Tn+HUieJn8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a35a6144b976f70827c2fe2f5c89d16d8f9179d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_7": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_15"
       },
       "locked": {
         "lastModified": 1779074409,
@@ -1045,6 +1416,66 @@
       }
     },
     "systems_10": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_11": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_12": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_13": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_14": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,20 @@
     eurydice.inputs.karamel.inputs.fstar.follows = "fstar-pinned";
     hax.url = "github:hacspec/hax/87ba96831ecfeb7dbb54efcf97036fbc5f25bc71";
     fstar-pinned.url = "github:FStarLang/FStar/v2025.10.06";
+
+    # --- Aeneas/Lean SHA-3 proof toolchain ---------------------------------
+    # Used only by the `aeneas-lean` devShell. Keep these revisions in sync
+    # with `libcrux-iot/sha3/proofs/aeneas-lean/{lean-toolchain,lakefile.toml}`
+    # and `libcrux-iot/sha3/hax_aeneas.py`.
+    #
+    # `hax-evit` is the private fork the Lean extraction requires. It is fetched
+    # over SSH, so the calling user needs read access (and an SSH key/agent
+    # configured) for `nix develop .#aeneas-lean` to evaluate.
+    hax-evit.url = "git+ssh://git@github.com/cryspen/hax-evit?ref=refs/heads/main&rev=1f85fc13b9967080cc657863e2000ba5d4aa8647";
+    # cryspen/aeneas@nightly-2026.06.04 == 8d2077c (matches AENEAS_VERSION in
+    # hax_aeneas.py). Its flake.lock pins the matching Charon nightly-2026.06.02,
+    # and its default package bundles a `charon` binary alongside `aeneas`.
+    aeneas.url = "github:cryspen/aeneas/nightly-2026.06.04";
   };
 
   outputs =
@@ -25,6 +39,7 @@
       eurydice,
       hax,
       fstar-pinned,
+      aeneas,
       ...
     }@inputs:
     flake-utils.lib.eachDefaultSystem (
@@ -62,6 +77,59 @@
             "rust-analyzer"
           ];
         };
+
+        # --- Aeneas/Lean toolchain (used by devShells.aeneas-lean) ----------
+        # `hax` and `aeneas` bake their version/commit into the binary at build
+        # time (hax via `env!("HAX_GIT_COMMIT_HASH")`, aeneas via a dune rule
+        # running `git describe`). Built from a Nix source tree (no `.git`),
+        # both report "unknown", so the version checks in `hax_aeneas.py` fail.
+        #
+        # We wrap each binary so the version query reports the flake-locked rev
+        # — the exact source Nix built — and pass every other invocation
+        # straight through. The reported value is taken from the lock, so it
+        # cannot drift from what is actually built.
+        haxEvitPkg = inputs.hax-evit.packages.${system}.default;
+        haxEvitRev = inputs.hax-evit.rev;
+        # `cargo hax --version` (clap long-version) is what the script greps for
+        # `commit=<rev>`; everything else passes through to the real binary.
+        haxVersionScript = pkgs.writeShellScript "cargo-hax" ''
+          case " $* " in
+            *" --version "*)
+              echo "hax"
+              echo "commit=${haxEvitRev}"
+              exit 0
+              ;;
+          esac
+          exec ${haxEvitPkg}/bin/cargo-hax "$@"
+        '';
+        haxEvit = pkgs.symlinkJoin {
+          name = "hax-evit-version-wrapped";
+          paths = [ haxEvitPkg ];
+          postBuild = ''
+            rm -f $out/bin/cargo-hax
+            install -m555 ${haxVersionScript} $out/bin/cargo-hax
+          '';
+        };
+
+        aeneasPkg = aeneas.packages.${system}.default;
+        aeneasRev = aeneas.rev;
+        aeneasVersionScript = pkgs.writeShellScript "aeneas" ''
+          case " $* " in
+            *" -version "*)
+              echo "aeneas ${aeneasRev}"
+              exit 0
+              ;;
+          esac
+          exec ${aeneasPkg}/bin/aeneas "$@"
+        '';
+        aeneasWrapped = pkgs.symlinkJoin {
+          name = "aeneas-version-wrapped";
+          paths = [ aeneasPkg ];
+          postBuild = ''
+            rm -f $out/bin/aeneas
+            install -m555 ${aeneasVersionScript} $out/bin/aeneas
+          '';
+        };
       in
       {
         devShells.default = pkgs.mkShell (
@@ -88,6 +156,41 @@
             LIBCLANG_PATH = "${pkgs.llvmPackages_18.libclang.lib}/lib";
           }
         );
+
+        # Toolchain for the SHA-3 Aeneas/Lean proof. Reproduces the
+        # "Reproduction" section of
+        # libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/README.md.
+        #
+        #   nix develop .#aeneas-lean
+        #
+        # Extraction (Rust -> Lean):
+        #   cd libcrux-iot/sha3 && ./hax_aeneas.py
+        # Proving:
+        #   cd libcrux-iot/sha3/proofs/aeneas-lean
+        #   lake exe cache get && lake build
+        devShells.aeneas-lean = pkgs.mkShell {
+          packages = [
+            # Extraction: `cargo hax into aeneas-lean` + Aeneas.
+            # Both are version-wrapped (see the `let` block) so the version
+            # checks in hax_aeneas.py pass against the flake-locked revs.
+            haxEvit # cargo-hax (+ bundled charon-driver)
+            aeneasWrapped # aeneas (+ bundled charon)
+            rustToolchain
+            pkgs.python3 # runs hax_aeneas.py
+
+            # Proving: elan provisions the pinned Lean toolchain (from the
+            # lean-toolchain file) and provides `lake`.
+            pkgs.elan
+
+            # Common build deps for lake / native crates.
+            pkgs.git
+            pkgs.curl
+            pkgs.cmake
+            pkgs.gmp
+            pkgs.pkg-config
+          ];
+          RUST_SRC_PATH = "${rustToolchain.outPath}/lib/rustlib/src/rust/library";
+        };
       }
     );
 }

--- a/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/AxiomCheck.lean
+++ b/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/AxiomCheck.lean
@@ -1,0 +1,48 @@
+import LibcruxIotSha3.Sponge.Shake
+
+/-!
+# Axiom hygiene regression check
+
+This module makes `lake build` **fail** if any of the six top-level digest
+specs comes to depend on `sorryAx` — i.e. on an admitted `sorry` anywhere in
+its proof tree, including the hand-written Aeneas stdlib models (e.g. the
+admitted `core.slice.Slice.get_unchecked` spec).
+
+It deliberately does *not* pin the full axiom set: that set legitimately
+includes many `bv_decide` axioms with hygienic (`✝`-suffixed) names that are
+not stable enough to match exactly. We only assert the soundness-critical
+property — no `sorry` — which is what `propext`/`Classical.choice`/`Quot.sound`
+and `bv_decide` are explicitly *not*.
+
+See the "Axiom hygiene" section of `README.md`.
+-/
+
+open Lean Elab Command
+
+/-- `#assert_no_sorry foo` errors (failing the build) if `foo` transitively
+depends on `sorryAx`. On success it logs a one-line confirmation with the
+total axiom count. -/
+syntax (name := assertNoSorry) "#assert_no_sorry " ident : command
+
+@[command_elab assertNoSorry]
+def elabAssertNoSorry : CommandElab := fun stx => do
+  match stx with
+  | `(#assert_no_sorry $id:ident) =>
+    let cs ← liftCoreM <| realizeGlobalConstWithInfos id
+    for c in cs do
+      let axioms ← collectAxioms c
+      if axioms.contains ``sorryAx then
+        throwError "AXIOM HYGIENE VIOLATION: '{c}' transitively depends on `sorryAx`"
+      logInfo m!"'{c}' is sorry-free ({axioms.size} axioms)"
+  | _ => throwUnsupportedSyntax
+
+namespace libcrux_iot_sha3.Sponge
+
+#assert_no_sorry shake128_spec
+#assert_no_sorry shake256_spec
+#assert_no_sorry sha224_ema_spec
+#assert_no_sorry sha256_ema_spec
+#assert_no_sorry sha384_ema_spec
+#assert_no_sorry sha512_ema_spec
+
+end libcrux_iot_sha3.Sponge

--- a/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/README.md
+++ b/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/README.md
@@ -55,6 +55,15 @@ The incremental API is not part of this verification.
 All of the top-level theorems report only standard Lean axioms (`propext`,
 `Classical.choice`, `Quot.sound`) plus `bv_decide`.
 
+This is enforced on every build by [`AxiomCheck.lean`](AxiomCheck.lean): it
+runs an `#assert_no_sorry` command on each of the six digest specs that fails
+the build if any of them comes to depend on `sorryAx` (an admitted `sorry`
+anywhere in the proof tree, including the hand-written Aeneas stdlib models).
+It checks only the soundness-critical `sorry` property, not the full axiom set
+(which contains hygienically-named `bv_decide` axioms that are not stable
+enough to pin exactly). To inspect the axioms of any declaration manually, use
+`#print axioms <name>`.
+
 
 ## Proof architecture
 

--- a/libcrux-iot/sha3/proofs/aeneas-lean/lake-manifest.json
+++ b/libcrux-iot/sha3/proofs/aeneas-lean/lake-manifest.json
@@ -11,7 +11,7 @@
    "inputRev": "b313344",
    "inherited": false,
    "configFile": "lakefile.toml"},
-  {"url": "https://github.com/cryspen/hax-evit",
+  {"url": "ssh://git@github.com/cryspen/hax-evit",
    "type": "git",
    "subDir": "hax-lib/proof-libs/aeneas-lean",
    "scope": "",

--- a/libcrux-iot/sha3/proofs/aeneas-lean/lakefile.toml
+++ b/libcrux-iot/sha3/proofs/aeneas-lean/lakefile.toml
@@ -8,7 +8,7 @@ globs = ["LibcruxIotSha3", "LibcruxIotSha3.+"]
 
 [[require]]
 name = "Hax"
-git = { url = "https://github.com/cryspen/hax-evit", subDir = "hax-lib/proof-libs/aeneas-lean" }
+git = { url = "ssh://git@github.com/cryspen/hax-evit", subDir = "hax-lib/proof-libs/aeneas-lean" }
 rev = "1f85fc13b9967080cc657863e2000ba5d4aa8647"
 
 [[require]]


### PR DESCRIPTION
I've added a aeneas-lean dev-shell to my flake.nix that can be used to extract and build the proof with the correct versions.

I've also added a small claude generated module that checks the top-level theorems for any transitive uses of admitted sorries and fails the build if that is the case. @abentkamp Are you fine with that addition or know of a better way to achieve this?