### PR TITLE
[sha3] derive clone for keccak sponge state and hashers

### DIFF
--- a/libcrux-iot/sha3/src/hasher.rs
+++ b/libcrux-iot/sha3/src/hasher.rs
@@ -12,6 +12,7 @@ macro_rules! impl_incremental_hash {
         /// A type that allows incremental hashing."
         ///
         /// This type also implements the array-ref and slice one-shot hashing [`libcrux_traits::digest`] traits."
+        #[derive(Clone)]
         pub struct $type {
             inner: KeccakSpongeState<$rate>,
         }

--- a/libcrux-iot/sha3/src/keccak.rs
+++ b/libcrux-iot/sha3/src/keccak.rs
@@ -11,6 +11,7 @@ use crate::state::KeccakState;
 
 /// The internal keccak state that can also buffer inputs to absorb.
 /// This is used in the general xof APIs and the incremental hashers in [`crate::hasher`].
+#[derive(Clone)]
 pub(crate) struct KeccakSpongeState<const RATE: usize> {
     inner: KeccakState,
 


### PR DESCRIPTION
Clone is needed for integration with embedded-cal and a nice thing to have in any case.

We could also impl Copy, but I chose not to. I think copying a hashers state should be deliberate and explicit.