### PR TITLE
[sha3] lean proof refactors

### DIFF
--- a/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/Sponge/Keccak.lean
+++ b/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/Sponge/Keccak.lean
@@ -145,6 +145,42 @@ theorem iterate_keccak_f_zero
   show Nat.fold 0 _ _ = _
   rw [Nat.fold_zero]
 
+/-! ### Helper: `iterate_keccak_f` on a `BitVec.ofNat` count equals the fold.
+
+For `n ≤ Std.Usize.max`, wrapping `n` as a `Usize` loses no information, so
+`iterate_keccak_f ⟨BitVec.ofNat _ n⟩` agrees with `iterate_keccak_f_fold _ n`. -/
+theorem iterate_keccak_f_ofNat_eq_fold (n : Nat) (st : Std.Array Std.U64 25#usize)
+    (h_n_le : n ≤ Std.Usize.max) :
+    sponge.iterate_keccak_f (⟨BitVec.ofNat _ n⟩ : Std.Usize) st
+      = iterate_keccak_f_fold st n := by
+  rw [iterate_keccak_f_eq_fold]
+  have h_val : (⟨BitVec.ofNat _ n⟩ : Std.Usize).val = n := by
+    show (BitVec.ofNat _ n).toNat = n
+    rw [BitVec.toNat_ofNat]
+    apply Nat.mod_eq_of_lt
+    have h1 : Std.UScalarTy.Usize.numBits = Std.Usize.numBits := by
+      rw [Std.Usize.numBits]
+    rw [h1]
+    have hpos : 0 < 2 ^ Std.Usize.numBits := Nat.two_pow_pos _
+    have h2 : 2 ^ Std.Usize.numBits = Std.Usize.max + 1 := by
+      rw [Std.Usize.max]; omega
+    omega
+  rw [h_val]
+
+/-! ### Helper: middle-region index bound for the squeeze loop.
+
+For a "middle" output index `RATE ≤ k < blocks * RATE`, the shifted index
+`k - RATE` lands within the squeeze loop's range `(blocks - 1) * RATE`. -/
+theorem squeeze_middle_bound {RATE blocks_us_val blocks_nat k : Nat}
+    (h_blocks_us_val : blocks_us_val = blocks_nat) (h_blocks_pos : 1 ≤ blocks_nat)
+    (hk_lo : RATE ≤ k) (hk_hi : k < blocks_nat * RATE) :
+    k - RATE < (blocks_us_val - 1) * RATE := by
+  rw [h_blocks_us_val]
+  have h_eq : blocks_nat * RATE = (blocks_nat - 1) * RATE + RATE := by
+    have h2 : blocks_nat = (blocks_nat - 1) + 1 := by omega
+    conv_lhs => rw [h2]
+    rw [Nat.add_mul, Nat.one_mul]
+  omega
 
 /-! ### Helper: spec-side `sponge.absorb` equals the impl absorb pipeline.
 
@@ -748,26 +784,6 @@ theorem keccak.keccak_keccak_spec_blocks_nonzero
     -- We use sponge_squeeze_byte_eq with the s_b function set to:
     --   k → if k < RATE then lift s2 else if k < blocks*RATE then s_bj else s_spec_last.
     -- Define s_b directly:
-    -- Helper: iterate_keccak_f via squeeze_fold-conversion.
-    have h_iter_eq_fold : ∀ (n : Nat) (st : Std.Array Std.U64 25#usize),
-        n ≤ Std.Usize.max →
-        sponge.iterate_keccak_f (⟨BitVec.ofNat _ n⟩ : Std.Usize) st
-          = iterate_keccak_f_fold st n := by
-      intro n st h_n_le
-      rw [iterate_keccak_f_eq_fold]
-      -- (⟨BitVec.ofNat _ n⟩ : Usize).val = n.
-      have h_val : (⟨BitVec.ofNat _ n⟩ : Std.Usize).val = n := by
-        show (BitVec.ofNat _ n).toNat = n
-        rw [BitVec.toNat_ofNat]
-        apply Nat.mod_eq_of_lt
-        have h1 : Std.UScalarTy.Usize.numBits = Std.Usize.numBits := by
-          rw [Std.Usize.numBits]
-        rw [h1]
-        have hpos : 0 < 2 ^ Std.Usize.numBits := Nat.two_pow_pos _
-        have h2 : 2 ^ Std.Usize.numBits = Std.Usize.max + 1 := by
-          rw [Std.Usize.max]; omega
-        omega
-      rw [h_val]
     -- Bound: blocks_nat ≤ outlen / RATE so blocks_nat ≤ Std.Usize.max.
     have h_blocks_le_max : blocks_nat ≤ Std.Usize.max := by
       have : blocks_nat ≤ out.val.length := by
@@ -777,14 +793,8 @@ theorem keccak.keccak_keccak_spec_blocks_nonzero
     -- We use a "choice" s_b: for k < outlen_us.val, it returns the appropriate state.
     -- Helper: condition for being a "middle" k.
     have h_middle_bound : ∀ k : Nat, RATE.val ≤ k → k < blocks_nat * RATE.val →
-        k - RATE.val < (blocks_us.val - 1) * RATE.val := by
-      intro k hk_lo hk_hi
-      rw [h_blocks_us_val]
-      have h_eq : blocks_nat * RATE.val = (blocks_nat - 1) * RATE.val + RATE.val := by
-        have h2 : blocks_nat = (blocks_nat - 1) + 1 := by omega
-        conv_lhs => rw [h2]
-        rw [Nat.add_mul, Nat.one_mul]
-      omega
+        k - RATE.val < (blocks_us.val - 1) * RATE.val :=
+      fun k hk_lo hk_hi => squeeze_middle_bound h_blocks_us_val h_blocks_pos hk_lo hk_hi
     -- Existential witness function via Classical.choice on the relevant condition.
     let s_b : Nat → Std.Array Std.U64 25#usize := fun k =>
       if hk_lo : RATE.val ≤ k then
@@ -802,7 +812,7 @@ theorem keccak.keccak_keccak_spec_blocks_nonzero
       have h_k_le : k ≤ Std.Usize.max := by omega
       have h_kRATE_le : k / RATE.val ≤ Std.Usize.max := by
         have := Nat.div_le_self k RATE.val; omega
-      rw [h_iter_eq_fold _ _ h_kRATE_le]
+      rw [iterate_keccak_f_ofNat_eq_fold _ _ h_kRATE_le]
       -- Split on which region k is in.
       by_cases hk_RATE : k < RATE.val
       · -- Region 1: k < RATE. k/RATE = 0, iterate 0 = .ok state.
@@ -1043,38 +1053,14 @@ theorem keccak.keccak_keccak_spec_blocks_nonzero
         rw [hblocks_nat_def]; exact Nat.div_le_self _ _
       omega
     have h_middle_bound : ∀ k : Nat, RATE.val ≤ k → k < blocks_nat * RATE.val →
-        k - RATE.val < (blocks_us.val - 1) * RATE.val := by
-      intro k hk_lo hk_hi
-      rw [h_blocks_us_val]
-      have h_eq : blocks_nat * RATE.val = (blocks_nat - 1) * RATE.val + RATE.val := by
-        have h2 : blocks_nat = (blocks_nat - 1) + 1 := by omega
-        conv_lhs => rw [h2]
-        rw [Nat.add_mul, Nat.one_mul]
-      omega
+        k - RATE.val < (blocks_us.val - 1) * RATE.val :=
+      fun k hk_lo hk_hi => squeeze_middle_bound h_blocks_us_val h_blocks_pos hk_lo hk_hi
     let s_b : Nat → Std.Array Std.U64 25#usize := fun k =>
       if hk_lo : RATE.val ≤ k then
         if hk_hi : k < blocks_nat * RATE.val then
           Classical.choose (h_loop_bytes (k - RATE.val) (h_middle_bound k hk_lo hk_hi))
         else Foundation.lift s3
       else Foundation.lift s2
-    have h_iter_eq_fold : ∀ (n : Nat) (st : Std.Array Std.U64 25#usize),
-        n ≤ Std.Usize.max →
-        sponge.iterate_keccak_f (⟨BitVec.ofNat _ n⟩ : Std.Usize) st
-          = iterate_keccak_f_fold st n := by
-      intro n st h_n_le
-      rw [iterate_keccak_f_eq_fold]
-      have h_val : (⟨BitVec.ofNat _ n⟩ : Std.Usize).val = n := by
-        show (BitVec.ofNat _ n).toNat = n
-        rw [BitVec.toNat_ofNat]
-        apply Nat.mod_eq_of_lt
-        have h1 : Std.UScalarTy.Usize.numBits = Std.Usize.numBits := by
-          rw [Std.Usize.numBits]
-        rw [h1]
-        have hpos : 0 < 2 ^ Std.Usize.numBits := Nat.two_pow_pos _
-        have h2 : 2 ^ Std.Usize.numBits = Std.Usize.max + 1 := by
-          rw [Std.Usize.max]; omega
-        omega
-      rw [h_val]
     have h_iter_const : ∀ k : Nat, k < outlen_us.val →
         sponge.iterate_keccak_f
             ⟨BitVec.ofNat _ (k / RATE.val)⟩ (Foundation.lift s2) = .ok (s_b k) := by
@@ -1083,7 +1069,7 @@ theorem keccak.keccak_keccak_spec_blocks_nonzero
       have h_k_le : k ≤ Std.Usize.max := by omega
       have h_kRATE_le : k / RATE.val ≤ Std.Usize.max := by
         have := Nat.div_le_self k RATE.val; omega
-      rw [h_iter_eq_fold _ _ h_kRATE_le]
+      rw [iterate_keccak_f_ofNat_eq_fold _ _ h_kRATE_le]
       by_cases hk_RATE : k < RATE.val
       · have hsb : s_b k = Foundation.lift s2 := by
           show (if hk_lo : RATE.val ≤ k then _ else Foundation.lift s2) = _

--- a/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/Sponge/Keccak.lean
+++ b/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/Sponge/Keccak.lean
@@ -145,6 +145,139 @@ theorem iterate_keccak_f_zero
   show Nat.fold 0 _ _ = _
   rw [Nat.fold_zero]
 
+
+/-! ### Helper: spec-side `sponge.absorb` equals the impl absorb pipeline.
+
+Common to all three top-level dispatch branches. Given the impl-side
+absorb chain — `keccak_loop0` producing `s1` (as `absorb_fold`) and
+`absorb_final` producing `s2` — the spec `sponge.absorb` evaluates to
+`.ok (lift s2)`. The bulk is a `pad_last_block` slice equality showing
+that the impl's `data[i3..i]` tail and the spec's `data.drop (n*RATE)`
+tail extract the same bytes. -/
+theorem sponge_absorb_eq_of_impl
+    (RATE : Std.Usize) (DELIM : Std.U8) (data : Slice Std.U8)
+    (s0 s1 s2 : state.KeccakState)
+    (i_us n_us rem_us i3_us : Std.Usize)
+    (h_RATE_ge_1 : 1 ≤ RATE.val)
+    (h_s0_lift : Foundation.lift s0 = Std.Array.repeat 25#usize 0#u64)
+    (h_i_us_val : i_us.val = data.val.length)
+    (h_n_us_val : n_us.val = data.val.length / RATE.val)
+    (h_rem_us_val : rem_us.val = data.val.length % RATE.val)
+    (h_i3_us_val : i3_us.val = data.val.length / RATE.val * RATE.val)
+    (h_s1_fold : absorb_fold s0 data RATE n_us.val = .ok (Foundation.lift s1))
+    (h_s2_spec : sponge.absorb_final (Foundation.lift s1) data i3_us rem_us RATE DELIM
+                  = .ok (Foundation.lift s2)) :
+    sponge.absorb RATE DELIM data = .ok (Foundation.lift s2) := by
+  have h_data_len_max : data.val.length ≤ Std.Usize.max := by
+    have := data.property; omega
+  set n_nat : Nat := data.val.length / RATE.val with hn_nat_def
+  set rem_nat : Nat := data.val.length % RATE.val with hrem_nat_def
+  have h_n_rem : n_nat * RATE.val + rem_nat = data.val.length := by
+    rw [hn_nat_def, hrem_nat_def]
+    exact Nat.div_add_mod' data.val.length RATE.val
+  have h_n_rate_le : n_nat * RATE.val ≤ data.val.length := by omega
+  have h_rem_lt_RATE : rem_nat < RATE.val := Nat.mod_lt _ (by omega)
+  have h_fold_spec : absorb_fold_spec (Foundation.lift s0) data RATE n_us.val
+                      = .ok (Foundation.lift s1) := by
+    rw [← absorb_fold_eq_spec]; exact h_s1_fold
+  unfold sponge.absorb
+  show sponge.absorb_rec (Std.Array.repeat 25#usize 0#u64) RATE DELIM data
+       = .ok (Foundation.lift s2)
+  rw [← h_s0_lift]
+  rw [sponge_absorb_rec_eq_fold (Foundation.lift s0) RATE DELIM data n_nat
+    (by rw [hn_nat_def]; exact h_n_rate_le)]
+  have h_fold_spec_n : absorb_fold_spec (Foundation.lift s0) data RATE n_nat
+                      = .ok (Foundation.lift s1) := by
+    rw [← h_n_us_val]; exact h_fold_spec
+  rw [h_fold_spec_n]; simp only [bind_tc_ok]
+  set tail : Slice Std.U8 :=
+    ⟨data.val.drop (n_nat * RATE.val), by
+      rw [List.length_drop]; have := data.property; omega⟩ with htail_def
+  have h_tail_len : tail.val.length = rem_nat := by
+    show (data.val.drop (n_nat * RATE.val)).length = _
+    rw [List.length_drop]; omega
+  have h_tail_lt_rate : tail.val.length < RATE.val := by
+    rw [h_tail_len]; exact h_rem_lt_RATE
+  rw [sponge_absorb_rec_unfold_short (Foundation.lift s1) RATE DELIM tail h_tail_lt_rate]
+  have h_slt_eq_rem : Std.Slice.len tail = rem_us := by
+    apply Std.UScalar.eq_of_val_eq
+    simp [Std.Slice.len, h_tail_len, h_rem_us_val]
+  rw [h_slt_eq_rem]
+  rw [show sponge.absorb_final (Foundation.lift s1) tail 0#usize rem_us RATE DELIM
+        = sponge.absorb_final (Foundation.lift s1) data i3_us rem_us RATE DELIM from ?_]
+  · exact h_s2_spec
+  · unfold sponge.absorb_final
+    have h_pad_eq :
+        sponge.pad_last_block tail 0#usize rem_us RATE DELIM
+          = sponge.pad_last_block data i3_us rem_us RATE DELIM := by
+      unfold sponge.pad_last_block
+      have h_lhs_add : (0#usize : Std.Usize) + rem_us = (.ok rem_us : Result Std.Usize) := by
+        have h_bnd : (0#usize : Std.Usize).val + rem_us.val ≤ Std.UScalar.max .Usize := by
+          rw [Std.UScalar.max_USize_eq]; show 0 + rem_us.val ≤ Std.Usize.max
+          rw [h_rem_us_val]; omega
+        obtain ⟨v, h_eq_v, h_v_val_eq, _⟩ :=
+          Std.WP.spec_imp_exists
+            (Std.UScalar.add_bv_spec (x := (0#usize : Std.Usize)) (y := rem_us) h_bnd)
+        have h_v_val : v.val = rem_us.val := by
+          rw [h_v_val_eq]; show 0 + rem_us.val = rem_us.val; omega
+        have h_v_eq : v = rem_us := Std.UScalar.eq_of_val_eq h_v_val
+        rw [h_eq_v, h_v_eq]
+      rw [h_lhs_add]; simp only [bind_tc_ok]
+      have h_rhs_add : i3_us + rem_us = (.ok i_us : Result Std.Usize) := by
+        have h_bnd : i3_us.val + rem_us.val ≤ Std.UScalar.max .Usize := by
+          rw [Std.UScalar.max_USize_eq, h_i3_us_val, h_rem_us_val]; omega
+        obtain ⟨v, h_eq_v, h_v_val_eq, _⟩ :=
+          Std.WP.spec_imp_exists
+            (Std.UScalar.add_bv_spec (x := i3_us) (y := rem_us) h_bnd)
+        have h_v_val : v.val = i_us.val := by
+          rw [h_v_val_eq, h_i3_us_val, h_rem_us_val, h_i_us_val]; omega
+        have h_v_eq : v = i_us := Std.UScalar.eq_of_val_eq h_v_val
+        rw [h_eq_v, h_v_eq]
+      rw [h_rhs_add]; simp only [bind_tc_ok]
+      have h_lhs_idx :
+          CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
+            (CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice Std.U8)
+            tail { start := 0#usize, «end» := rem_us }
+          = .ok tail := by
+        unfold CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
+               CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
+               core.slice.index.Slice.index
+               core.slice.index.SliceIndexRangeUsizeSlice.index
+        have h0 : (0#usize : Std.Usize) ≤ rem_us := by
+          show (0 : Nat) ≤ rem_us.val; omega
+        have h1' : (⟨0#usize, rem_us⟩ : core.ops.range.Range Std.Usize).end.val ≤ tail.length := by
+          show rem_us.val ≤ tail.val.length
+          rw [h_tail_len, h_rem_us_val]
+        simp [h0, h1']
+        apply Subtype.ext
+        show tail.val.slice ((0#usize : Std.Usize).val) rem_us.val = tail.val
+        rw [show ((0#usize : Std.Usize).val : Nat) = 0 from rfl, h_rem_us_val]
+        unfold List.slice
+        rw [List.drop_zero]
+        rw [List.take_of_length_le (by rw [h_tail_len]; omega)]
+      have h_rhs_idx :
+          CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
+            (CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice Std.U8)
+            data { start := i3_us, «end» := i_us }
+          = .ok tail := by
+        unfold CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
+               CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
+               core.slice.index.Slice.index
+               core.slice.index.SliceIndexRangeUsizeSlice.index
+        have h0 : i3_us ≤ i_us := by
+          show i3_us.val ≤ i_us.val; rw [h_i3_us_val, h_i_us_val]; omega
+        have h1' : (⟨i3_us, i_us⟩ : core.ops.range.Range Std.Usize).end.val ≤ data.length := by
+          show i_us.val ≤ data.length
+          rw [h_i_us_val]
+        simp [h0, h1']
+        apply Subtype.ext
+        show data.val.slice i3_us.val i_us.val = tail.val
+        rw [h_i3_us_val, h_i_us_val]
+        show data.val.slice (n_nat * RATE.val) data.val.length = data.val.drop (n_nat * RATE.val)
+        unfold List.slice
+        rw [List.take_of_length_le (by rw [List.length_drop])]
+      rw [h_lhs_idx, h_rhs_idx]
+    rw [h_pad_eq]
 /-! ### Main theorem: `keccak.keccak_keccak_spec` (blocks = 0 branch).
 
 We land the `blocks = 0` case end-to-end. The post is the textbook
@@ -298,140 +431,11 @@ theorem keccak.keccak_keccak_spec_blocks_zero
   -- We derive this from h_s1_fold and h_s2_spec.
   -- h_s1_fold : absorb_fold s0 data RATE n_us.val = .ok (lift s1).
   -- We use absorb_fold_eq_spec to translate to absorb_fold_spec (lift s0) data RATE n_us.val.
-  have h_fold_spec : absorb_fold_spec (Foundation.lift s0) data RATE n_us.val
-                      = .ok (Foundation.lift s1) := by
-    rw [← absorb_fold_eq_spec]; exact h_s1_fold
-  -- h_s2_spec : sponge.absorb_final (lift s1) data i3_us rem_us RATE DELIM = .ok (lift s2).
-  -- Now compose via sponge_absorb_rec_eq_fold + unfold_short.
-  have h_absorb_eq : sponge.absorb RATE DELIM data = .ok (Foundation.lift s2) := by
-    unfold sponge.absorb
-    -- Goal: `let a := Array.repeat 25 0; sponge.absorb_rec a RATE DELIM data = .ok (lift s2)`.
-    show sponge.absorb_rec (Std.Array.repeat 25#usize 0#u64) RATE DELIM data
-         = .ok (Foundation.lift s2)
-    rw [← h_s0_lift]
-    -- Now: sponge.absorb_rec (lift s0) RATE DELIM data = .ok (lift s2).
-    rw [sponge_absorb_rec_eq_fold (Foundation.lift s0) RATE DELIM data n_nat (by rw [hn_nat_def]; exact h_n_rate_le)]
-    -- Now: absorb_fold_spec (lift s0) data RATE n_nat >>= fun s_n =>
-    --        absorb_rec s_n RATE DELIM ⟨data.drop (n_nat*RATE), _⟩
-    --      = .ok (lift s2).
-    -- Step A: absorb_fold_spec (lift s0) data RATE n_nat = .ok (lift s1).
-    have h_fold_spec_n : absorb_fold_spec (Foundation.lift s0) data RATE n_nat
-                        = .ok (Foundation.lift s1) := by
-      rw [← h_n_us_val]; exact h_fold_spec
-    rw [h_fold_spec_n]; simp only [bind_tc_ok]
-    -- Step B: absorb_rec (lift s1) RATE DELIM ⟨data.drop (n_nat * RATE), _⟩ = .ok (lift s2).
-    -- We apply `sponge_absorb_rec_unfold_short` since the tail length is rem_nat < RATE.
-    set tail : Slice Std.U8 :=
-      ⟨data.val.drop (n_nat * RATE.val), by
-        rw [List.length_drop]; have := data.property; omega⟩ with htail_def
-    have h_tail_len : tail.val.length = rem_nat := by
-      show (data.val.drop (n_nat * RATE.val)).length = _
-      rw [List.length_drop]; omega
-    have h_tail_lt_rate : tail.val.length < RATE.val := by
-      rw [h_tail_len]; exact h_rem_lt_RATE
-    rw [sponge_absorb_rec_unfold_short (Foundation.lift s1) RATE DELIM tail h_tail_lt_rate]
-    -- Now goal: sponge.absorb_final (lift s1) tail 0#usize (Slice.len tail) RATE DELIM
-    --        = .ok (lift s2).
-    -- We have h_s2_spec : sponge.absorb_final (lift s1) data i3_us rem_us RATE DELIM = .ok (lift s2).
-    -- The two absorb_final calls have:
-    --   LHS: message = tail (msg.drop (n*rate)), msg_offset = 0, remaining = Slice.len tail (= rem_nat).
-    --   RHS: message = data, msg_offset = i3_us (= n*rate), remaining = rem_us (= rem_nat).
-    -- Both extract the same bytes (data[n*rate..data.length]) via `pad_last_block`.
-    -- Show LHS = RHS by `pad_last_block_eq`.
-    -- We compute (Slice.len tail).val = tail.length = rem_nat = rem_us.val.
-    have h_slt_eq_rem : Std.Slice.len tail = rem_us := by
-      apply Std.UScalar.eq_of_val_eq
-      simp [Std.Slice.len, h_tail_len, h_rem_us_val]
-    rw [h_slt_eq_rem]
-    -- Now LHS: sponge.absorb_final (lift s1) tail 0#usize rem_us RATE DELIM.
-    -- RHS: sponge.absorb_final (lift s1) data i3_us rem_us RATE DELIM.
-    -- Show these are equal by reducing to the same `pad_last_block`.
-    rw [show sponge.absorb_final (Foundation.lift s1) tail 0#usize rem_us RATE DELIM
-          = sponge.absorb_final (Foundation.lift s1) data i3_us rem_us RATE DELIM from ?_]
-    · exact h_s2_spec
-    · -- pad_last_block tail 0 rem RATE DELIM = pad_last_block data i3_us rem RATE DELIM.
-      unfold sponge.absorb_final
-      -- Both have form: do let block ← pad_last_block ...; ...
-      have h_pad_eq :
-          sponge.pad_last_block tail 0#usize rem_us RATE DELIM
-            = sponge.pad_last_block data i3_us rem_us RATE DELIM := by
-        unfold sponge.pad_last_block
-        -- Both produce a buffer; they differ only in the `s1` slice extracted.
-        -- Reduce both `let i ← off + remaining`.
-        -- LHS: 0#usize + rem_us = .ok rem_us.
-        have h_lhs_add : (0#usize : Std.Usize) + rem_us = (.ok rem_us : Result Std.Usize) := by
-          have h_bnd : (0#usize : Std.Usize).val + rem_us.val ≤ Std.UScalar.max .Usize := by
-            rw [Std.UScalar.max_USize_eq]; show 0 + rem_us.val ≤ Std.Usize.max
-            rw [h_rem_us_val]; omega
-          obtain ⟨v, h_eq_v, h_v_val_eq, _⟩ :=
-            Std.WP.spec_imp_exists
-              (Std.UScalar.add_bv_spec (x := (0#usize : Std.Usize)) (y := rem_us) h_bnd)
-          have h_v_val : v.val = rem_us.val := by
-            rw [h_v_val_eq]; show 0 + rem_us.val = rem_us.val; omega
-          have h_v_eq : v = rem_us := Std.UScalar.eq_of_val_eq h_v_val
-          rw [h_eq_v, h_v_eq]
-        rw [h_lhs_add]; simp only [bind_tc_ok]
-        -- RHS: i3_us + rem_us = .ok i_us (since i3_us.val + rem_us.val = n*RATE + rem = data.length = i_us.val).
-        have h_rhs_add : i3_us + rem_us = (.ok i_us : Result Std.Usize) := by
-          have h_bnd : i3_us.val + rem_us.val ≤ Std.UScalar.max .Usize := by
-            rw [Std.UScalar.max_USize_eq, h_i3_us_val, h_rem_us_val]; omega
-          obtain ⟨v, h_eq_v, h_v_val_eq, _⟩ :=
-            Std.WP.spec_imp_exists
-              (Std.UScalar.add_bv_spec (x := i3_us) (y := rem_us) h_bnd)
-          have h_v_val : v.val = i_us.val := by
-            rw [h_v_val_eq, h_i3_us_val, h_rem_us_val, h_i_us_val]; omega
-          have h_v_eq : v = i_us := Std.UScalar.eq_of_val_eq h_v_val
-          rw [h_eq_v, h_v_eq]
-        rw [h_rhs_add]; simp only [bind_tc_ok]
-        -- Now both sides have slice indices that produce the same byte sequence.
-        -- LHS: index tail [0, rem_us]. Bytes = tail.val.slice 0 rem.val = tail.val (= data.drop n*rate, length rem).
-        -- RHS: index data [i3_us, i_us]. Bytes = data.val.slice (n*rate) (data.length).
-        -- = data.val.drop (n*rate) since (data.length - n*rate) covers the whole drop.
-        -- Show both indices yield the same `Slice`.
-        have h_lhs_idx :
-            CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
-              (CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice Std.U8)
-              tail { start := 0#usize, «end» := rem_us }
-            = .ok tail := by
-          unfold CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
-                 CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
-                 core.slice.index.Slice.index
-                 core.slice.index.SliceIndexRangeUsizeSlice.index
-          have h0 : (0#usize : Std.Usize) ≤ rem_us := by
-            show (0 : Nat) ≤ rem_us.val; omega
-          have h1' : (⟨0#usize, rem_us⟩ : core.ops.range.Range Std.Usize).end.val ≤ tail.length := by
-            show rem_us.val ≤ tail.val.length
-            rw [h_tail_len, h_rem_us_val]
-          simp [h0, h1']
-          apply Subtype.ext
-          show tail.val.slice ((0#usize : Std.Usize).val) rem_us.val = tail.val
-          rw [show ((0#usize : Std.Usize).val : Nat) = 0 from rfl, h_rem_us_val]
-          unfold List.slice
-          rw [List.drop_zero]
-          rw [List.take_of_length_le (by rw [h_tail_len]; omega)]
-        have h_rhs_idx :
-            CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
-              (CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice Std.U8)
-              data { start := i3_us, «end» := i_us }
-            = .ok tail := by
-          unfold CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
-                 CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
-                 core.slice.index.Slice.index
-                 core.slice.index.SliceIndexRangeUsizeSlice.index
-          have h0 : i3_us ≤ i_us := by
-            show i3_us.val ≤ i_us.val; rw [h_i3_us_val, h_i_us_val]; omega
-          have h1' : (⟨i3_us, i_us⟩ : core.ops.range.Range Std.Usize).end.val ≤ data.length := by
-            show i_us.val ≤ data.length
-            rw [h_i_us_val]
-          simp [h0, h1']
-          apply Subtype.ext
-          show data.val.slice i3_us.val i_us.val = tail.val
-          rw [h_i3_us_val, h_i_us_val]
-          show data.val.slice (n_nat * RATE.val) data.val.length = data.val.drop (n_nat * RATE.val)
-          unfold List.slice
-          rw [List.take_of_length_le (by rw [List.length_drop])]
-        rw [h_lhs_idx, h_rhs_idx]
-      rw [h_pad_eq]
+  have h_absorb_eq : sponge.absorb RATE DELIM data = .ok (Foundation.lift s2) :=
+    sponge_absorb_eq_of_impl RATE DELIM data s0 s1 s2 i_us n_us rem_us i3_us
+      h_RATE_ge_1 h_s0_lift h_i_us_val
+      (h_n_us_val.trans hn_nat_def) (h_rem_us_val.trans hrem_nat_def)
+      (h_i3_us_val.trans (by rw [hn_nat_def])) h_s1_fold h_s2_spec
   -- Step 16: spec-side squeeze. Need:
   --   sponge.squeeze outlen_us (lift s2) RATE = .ok spec_out.
   -- Use sponge_squeeze_byte_eq with the constant `s_b` function (since outlen < RATE,
@@ -723,112 +727,11 @@ theorem keccak.keccak_keccak_spec_blocks_nonzero
       rw [h_idx_eq]; simp only [bind_tc_ok]
       rw [h_s5_eq]; simp only [bind_tc_ok]
     -- Step 20: spec-side absorb (same as blocks_zero case).
-    have h_fold_spec : absorb_fold_spec (Foundation.lift s0) data RATE n_us.val
-                        = .ok (Foundation.lift s1) := by
-      rw [← absorb_fold_eq_spec]; exact h_s1_fold
-    have h_absorb_eq : sponge.absorb RATE DELIM data = .ok (Foundation.lift s2) := by
-      unfold sponge.absorb
-      show sponge.absorb_rec (Std.Array.repeat 25#usize 0#u64) RATE DELIM data
-           = .ok (Foundation.lift s2)
-      rw [← h_s0_lift]
-      rw [sponge_absorb_rec_eq_fold (Foundation.lift s0) RATE DELIM data n_nat
-        (by rw [hn_nat_def]; exact h_n_rate_le)]
-      have h_fold_spec_n : absorb_fold_spec (Foundation.lift s0) data RATE n_nat
-                          = .ok (Foundation.lift s1) := by
-        rw [← h_n_us_val]; exact h_fold_spec
-      rw [h_fold_spec_n]; simp only [bind_tc_ok]
-      set tail : Slice Std.U8 :=
-        ⟨data.val.drop (n_nat * RATE.val), by
-          rw [List.length_drop]; have := data.property; omega⟩ with htail_def
-      have h_tail_len : tail.val.length = rem_nat := by
-        show (data.val.drop (n_nat * RATE.val)).length = _
-        rw [List.length_drop]; omega
-      have h_tail_lt_rate : tail.val.length < RATE.val := by
-        rw [h_tail_len]; exact h_rem_lt_RATE
-      rw [sponge_absorb_rec_unfold_short (Foundation.lift s1) RATE DELIM tail h_tail_lt_rate]
-      have h_slt_eq_rem : Std.Slice.len tail = rem_us := by
-        apply Std.UScalar.eq_of_val_eq
-        simp [Std.Slice.len, h_tail_len, h_rem_us_val]
-      rw [h_slt_eq_rem]
-      rw [show sponge.absorb_final (Foundation.lift s1) tail 0#usize rem_us RATE DELIM
-            = sponge.absorb_final (Foundation.lift s1) data i3_us rem_us RATE DELIM from ?_]
-      · exact h_s2_spec
-      · -- Same pad_last_block equality as in blocks_zero case.
-        unfold sponge.absorb_final
-        have h_pad_eq :
-            sponge.pad_last_block tail 0#usize rem_us RATE DELIM
-              = sponge.pad_last_block data i3_us rem_us RATE DELIM := by
-          unfold sponge.pad_last_block
-          have h_lhs_add : (0#usize : Std.Usize) + rem_us = (.ok rem_us : Result Std.Usize) := by
-            have h_bnd : (0#usize : Std.Usize).val + rem_us.val ≤ Std.UScalar.max .Usize := by
-              rw [Std.UScalar.max_USize_eq]; show 0 + rem_us.val ≤ Std.Usize.max
-              rw [h_rem_us_val]; omega
-            obtain ⟨v, h_eq_v, h_v_val_eq, _⟩ :=
-              Std.WP.spec_imp_exists
-                (Std.UScalar.add_bv_spec (x := (0#usize : Std.Usize)) (y := rem_us) h_bnd)
-            have h_v_val : v.val = rem_us.val := by
-              rw [h_v_val_eq]; show 0 + rem_us.val = rem_us.val; omega
-            have h_v_eq : v = rem_us := Std.UScalar.eq_of_val_eq h_v_val
-            rw [h_eq_v, h_v_eq]
-          rw [h_lhs_add]; simp only [bind_tc_ok]
-          have h_rhs_add : i3_us + rem_us = (.ok i_us : Result Std.Usize) := by
-            have h_bnd : i3_us.val + rem_us.val ≤ Std.UScalar.max .Usize := by
-              rw [Std.UScalar.max_USize_eq, h_i3_us_val, h_rem_us_val]; omega
-            obtain ⟨v, h_eq_v, h_v_val_eq, _⟩ :=
-              Std.WP.spec_imp_exists
-                (Std.UScalar.add_bv_spec (x := i3_us) (y := rem_us) h_bnd)
-            have h_v_val : v.val = i_us.val := by
-              rw [h_v_val_eq, h_i3_us_val, h_rem_us_val, h_i_us_val]; omega
-            have h_v_eq : v = i_us := Std.UScalar.eq_of_val_eq h_v_val
-            rw [h_eq_v, h_v_eq]
-          rw [h_rhs_add]; simp only [bind_tc_ok]
-          have h_lhs_idx :
-              CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
-                (CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
-                  Std.U8)
-                tail { start := 0#usize, «end» := rem_us }
-              = .ok tail := by
-            unfold CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
-                   CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
-                   core.slice.index.Slice.index
-                   core.slice.index.SliceIndexRangeUsizeSlice.index
-            have h0 : (0#usize : Std.Usize) ≤ rem_us := by
-              show (0 : Nat) ≤ rem_us.val; omega
-            have h1' : (⟨0#usize, rem_us⟩ : core.ops.range.Range Std.Usize).end.val
-                        ≤ tail.length := by
-              show rem_us.val ≤ tail.val.length
-              rw [h_tail_len, h_rem_us_val]
-            simp [h0, h1']
-            apply Subtype.ext
-            show tail.val.slice ((0#usize : Std.Usize).val) rem_us.val = tail.val
-            rw [show ((0#usize : Std.Usize).val : Nat) = 0 from rfl, h_rem_us_val]
-            unfold List.slice
-            rw [List.drop_zero]
-            rw [List.take_of_length_le (by rw [h_tail_len]; omega)]
-          have h_rhs_idx :
-              CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
-                (CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
-                  Std.U8)
-                data { start := i3_us, «end» := i_us }
-              = .ok tail := by
-            unfold CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
-                   CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
-                   core.slice.index.Slice.index
-                   core.slice.index.SliceIndexRangeUsizeSlice.index
-            have h0 : i3_us ≤ i_us := by
-              show i3_us.val ≤ i_us.val; rw [h_i3_us_val, h_i_us_val]; omega
-            have h1' : (⟨i3_us, i_us⟩ : core.ops.range.Range Std.Usize).end.val ≤ data.length := by
-              show i_us.val ≤ data.length
-              rw [h_i_us_val]
-            simp [h0, h1']
-            apply Subtype.ext
-            show data.val.slice i3_us.val i_us.val = tail.val
-            rw [h_i3_us_val, h_i_us_val]
-            show data.val.slice (n_nat * RATE.val) data.val.length = data.val.drop (n_nat * RATE.val)
-            unfold List.slice
-            rw [List.take_of_length_le (by rw [List.length_drop])]
-          rw [h_lhs_idx, h_rhs_idx]
-        rw [h_pad_eq]
+    have h_absorb_eq : sponge.absorb RATE DELIM data = .ok (Foundation.lift s2) :=
+      sponge_absorb_eq_of_impl RATE DELIM data s0 s1 s2 i_us n_us rem_us i3_us
+        h_RATE_ge_1 h_s0_lift h_i_us_val
+        (h_n_us_val.trans hn_nat_def) (h_rem_us_val.trans hrem_nat_def)
+        (h_i3_us_val.trans (by rw [hn_nat_def])) h_s1_fold h_s2_spec
     -- Step 21: spec-side squeeze using sponge_squeeze_byte_eq.
     have h_RATE_pos : 0 < RATE.val := h_RATE_ge_1
     -- The s_b function: for each k < outlen, return state of iterate (k/RATE) (lift s2).
@@ -1128,112 +1031,11 @@ theorem keccak.keccak_keccak_spec_blocks_nonzero
       rw [h_massert]; simp only [bind_tc_ok]
       rw [if_neg h_not_partial]
     -- Spec-side absorb (same as partial branch).
-    have h_fold_spec : absorb_fold_spec (Foundation.lift s0) data RATE n_us.val
-                        = .ok (Foundation.lift s1) := by
-      rw [← absorb_fold_eq_spec]; exact h_s1_fold
-    have h_absorb_eq : sponge.absorb RATE DELIM data = .ok (Foundation.lift s2) := by
-      unfold sponge.absorb
-      show sponge.absorb_rec (Std.Array.repeat 25#usize 0#u64) RATE DELIM data
-           = .ok (Foundation.lift s2)
-      rw [← h_s0_lift]
-      rw [sponge_absorb_rec_eq_fold (Foundation.lift s0) RATE DELIM data n_nat
-        (by rw [hn_nat_def]; exact h_n_rate_le)]
-      have h_fold_spec_n : absorb_fold_spec (Foundation.lift s0) data RATE n_nat
-                          = .ok (Foundation.lift s1) := by
-        rw [← h_n_us_val]; exact h_fold_spec
-      rw [h_fold_spec_n]; simp only [bind_tc_ok]
-      set tail : Slice Std.U8 :=
-        ⟨data.val.drop (n_nat * RATE.val), by
-          rw [List.length_drop]; have := data.property; omega⟩ with htail_def
-      have h_tail_len : tail.val.length = rem_nat := by
-        show (data.val.drop (n_nat * RATE.val)).length = _
-        rw [List.length_drop]; omega
-      have h_tail_lt_rate : tail.val.length < RATE.val := by
-        rw [h_tail_len]; exact h_rem_lt_RATE
-      rw [sponge_absorb_rec_unfold_short (Foundation.lift s1) RATE DELIM tail h_tail_lt_rate]
-      have h_slt_eq_rem : Std.Slice.len tail = rem_us := by
-        apply Std.UScalar.eq_of_val_eq
-        simp [Std.Slice.len, h_tail_len, h_rem_us_val]
-      rw [h_slt_eq_rem]
-      rw [show sponge.absorb_final (Foundation.lift s1) tail 0#usize rem_us RATE DELIM
-            = sponge.absorb_final (Foundation.lift s1) data i3_us rem_us RATE DELIM from ?_]
-      · exact h_s2_spec
-      · unfold sponge.absorb_final
-        have h_pad_eq :
-            sponge.pad_last_block tail 0#usize rem_us RATE DELIM
-              = sponge.pad_last_block data i3_us rem_us RATE DELIM := by
-          unfold sponge.pad_last_block
-          have h_lhs_add : (0#usize : Std.Usize) + rem_us = (.ok rem_us : Result Std.Usize) := by
-            have h_bnd : (0#usize : Std.Usize).val + rem_us.val ≤ Std.UScalar.max .Usize := by
-              rw [Std.UScalar.max_USize_eq]; show 0 + rem_us.val ≤ Std.Usize.max
-              rw [h_rem_us_val]; omega
-            obtain ⟨v, h_eq_v, h_v_val_eq, _⟩ :=
-              Std.WP.spec_imp_exists
-                (Std.UScalar.add_bv_spec (x := (0#usize : Std.Usize)) (y := rem_us) h_bnd)
-            have h_v_val : v.val = rem_us.val := by
-              rw [h_v_val_eq]; show 0 + rem_us.val = rem_us.val; omega
-            have h_v_eq : v = rem_us := Std.UScalar.eq_of_val_eq h_v_val
-            rw [h_eq_v, h_v_eq]
-          rw [h_lhs_add]; simp only [bind_tc_ok]
-          have h_rhs_add : i3_us + rem_us = (.ok i_us : Result Std.Usize) := by
-            have h_bnd : i3_us.val + rem_us.val ≤ Std.UScalar.max .Usize := by
-              rw [Std.UScalar.max_USize_eq, h_i3_us_val, h_rem_us_val]; omega
-            obtain ⟨v, h_eq_v, h_v_val_eq, _⟩ :=
-              Std.WP.spec_imp_exists
-                (Std.UScalar.add_bv_spec (x := i3_us) (y := rem_us) h_bnd)
-            have h_v_val : v.val = i_us.val := by
-              rw [h_v_val_eq, h_i3_us_val, h_rem_us_val, h_i_us_val]; omega
-            have h_v_eq : v = i_us := Std.UScalar.eq_of_val_eq h_v_val
-            rw [h_eq_v, h_v_eq]
-          rw [h_rhs_add]; simp only [bind_tc_ok]
-          have h_lhs_idx :
-              CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
-                (CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
-                  Std.U8)
-                tail { start := 0#usize, «end» := rem_us }
-              = .ok tail := by
-            unfold CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
-                   CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
-                   core.slice.index.Slice.index
-                   core.slice.index.SliceIndexRangeUsizeSlice.index
-            have h0 : (0#usize : Std.Usize) ≤ rem_us := by
-              show (0 : Nat) ≤ rem_us.val; omega
-            have h1' : (⟨0#usize, rem_us⟩ : core.ops.range.Range Std.Usize).end.val
-                        ≤ tail.length := by
-              show rem_us.val ≤ tail.val.length
-              rw [h_tail_len, h_rem_us_val]
-            simp [h0, h1']
-            apply Subtype.ext
-            show tail.val.slice ((0#usize : Std.Usize).val) rem_us.val = tail.val
-            rw [show ((0#usize : Std.Usize).val : Nat) = 0 from rfl, h_rem_us_val]
-            unfold List.slice
-            rw [List.drop_zero]
-            rw [List.take_of_length_le (by rw [h_tail_len]; omega)]
-          have h_rhs_idx :
-              CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
-                (CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
-                  Std.U8)
-                data { start := i3_us, «end» := i_us }
-              = .ok tail := by
-            unfold CoreModels.core.Slice.Insts.CoreOpsIndexIndex.index
-                   CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice
-                   core.slice.index.Slice.index
-                   core.slice.index.SliceIndexRangeUsizeSlice.index
-            have h0 : i3_us ≤ i_us := by
-              show i3_us.val ≤ i_us.val; rw [h_i3_us_val, h_i_us_val]; omega
-            have h1' : (⟨i3_us, i_us⟩ : core.ops.range.Range Std.Usize).end.val ≤ data.length := by
-              show i_us.val ≤ data.length
-              rw [h_i_us_val]
-            simp [h0, h1']
-            apply Subtype.ext
-            show data.val.slice i3_us.val i_us.val = tail.val
-            rw [h_i3_us_val, h_i_us_val]
-            show data.val.slice (n_nat * RATE.val) data.val.length
-                = data.val.drop (n_nat * RATE.val)
-            unfold List.slice
-            rw [List.take_of_length_le (by rw [List.length_drop])]
-          rw [h_lhs_idx, h_rhs_idx]
-        rw [h_pad_eq]
+    have h_absorb_eq : sponge.absorb RATE DELIM data = .ok (Foundation.lift s2) :=
+      sponge_absorb_eq_of_impl RATE DELIM data s0 s1 s2 i_us n_us rem_us i3_us
+        h_RATE_ge_1 h_s0_lift h_i_us_val
+        (h_n_us_val.trans hn_nat_def) (h_rem_us_val.trans hrem_nat_def)
+        (h_i3_us_val.trans (by rw [hn_nat_def])) h_s1_fold h_s2_spec
     -- Spec-side squeeze (no region 3; outlen = blocks * RATE).
     have h_RATE_pos : 0 < RATE.val := h_RATE_ge_1
     have h_blocks_le_max : blocks_nat ≤ Std.Usize.max := by

--- a/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/Sponge/Keccak.lean
+++ b/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/Sponge/Keccak.lean
@@ -182,6 +182,51 @@ theorem squeeze_middle_bound {RATE blocks_us_val blocks_nat k : Nat}
     rw [Nat.add_mul, Nat.one_mul]
   omega
 
+/-! ### Helpers: per-byte div/mod identities for the squeeze regions.
+
+These pure-`Nat` facts and the `iterate_keccak_f_fold` shift below are shared
+between the two `blocks ≥ 1` sub-branches (partial / full trailing block) in
+both the `iterate`-witness construction and the per-byte equality. -/
+
+theorem sub_rate_div_succ {RATE k : Nat} (h_RATE_pos : 0 < RATE) (hk_RATE : RATE ≤ k) :
+    (k - RATE) / RATE + 1 = k / RATE := by
+  have hd_ge_1 : 1 ≤ k / RATE := (Nat.one_le_div_iff h_RATE_pos).mpr hk_RATE
+  have h_mod_lt : k % RATE < RATE := Nat.mod_lt _ h_RATE_pos
+  have h_kdivmod : k = k / RATE * RATE + k % RATE := (Nat.div_add_mod' k RATE).symm
+  have h_split : k / RATE * RATE = (k / RATE - 1) * RATE + RATE := by
+    conv_lhs => rw [show k / RATE = (k / RATE - 1) + 1 from by omega]
+    rw [Nat.add_mul, Nat.one_mul]
+  have h_eq : k - RATE = k % RATE + (k / RATE - 1) * RATE := by omega
+  have h_div_compute : (k - RATE) / RATE = k / RATE - 1 := by
+    rw [h_eq]
+    rw [Nat.add_mul_div_right _ _ h_RATE_pos]
+    rw [Nat.div_eq_of_lt h_mod_lt]
+    omega
+  omega
+
+theorem sub_rate_mod_eq {RATE k : Nat} (h_RATE_pos : 0 < RATE) (hk_RATE : RATE ≤ k) :
+    (k - RATE) % RATE = k % RATE := by
+  have h_rewrite : k - RATE = k % RATE + (k / RATE - 1) * RATE := by
+    have hd := Nat.div_add_mod' k RATE
+    have hd_ge_1 : 1 ≤ k / RATE := (Nat.one_le_div_iff h_RATE_pos).mpr hk_RATE
+    have h_split : k / RATE * RATE = (k / RATE - 1) * RATE + RATE := by
+      conv_lhs => rw [show k / RATE = (k / RATE - 1) + 1 from by omega]
+      rw [Nat.add_mul, Nat.one_mul]
+    omega
+  rw [h_rewrite, Nat.add_mul_mod_self_right]
+  exact Nat.mod_eq_of_lt (Nat.mod_lt _ h_RATE_pos)
+
+theorem sub_div_mul_eq (k RATE : Nat) : k - k / RATE * RATE = k % RATE := by
+  have hd := Nat.div_add_mod' k RATE; omega
+
+/-- Shift the iterate count by one block: in the middle region `k / RATE`
+applications agree with `(k - RATE) / RATE + 1` applications. -/
+theorem iter_fold_shift {RATE k : Nat} {st target : Std.Array Std.U64 25#usize}
+    (h_RATE_pos : 0 < RATE) (hk_RATE : RATE ≤ k)
+    (h : iterate_keccak_f_fold st ((k - RATE) / RATE + 1) = .ok target) :
+    iterate_keccak_f_fold st (k / RATE) = .ok target := by
+  rwa [sub_rate_div_succ h_RATE_pos hk_RATE] at h
+
 /-! ### Helper: spec-side `sponge.absorb` equals the impl absorb pipeline.
 
 Common to all three top-level dispatch branches. Given the impl-side
@@ -837,34 +882,9 @@ theorem keccak.keccak_keccak_spec_blocks_nonzero
                   else _) = _
             rw [dif_pos hk_RATE, dif_pos hk_last]
           rw [hsb]
-          have h_choose_spec := Classical.choose_spec (h_loop_bytes (k - RATE.val) h_mb)
-          have h_fold_eq := h_choose_spec.1
-          have hd_ge_1 : 1 ≤ k / RATE.val :=
-            (Nat.one_le_div_iff (by omega)).mpr hk_RATE
-          have h_mod_lt : k % RATE.val < RATE.val := Nat.mod_lt _ (by omega)
-          have h_kdivmod : k = k / RATE.val * RATE.val + k % RATE.val :=
-            (Nat.div_add_mod' k RATE.val).symm
-          have h_split : k / RATE.val * RATE.val
-                        = (k / RATE.val - 1) * RATE.val + RATE.val := by
-            conv_lhs => rw [show k / RATE.val = (k / RATE.val - 1) + 1 from by omega]
-            rw [Nat.add_mul, Nat.one_mul]
-          have h_eq : k - RATE.val = k % RATE.val + (k / RATE.val - 1) * RATE.val := by omega
-          have h_div_eq : (k - RATE.val) / RATE.val + 1 = k / RATE.val := by
-            have h_div_compute : (k - RATE.val) / RATE.val = k / RATE.val - 1 := by
-              rw [h_eq]
-              rw [Nat.add_mul_div_right _ _ (by omega : 0 < RATE.val)]
-              rw [Nat.div_eq_of_lt h_mod_lt]
-              omega
-            omega
+          have h_fold_eq := (Classical.choose_spec (h_loop_bytes (k - RATE.val) h_mb)).1
           unfold squeeze_fold at h_fold_eq
-          -- h_fold_eq : Nat.fold ((k-RATE)/RATE + 1) ... = .ok (Classical.choose ...).
-          -- Goal: Nat.fold (k/RATE) ... = .ok (Classical.choose ...).
-          -- Use h_div_eq directly.
-          have h_eq_arg : (k - RATE.val) / RATE.val + 1 = k / RATE.val := h_div_eq
-          calc iterate_keccak_f_fold (Foundation.lift s2) (k / RATE.val)
-              = iterate_keccak_f_fold (Foundation.lift s2) ((k - RATE.val) / RATE.val + 1) := by
-                rw [h_eq_arg]
-            _ = .ok (Classical.choose (h_loop_bytes (k - RATE.val) h_mb)) := h_fold_eq
+          exact iter_fold_shift h_RATE_pos hk_RATE h_fold_eq
         · -- Region 3: k ≥ last = blocks_nat * RATE.val. s_b k = s_spec_last.
           push Not at hk_last
           have hsb : s_b k = s_spec_last := by
@@ -959,20 +979,7 @@ theorem keccak.keccak_keccak_spec_blocks_nonzero
                   = .ok s_bj_loop := by rw [← h1, h2]
           exact (Result.ok.injEq _ _).mp this
         rw [h_s_b_eq]
-        have h_div_ge_1 : 1 ≤ k / RATE.val := (Nat.one_le_div_iff (by omega)).mpr hk_RATE
-        have h_kmRATE_mod : (k - RATE.val) % RATE.val = k % RATE.val := by
-          have h_rewrite : k - RATE.val = k % RATE.val + (k / RATE.val - 1) * RATE.val := by
-            have hd := Nat.div_add_mod' k RATE.val
-            have h_split : k / RATE.val * RATE.val = (k / RATE.val - 1) * RATE.val + RATE.val := by
-              conv_lhs => rw [show k / RATE.val = (k / RATE.val - 1) + 1 from by omega]
-              rw [Nat.add_mul, Nat.one_mul]
-            omega
-          rw [h_rewrite]
-          rw [Nat.add_mul_mod_self_right]
-          exact Nat.mod_eq_of_lt (Nat.mod_lt _ (by omega))
-        have h_sub_mod : k - k / RATE.val * RATE.val = k % RATE.val := by
-          have hd := Nat.div_add_mod' k RATE.val; omega
-        rw [h_kmRATE_mod, h_sub_mod]
+        rw [sub_rate_mod_eq h_RATE_pos hk_RATE, sub_div_mul_eq k RATE.val]
       · push Not at hk_last
         -- Region 3: last ≤ k < outlen.
         have h_off_le_k : offset.val ≤ k := by rw [h_offset_eq_last]; exact hk_last
@@ -1089,29 +1096,9 @@ theorem keccak.keccak_keccak_spec_blocks_nonzero
                 else _) = _
           rw [dif_pos hk_RATE, dif_pos hk_last]
         rw [hsb]
-        have h_choose_spec := Classical.choose_spec (h_loop_bytes (k - RATE.val) h_mb)
-        have h_fold_eq := h_choose_spec.1
-        have hd_ge_1 : 1 ≤ k / RATE.val := (Nat.one_le_div_iff (by omega)).mpr hk_RATE
-        have h_mod_lt : k % RATE.val < RATE.val := Nat.mod_lt _ (by omega)
-        have h_kdivmod : k = k / RATE.val * RATE.val + k % RATE.val :=
-          (Nat.div_add_mod' k RATE.val).symm
-        have h_split : k / RATE.val * RATE.val
-                      = (k / RATE.val - 1) * RATE.val + RATE.val := by
-          conv_lhs => rw [show k / RATE.val = (k / RATE.val - 1) + 1 from by omega]
-          rw [Nat.add_mul, Nat.one_mul]
-        have h_eq : k - RATE.val = k % RATE.val + (k / RATE.val - 1) * RATE.val := by omega
-        have h_div_eq : (k - RATE.val) / RATE.val + 1 = k / RATE.val := by
-          have h_div_compute : (k - RATE.val) / RATE.val = k / RATE.val - 1 := by
-            rw [h_eq]
-            rw [Nat.add_mul_div_right _ _ (by omega : 0 < RATE.val)]
-            rw [Nat.div_eq_of_lt h_mod_lt]
-            omega
-          omega
+        have h_fold_eq := (Classical.choose_spec (h_loop_bytes (k - RATE.val) h_mb)).1
         unfold squeeze_fold at h_fold_eq
-        calc iterate_keccak_f_fold (Foundation.lift s2) (k / RATE.val)
-            = iterate_keccak_f_fold (Foundation.lift s2) ((k - RATE.val) / RATE.val + 1) := by
-              rw [h_div_eq]
-          _ = .ok (Classical.choose (h_loop_bytes (k - RATE.val) h_mb)) := h_fold_eq
+        exact iter_fold_shift h_RATE_pos hk_RATE h_fold_eq
     obtain ⟨spec_out, h_spec_squeeze, h_spec_bytes⟩ :=
       sponge_squeeze_byte_eq outlen_us (Foundation.lift s2) RATE h_RATE_pos h_RATE_mod
         h_RATE_le_200 s_b h_iter_const
@@ -1161,20 +1148,7 @@ theorem keccak.keccak_keccak_spec_blocks_nonzero
                 = .ok s_bj_loop := by rw [← h1, h2]
         exact (Result.ok.injEq _ _).mp this
       rw [h_s_b_eq]
-      have h_div_ge_1 : 1 ≤ k / RATE.val := (Nat.one_le_div_iff (by omega)).mpr hk_RATE
-      have h_kmRATE_mod : (k - RATE.val) % RATE.val = k % RATE.val := by
-        have h_rewrite : k - RATE.val = k % RATE.val + (k / RATE.val - 1) * RATE.val := by
-          have hd := Nat.div_add_mod' k RATE.val
-          have h_split : k / RATE.val * RATE.val = (k / RATE.val - 1) * RATE.val + RATE.val := by
-            conv_lhs => rw [show k / RATE.val = (k / RATE.val - 1) + 1 from by omega]
-            rw [Nat.add_mul, Nat.one_mul]
-          omega
-        rw [h_rewrite]
-        rw [Nat.add_mul_mod_self_right]
-        exact Nat.mod_eq_of_lt (Nat.mod_lt _ (by omega))
-      have h_sub_mod : k - k / RATE.val * RATE.val = k % RATE.val := by
-        have hd := Nat.div_add_mod' k RATE.val; omega
-      rw [h_kmRATE_mod, h_sub_mod]
+      rw [sub_rate_mod_eq h_RATE_pos hk_RATE, sub_div_mul_eq k RATE.val]
 
 /-! ### Combined dispatcher: `keccak.keccak_keccak_spec`.
 

--- a/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/Sponge/LoopSpecs.lean
+++ b/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/Sponge/LoopSpecs.lean
@@ -724,45 +724,21 @@ private theorem u8_bv_inj (x y : BitVec 8) :
   · intro h; cases h; rfl
   · intro h; rw [h]
 
-/-- Pure-BV byte-bridge for the `lo` half (in `setWidth 8` form). Closed by
-    `bv_decide` (one call per byte index). -/
-private theorem deinterleave_bv_lo_setWidth_eq_0 (e o : BitVec 32) :
-    (deinterleave_bv e o).1.setWidth 8 = ((lift_lane_bv e o) >>> 0).setWidth 8 := by
-  simp only [deinterleave_bv, lift_lane_bv, spread_to_even]; bv_decide
+/-- Pure-BV byte-bridges in `setWidth 8` form, one general lemma per half.
+    The four byte indices `i < 4` are dispatched by `omega` + `bv_decide`
+    (the case-split is needed because `bv_decide` cannot quantify over the
+    shift amount). -/
+private theorem deinterleave_bv_lo_setWidth_eq (e o : BitVec 32) (i : Nat) (hi : i < 4) :
+    ((deinterleave_bv e o).1 >>> (8 * i)).setWidth 8
+      = ((lift_lane_bv e o) >>> (8 * i)).setWidth 8 := by
+  rcases (show i = 0 ∨ i = 1 ∨ i = 2 ∨ i = 3 from by omega) with h | h | h | h <;>
+    subst h <;> simp only [deinterleave_bv, lift_lane_bv, spread_to_even] <;> bv_decide
 
-private theorem deinterleave_bv_lo_setWidth_eq_1 (e o : BitVec 32) :
-    ((deinterleave_bv e o).1 >>> 8).setWidth 8
-      = ((lift_lane_bv e o) >>> 8).setWidth 8 := by
-  simp only [deinterleave_bv, lift_lane_bv, spread_to_even]; bv_decide
-
-private theorem deinterleave_bv_lo_setWidth_eq_2 (e o : BitVec 32) :
-    ((deinterleave_bv e o).1 >>> 16).setWidth 8
-      = ((lift_lane_bv e o) >>> 16).setWidth 8 := by
-  simp only [deinterleave_bv, lift_lane_bv, spread_to_even]; bv_decide
-
-private theorem deinterleave_bv_lo_setWidth_eq_3 (e o : BitVec 32) :
-    ((deinterleave_bv e o).1 >>> 24).setWidth 8
-      = ((lift_lane_bv e o) >>> 24).setWidth 8 := by
-  simp only [deinterleave_bv, lift_lane_bv, spread_to_even]; bv_decide
-
-private theorem deinterleave_bv_hi_setWidth_eq_0 (e o : BitVec 32) :
-    (deinterleave_bv e o).2.setWidth 8 = ((lift_lane_bv e o) >>> 32).setWidth 8 := by
-  simp only [deinterleave_bv, lift_lane_bv, spread_to_even]; bv_decide
-
-private theorem deinterleave_bv_hi_setWidth_eq_1 (e o : BitVec 32) :
-    ((deinterleave_bv e o).2 >>> 8).setWidth 8
-      = ((lift_lane_bv e o) >>> 40).setWidth 8 := by
-  simp only [deinterleave_bv, lift_lane_bv, spread_to_even]; bv_decide
-
-private theorem deinterleave_bv_hi_setWidth_eq_2 (e o : BitVec 32) :
-    ((deinterleave_bv e o).2 >>> 16).setWidth 8
-      = ((lift_lane_bv e o) >>> 48).setWidth 8 := by
-  simp only [deinterleave_bv, lift_lane_bv, spread_to_even]; bv_decide
-
-private theorem deinterleave_bv_hi_setWidth_eq_3 (e o : BitVec 32) :
-    ((deinterleave_bv e o).2 >>> 24).setWidth 8
-      = ((lift_lane_bv e o) >>> 56).setWidth 8 := by
-  simp only [deinterleave_bv, lift_lane_bv, spread_to_even]; bv_decide
+private theorem deinterleave_bv_hi_setWidth_eq (e o : BitVec 32) (i : Nat) (hi : i < 4) :
+    ((deinterleave_bv e o).2 >>> (8 * i)).setWidth 8
+      = ((lift_lane_bv e o) >>> (8 * (i + 4))).setWidth 8 := by
+  rcases (show i = 0 ∨ i = 1 ∨ i = 2 ∨ i = 3 from by omega) with h | h | h | h <;>
+    subst h <;> simp only [deinterleave_bv, lift_lane_bv, spread_to_even] <;> bv_decide
 
 /-- Convert `BitVec.ofNat 8 (b.toNat >>> off &&& 0xff)` to a pure-BitVec
     `(b >>> off).setWidth 8` form (the latter is `bv_decide`-friendly). -/
@@ -859,86 +835,18 @@ private theorem byte_bridge_hi (e o : BitVec 32) (i : Nat) (_hi : i < 4)
         (BitVec.getElem!_eq_testBit_toNat _ _).symm]
   rw [setWidth8_shift_getElem _ _ _ hj]
 
-/-- Byte-level bridge for byte `0` of the `lo` half. -/
-private theorem deinterleave_bv_lo_toLEBytes_byte_0 (e o : BitVec 32) :
-    (deinterleave_bv e o).1.toLEBytes[0]!
-      = (BitVec.ofNat 8 (((lift_lane_bv e o).toNat >>> 0) &&& 0xff)) := by
-  have h_setW : ((deinterleave_bv e o).1 >>> (8 * 0)).setWidth 8
-                  = ((lift_lane_bv e o) >>> (8 * 0)).setWidth 8 := by
-    simp only [Nat.mul_zero, BitVec.ushiftRight_zero]
-    exact deinterleave_bv_lo_setWidth_eq_0 e o
-  have := byte_bridge_lo e o 0 (by decide) h_setW
-  simpa using this
+/-- Byte-level bridge for the `lo` half: byte `i` (`i < 4`) of the lane. -/
+private theorem deinterleave_bv_lo_toLEBytes_byte (e o : BitVec 32) (i : Nat) (hi : i < 4) :
+    (deinterleave_bv e o).1.toLEBytes[i]!
+      = (BitVec.ofNat 8 (((lift_lane_bv e o).toNat >>> (8 * i)) &&& 0xff)) :=
+  byte_bridge_lo e o i hi (deinterleave_bv_lo_setWidth_eq e o i hi)
 
-private theorem deinterleave_bv_lo_toLEBytes_byte_1 (e o : BitVec 32) :
-    (deinterleave_bv e o).1.toLEBytes[1]!
-      = (BitVec.ofNat 8 (((lift_lane_bv e o).toNat >>> 8) &&& 0xff)) := by
-  have h_setW : ((deinterleave_bv e o).1 >>> (8 * 1)).setWidth 8
-                  = ((lift_lane_bv e o) >>> (8 * 1)).setWidth 8 := by
-    simp only [Nat.mul_one]
-    exact deinterleave_bv_lo_setWidth_eq_1 e o
-  have := byte_bridge_lo e o 1 (by decide) h_setW
-  simpa using this
-
-private theorem deinterleave_bv_lo_toLEBytes_byte_2 (e o : BitVec 32) :
-    (deinterleave_bv e o).1.toLEBytes[2]!
-      = (BitVec.ofNat 8 (((lift_lane_bv e o).toNat >>> 16) &&& 0xff)) := by
-  have h_setW : ((deinterleave_bv e o).1 >>> (8 * 2)).setWidth 8
-                  = ((lift_lane_bv e o) >>> (8 * 2)).setWidth 8 := by
-    show ((deinterleave_bv e o).1 >>> 16).setWidth 8 = _
-    exact deinterleave_bv_lo_setWidth_eq_2 e o
-  have := byte_bridge_lo e o 2 (by decide) h_setW
-  simpa using this
-
-private theorem deinterleave_bv_lo_toLEBytes_byte_3 (e o : BitVec 32) :
-    (deinterleave_bv e o).1.toLEBytes[3]!
-      = (BitVec.ofNat 8 (((lift_lane_bv e o).toNat >>> 24) &&& 0xff)) := by
-  have h_setW : ((deinterleave_bv e o).1 >>> (8 * 3)).setWidth 8
-                  = ((lift_lane_bv e o) >>> (8 * 3)).setWidth 8 := by
-    show ((deinterleave_bv e o).1 >>> 24).setWidth 8 = _
-    exact deinterleave_bv_lo_setWidth_eq_3 e o
-  have := byte_bridge_lo e o 3 (by decide) h_setW
-  simpa using this
-
-private theorem deinterleave_bv_hi_toLEBytes_byte_0 (e o : BitVec 32) :
-    (deinterleave_bv e o).2.toLEBytes[0]!
-      = (BitVec.ofNat 8 (((lift_lane_bv e o).toNat >>> 32) &&& 0xff)) := by
-  have h_setW : ((deinterleave_bv e o).2 >>> (8 * 0)).setWidth 8
-                  = ((lift_lane_bv e o) >>> (8 * (0 + 4))).setWidth 8 := by
-    simp only [Nat.mul_zero, BitVec.ushiftRight_zero, Nat.zero_add]
-    exact deinterleave_bv_hi_setWidth_eq_0 e o
-  have := byte_bridge_hi e o 0 (by decide) h_setW
-  simpa using this
-
-private theorem deinterleave_bv_hi_toLEBytes_byte_1 (e o : BitVec 32) :
-    (deinterleave_bv e o).2.toLEBytes[1]!
-      = (BitVec.ofNat 8 (((lift_lane_bv e o).toNat >>> 40) &&& 0xff)) := by
-  have h_setW : ((deinterleave_bv e o).2 >>> (8 * 1)).setWidth 8
-                  = ((lift_lane_bv e o) >>> (8 * (1 + 4))).setWidth 8 := by
-    show ((deinterleave_bv e o).2 >>> 8).setWidth 8 = _
-    exact deinterleave_bv_hi_setWidth_eq_1 e o
-  have := byte_bridge_hi e o 1 (by decide) h_setW
-  simpa using this
-
-private theorem deinterleave_bv_hi_toLEBytes_byte_2 (e o : BitVec 32) :
-    (deinterleave_bv e o).2.toLEBytes[2]!
-      = (BitVec.ofNat 8 (((lift_lane_bv e o).toNat >>> 48) &&& 0xff)) := by
-  have h_setW : ((deinterleave_bv e o).2 >>> (8 * 2)).setWidth 8
-                  = ((lift_lane_bv e o) >>> (8 * (2 + 4))).setWidth 8 := by
-    show ((deinterleave_bv e o).2 >>> 16).setWidth 8 = _
-    exact deinterleave_bv_hi_setWidth_eq_2 e o
-  have := byte_bridge_hi e o 2 (by decide) h_setW
-  simpa using this
-
-private theorem deinterleave_bv_hi_toLEBytes_byte_3 (e o : BitVec 32) :
-    (deinterleave_bv e o).2.toLEBytes[3]!
-      = (BitVec.ofNat 8 (((lift_lane_bv e o).toNat >>> 56) &&& 0xff)) := by
-  have h_setW : ((deinterleave_bv e o).2 >>> (8 * 3)).setWidth 8
-                  = ((lift_lane_bv e o) >>> (8 * (3 + 4))).setWidth 8 := by
-    show ((deinterleave_bv e o).2 >>> 24).setWidth 8 = _
-    exact deinterleave_bv_hi_setWidth_eq_3 e o
-  have := byte_bridge_hi e o 3 (by decide) h_setW
-  simpa using this
+/-- Byte-level bridge for the `hi` half: byte `i` (`i < 4`), i.e. byte `i + 4`
+    of the full 64-bit lane. -/
+private theorem deinterleave_bv_hi_toLEBytes_byte (e o : BitVec 32) (i : Nat) (hi : i < 4) :
+    (deinterleave_bv e o).2.toLEBytes[i]!
+      = (BitVec.ofNat 8 (((lift_lane_bv e o).toNat >>> (8 * (i + 4))) &&& 0xff)) :=
+  byte_bridge_hi e o i hi (deinterleave_bv_hi_setWidth_eq e o i hi)
 
 /-- The outer fixpoint of `state.store_block_2u32_loop` terminates with
     `.ok`, preserves the length of the output slice, and at every byte
@@ -1173,16 +1081,8 @@ theorem state.store_block_2u32_loop_spec
               rw [show lift_lane r_4 = ⟨lift_lane_bv (r_4.val[0]!).bv (r_4.val[1]!).bv⟩ from rfl]
               -- lift_lane.bv = lift_lane_bv ...
               rw [hb_mod_8, h_r6]
-              -- Goal: lo half byte (b - 8k) ∈ [0,4), bridge via the 4 byte_i helpers.
-              rcases (show b - 8 * k.val = 0 ∨ b - 8 * k.val = 1
-                          ∨ b - 8 * k.val = 2 ∨ b - 8 * k.val = 3 from by omega) with
-                heq | heq | heq | heq <;>
-                ( rw [heq]
-                  first
-                  | exact deinterleave_bv_lo_toLEBytes_byte_0 _ _
-                  | exact deinterleave_bv_lo_toLEBytes_byte_1 _ _
-                  | exact deinterleave_bv_lo_toLEBytes_byte_2 _ _
-                  | exact deinterleave_bv_lo_toLEBytes_byte_3 _ _)
+              -- Goal: lo half byte (b - 8k) ∈ [0,4), bridge via the general lo helper.
+              exact deinterleave_bv_lo_toLEBytes_byte _ _ _ (by omega)
             · -- Middle of SECOND setSlice (offset 8k+4, length 4).
               push Not at hb_lt_p1
               have hb_lt_p2 : b < 8 * k.val + 8 := by omega
@@ -1230,15 +1130,8 @@ theorem state.store_block_2u32_loop_spec
               have hb_decomp : 8 * (b - 8 * k.val)
                                   = 8 * ((b - (8 * k.val + 4)) + 4) := by omega
               rw [hb_decomp]
-              rcases (show b - (8 * k.val + 4) = 0 ∨ b - (8 * k.val + 4) = 1
-                          ∨ b - (8 * k.val + 4) = 2 ∨ b - (8 * k.val + 4) = 3 from by omega) with
-                heq | heq | heq | heq <;>
-                ( rw [heq]
-                  first
-                  | exact deinterleave_bv_hi_toLEBytes_byte_0 _ _
-                  | exact deinterleave_bv_hi_toLEBytes_byte_1 _ _
-                  | exact deinterleave_bv_hi_toLEBytes_byte_2 _ _
-                  | exact deinterleave_bv_hi_toLEBytes_byte_3 _ _)
+              -- Goal: hi half byte (b - (8k+4)) ∈ [0,4), bridge via the general hi helper.
+              exact deinterleave_bv_hi_toLEBytes_byte _ _ _ (by omega)
         · -- Untouched bytes: 8(k+1) ≤ b → preserved.
           intro b hb_ge hb_25
           have hb_ge_8k1 : 8 * (k.val + 1) ≤ b := by

--- a/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/Sponge/SqueezeBlock.lean
+++ b/libcrux-iot/sha3/proofs/aeneas-lean/LibcruxIotSha3/Sponge/SqueezeBlock.lean
@@ -268,6 +268,71 @@ theorem core_models_Array_Insts_index_RangeUsize_spec
     · rw [hv_val, h_slice_val]
     · rw [hv_len]
 
+/-! ### Helper: copy the first `out.length` bytes of a 200-byte buffer.
+
+The trailing portion shared by `squeeze_last` and `squeeze_first_and_last`:
+given the filled 200-byte buffer `b1`, index it by `[0, out.length)` and
+`copy_from_slice` into `out`. Produces the resulting slice `s2` together with
+the impl-side index equality (already through the wrapper instance), the
+`copy_from_slice` equality, and the length / per-byte characterization. -/
+private theorem squeeze_copy_tail
+    (out : Slice Std.U8) (b1 : Std.Array Std.U8 200#usize)
+    (h_out_le : out.val.length ≤ 200) :
+    ∃ s2 : Slice Std.U8,
+      CoreModels.core.Array.Insts.CoreOpsIndexIndex.index
+        (CoreModels.core.Slice.Insts.CoreOpsIndexIndex
+          (CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice Std.U8))
+        b1 { start := 0#usize, «end» := Std.Slice.len out } = .ok s2
+      ∧ CoreModels.core.slice.Slice.copy_from_slice
+          CoreModels.core.U8.Insts.CoreMarkerCopy out s2 = .ok s2
+      ∧ s2.val.length = out.val.length
+      ∧ ∀ k : Nat, k < out.val.length → s2.val[k]! = b1.val[k]! := by
+  set i := Std.Slice.len out
+  have h_i_val : i.val = out.val.length := by
+    simp [i, Std.Slice.len]
+  -- Index `b1` by `[0, i)` via the Array-index helper.
+  have h_i_le : (0#usize : Std.Usize).val ≤ i.val := by
+    show 0 ≤ i.val; omega
+  have h_i_le_N : i.val ≤ (200#usize : Std.Usize).val := by
+    rw [h_i_val]; show out.val.length ≤ 200; omega
+  obtain ⟨s2, h_s2_eq, h_s2_val, h_s2_len⟩ :=
+    triple_exists_ok_sb
+      (core_models_Array_Insts_index_RangeUsize_spec
+        b1 { start := 0#usize, «end» := i } h_i_le h_i_le_N)
+  have h_s2_len' : s2.val.length = out.val.length := by
+    rw [h_s2_len]
+    show i.val - 0 = out.val.length
+    omega
+  have h_s2_bytes : ∀ k : Nat, k < out.val.length → s2.val[k]! = b1.val[k]! := by
+    intro k hk
+    rw [h_s2_val]
+    -- `b1.val.slice 0 i.val = (b1.val.drop 0).take i.val = b1.val.take i.val`.
+    show (List.slice ((0#usize : Std.Usize).val) i.val b1.val)[k]! = _
+    have h_zero : ((0#usize : Std.Usize).val : Nat) = 0 := rfl
+    rw [h_zero]
+    unfold List.slice
+    rw [List.drop_zero]
+    have hk_i : k < i.val := by rw [h_i_val]; exact hk
+    exact List.getElem!_take_of_lt _ k _ hk_i
+  -- `copy_from_slice out s2` succeeds (lengths agree) and returns `s2`.
+  have h_copy : CoreModels.core.slice.Slice.copy_from_slice
+        CoreModels.core.U8.Insts.CoreMarkerCopy out s2 = .ok s2 := by
+    unfold CoreModels.core.slice.Slice.copy_from_slice
+    have h_len_eq : Std.Slice.len out = Std.Slice.len s2 := by
+      apply Std.UScalar.eq_of_val_eq
+      simp [Std.Slice.len, h_s2_len']
+    simp [h_len_eq]
+  -- Wrapper-identity: `Slice.Insts.CoreOpsIndexIndex inst = inst`.
+  have h_wrap_eq :
+      CoreModels.core.Slice.Insts.CoreOpsIndexIndex
+        (CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice Std.U8)
+      = CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice Std.U8 := by
+    unfold CoreModels.core.Slice.Insts.CoreOpsIndexIndex
+    rfl
+  refine ⟨s2, ?_, h_copy, h_s2_len', h_s2_bytes⟩
+  rw [h_wrap_eq]
+  exact h_s2_eq
+
 /-! ### Triple 3: `keccak.squeeze_last`. -/
 
 /-- `keccak.squeeze_last RATE s out` —
@@ -311,58 +376,10 @@ theorem keccak.squeeze_last_spec
   -- Step 3: discharge `Slice.len out`.
   have h_len : CoreModels.core.slice.Slice.len out = .ok (Std.Slice.len out) := by
     unfold CoreModels.core.slice.Slice.len; rfl
-  set i := Std.Slice.len out
-  have h_i_val : i.val = out.val.length := by
-    simp [i, Std.Slice.len]
-  -- Step 4: index `b1` by `[0, i)`. We use the helper above.
-  have h_i_le : (0#usize : Std.Usize).val ≤ i.val := by
-    show 0 ≤ i.val; omega
-  have h_i_le_N : i.val ≤ (200#usize : Std.Usize).val := by
-    rw [h_i_val]
-    have hb1len : b1.val.length = 200 := h_b1_len
-    have hb1_prop : b1.val.length = (200#usize : Std.Usize).val := by
-      rw [hb1len]; rfl
-    show i.val ≤ 200
-    -- Need out.val.length ≤ 200.
-    rw [h_i_val]
-    omega
-  obtain ⟨s2, h_s2_eq, h_s2_val, h_s2_len⟩ :=
-    triple_exists_ok_sb
-      (core_models_Array_Insts_index_RangeUsize_spec
-        b1 { start := 0#usize, «end» := i } h_i_le h_i_le_N)
-  -- s2.val = b1.val.slice 0 i.val = (b1.val.drop 0).take i.val.
-  -- We need: s2.val.length = out.val.length, and for k < out.val.length, s2.val[k]! = b1.val[k]!.
-  have h_s2_len' : s2.val.length = out.val.length := by
-    rw [h_s2_len]
-    show i.val - 0 = out.val.length
-    omega
-  have h_s2_bytes : ∀ k : Nat, k < out.val.length → s2.val[k]! = b1.val[k]! := by
-    intro k hk
-    rw [h_s2_val]
-    -- `b1.val.slice 0 i.val = (b1.val.drop 0).take i.val = b1.val.take i.val`.
-    show (List.slice ((0#usize : Std.Usize).val) i.val b1.val)[k]! = _
-    have h_zero : ((0#usize : Std.Usize).val : Nat) = 0 := rfl
-    rw [h_zero]
-    unfold List.slice
-    rw [List.drop_zero]
-    have hk_i : k < i.val := by rw [h_i_val]; exact hk
-    exact List.getElem!_take_of_lt _ k _ hk_i
-  -- Step 5: discharge `copy_from_slice out s2`. Length check: out.val.length = s2.val.length.
-  have h_copy : CoreModels.core.slice.Slice.copy_from_slice
-        CoreModels.core.U8.Insts.CoreMarkerCopy out s2 = .ok s2 := by
-    unfold CoreModels.core.slice.Slice.copy_from_slice
-    have h_len_eq : Std.Slice.len out = Std.Slice.len s2 := by
-      apply Std.UScalar.eq_of_val_eq
-      simp [Std.Slice.len, h_s2_len']
-    simp [h_len_eq]
-  -- Wrapper-identity: `Slice.Insts.CoreOpsIndexIndex inst = inst`.
-  have h_wrap_eq :
-      CoreModels.core.Slice.Insts.CoreOpsIndexIndex
-        (CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice Std.U8)
-      = CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice Std.U8 := by
-    unfold CoreModels.core.Slice.Insts.CoreOpsIndexIndex
-    rfl
-  -- Step 6: assemble impl-side equality.
+  -- Step 4: copy the first `out.length` bytes of the 200-byte buffer `b1`.
+  obtain ⟨s2, h_s2_eq, h_copy, h_s2_len', h_s2_bytes⟩ :=
+    squeeze_copy_tail out b1 (by omega)
+  -- Step 5: assemble impl-side equality.
   have h_impl_eq :
       keccak.squeeze_last RATE s out = .ok s2 := by
     unfold keccak.squeeze_last
@@ -370,10 +387,9 @@ theorem keccak.squeeze_last_spec
     rw [h_classify]; simp only [bind_tc_ok]
     rw [h_b1_eq]; simp only [bind_tc_ok]
     rw [h_len]; simp only [bind_tc_ok]
-    rw [h_wrap_eq]
     rw [h_s2_eq]; simp only [bind_tc_ok]
     exact h_copy
-  -- Step 7: build the per-byte post.
+  -- Step 6: build the per-byte post.
   -- For k < out.val.length ≤ RATE.val, s2.val[k]! = b1.val[k]! = the toLEBytes-of-lift formula on s1.
   -- And `Foundation.lift s1 = s_spec` where keccak_f (lift s) = .ok s_spec.
   refine triple_of_ok_sb (v := s2) h_impl_eq ?_
@@ -415,50 +431,10 @@ theorem keccak.squeeze_first_and_last_spec
   -- Step 2: discharge `Slice.len out`.
   have h_len : CoreModels.core.slice.Slice.len out = .ok (Std.Slice.len out) := by
     unfold CoreModels.core.slice.Slice.len; rfl
-  set i := Std.Slice.len out
-  have h_i_val : i.val = out.val.length := by
-    simp [i, Std.Slice.len]
-  -- Step 3: index `b1` by `[0, i)`.
-  have h_i_le : (0#usize : Std.Usize).val ≤ i.val := by
-    show 0 ≤ i.val; omega
-  have h_i_le_N : i.val ≤ (200#usize : Std.Usize).val := by
-    rw [h_i_val]
-    show out.val.length ≤ 200
-    omega
-  obtain ⟨s2, h_s2_eq, h_s2_val, h_s2_len⟩ :=
-    triple_exists_ok_sb
-      (core_models_Array_Insts_index_RangeUsize_spec
-        b1 { start := 0#usize, «end» := i } h_i_le h_i_le_N)
-  have h_s2_len' : s2.val.length = out.val.length := by
-    rw [h_s2_len]
-    show i.val - 0 = out.val.length
-    omega
-  have h_s2_bytes : ∀ k : Nat, k < out.val.length → s2.val[k]! = b1.val[k]! := by
-    intro k hk
-    rw [h_s2_val]
-    show (List.slice ((0#usize : Std.Usize).val) i.val b1.val)[k]! = _
-    have h_zero : ((0#usize : Std.Usize).val : Nat) = 0 := rfl
-    rw [h_zero]
-    unfold List.slice
-    rw [List.drop_zero]
-    have hk_i : k < i.val := by rw [h_i_val]; exact hk
-    exact List.getElem!_take_of_lt _ k _ hk_i
-  -- Step 4: discharge `copy_from_slice out s2`.
-  have h_copy : CoreModels.core.slice.Slice.copy_from_slice
-        CoreModels.core.U8.Insts.CoreMarkerCopy out s2 = .ok s2 := by
-    unfold CoreModels.core.slice.Slice.copy_from_slice
-    have h_len_eq : Std.Slice.len out = Std.Slice.len s2 := by
-      apply Std.UScalar.eq_of_val_eq
-      simp [Std.Slice.len, h_s2_len']
-    simp [h_len_eq]
-  -- Wrapper-identity: `Slice.Insts.CoreOpsIndexIndex inst = inst`.
-  have h_wrap_eq :
-      CoreModels.core.Slice.Insts.CoreOpsIndexIndex
-        (CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice Std.U8)
-      = CoreModels.core.ops.range.RangeUsize.Insts.CoreSliceIndexSliceIndexSliceSlice Std.U8 := by
-    unfold CoreModels.core.Slice.Insts.CoreOpsIndexIndex
-    rfl
-  -- Step 5: assemble impl-side equality.
+  -- Step 3: copy the first `out.length` bytes of the 200-byte buffer `b1`.
+  obtain ⟨s2, h_s2_eq, h_copy, h_s2_len', h_s2_bytes⟩ :=
+    squeeze_copy_tail out b1 (by omega)
+  -- Step 4: assemble impl-side equality.
   have h_impl_eq :
       keccak.squeeze_first_and_last RATE s out = .ok s2 := by
     unfold keccak.squeeze_first_and_last
@@ -476,10 +452,9 @@ theorem keccak.squeeze_first_and_last_spec
     rw [h_classify]; simp only [bind_tc_ok]
     rw [h_b1_eq]; simp only [bind_tc_ok]
     rw [h_len]; simp only [bind_tc_ok]
-    rw [h_wrap_eq]
     rw [h_s2_eq]; simp only [bind_tc_ok]
     exact h_copy
-  -- Step 6: build the per-byte post.
+  -- Step 5: build the per-byte post.
   refine triple_of_ok_sb (v := s2) h_impl_eq ?_
   refine ⟨h_s2_len', ?_⟩
   intro k hk


### PR DESCRIPTION
I wanted to get a better feel for what it is like to work with claude code in these Lean proofs. I prompted it to review parts of the code and identify whether the verbosity is necessary/beneficial or if there are places in the proof that can be made more succinct.

This set of commits was authored by claude code (opus 4.8) and reduces some code duplication. The top-level theorems themselves are not changed, only their proofs and some proofs further down.

I'm unsure whether these changes are actually an improvement for a human or for an LLM. I suspect there is a trade-off between verbose, straight-line proofs, without many abstractions and some duplication, which then require more context for the LLM to work on it, and more succinct code with more abstractions which requires less context but might be harder to reason about. I'm not sure which style is better for further LLM-driven iteration.

@abentkamp Do you have thoughts on this trade-off and this style of refactoring done in this PR?