### PR TITLE
[aes] secret independence

### DIFF
--- a/.github/workflows/aes-build-test.yml
+++ b/.github/workflows/aes-build-test.yml
@@ -1,0 +1,100 @@
+name: AES - Build & Test
+
+permissions: {}
+
+on:
+  merge_group:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main", "*"]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: ${{ github.event_name != 'merge_group' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # These are all arm64, of course, but at least we can test on
+        # some ARM architectures with different stack size defaults
+        # etc
+        os:
+          - ubuntu-24.04-arm
+          - macos-latest
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+        working-directory: libcrux-iot/aes
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      # Build ...
+      - name: 🔨 Build
+        run: |
+          rustc --print=cfg
+          cargo build --verbose
+
+      - name: 🔨 Build Release
+        run: cargo build --verbose --release
+
+      # Test ...
+      - name: 🏃🏻‍♀️ Test
+        run: |
+          cargo clean
+          cargo test --verbose
+
+      - name: 🏃🏻‍♀️ Test with -F check-secret-independence
+        run: |
+          cargo clean
+          cargo test --verbose -F check-secret-independence
+
+      - name: 🏃🏻‍♀️ Test Release
+        run: |
+          cargo clean
+          cargo test --verbose --release
+
+  asan:
+    if: ${{ github.event_name != 'merge_group' }}
+    runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: libcrux-iot/aes
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install nightly Rust
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: "aarch64-apple-darwin"
+
+      - name: 🏃🏻 Asan MacOS
+        run: RUSTDOCFLAGS=-Zsanitizer=address RUSTFLAGS=-Zsanitizer=address cargo +nightly test --release --target aarch64-apple-darwin
+
+  aes-build-test-status:
+    if: ${{ always() }}
+    needs: [build, asan]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Successful
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Failing
+        if: ${{ (contains(needs.*.result, 'failure')) }}
+        run: exit 1

--- a/libcrux-iot/Cargo.toml
+++ b/libcrux-iot/Cargo.toml
@@ -31,7 +31,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 [patch.crates-io]
 hax-lib = { git = "https://github.com/cryspen/hax", branch = "jonas/fstar-wrapping" }
 # patch until libcrux-secrets 0.0.6 is released
-libcrux-secrets = { git = "https://github.com/cryspen/libcrux.git", rev = "c4253d211a605f4a284c595fc6ca28ae18dd07ba" }
+libcrux-secrets = { git = "https://github.com/cryspen/libcrux.git", rev = "10a65cfa9175e8f78198f24ba450c17090622945" }
 
 [profile.release-debug]
 inherits = "release"

--- a/libcrux-iot/aes/Cargo.toml
+++ b/libcrux-iot/aes/Cargo.toml
@@ -18,6 +18,11 @@ libcrux-traits.workspace = true
 libcrux-secrets.workspace = true
 
 [features]
+# Currently, the libcrux-secrets types are only used in the high-level libcrux-traits
+# implementations for the aes gcm types. Internally, this crate does not use secrets types.
+# We currently declassify at the boundary between libcrux-traits implementations and the
+# internal APIs.
+check-secret-independence = ["libcrux-secrets/check-secret-independence"]
 default = []
 std = [] # This is only used stderr output in tests.
 

--- a/libcrux-iot/aes/examples/bench_typed_owned.rs
+++ b/libcrux-iot/aes/examples/bench_typed_owned.rs
@@ -3,21 +3,28 @@ use libcrux_iot_aes::{
     aes_gcm_128::{Key, Nonce, Tag},
     AeadConsts as _, AesGcm128,
 };
+use libcrux_secrets::{Classify, ClassifyRef};
 
 fn main() {
     const PAYLOAD_SIZE: usize = 3045;
 
-    let key: Key = [0x16; AesGcm128::KEY_LEN].into();
-    let nonce: Nonce = [0x12; AesGcm128::NONCE_LEN].into();
+    let key: Key = [0x16; AesGcm128::KEY_LEN].classify().into();
+    let nonce: Nonce = [0x12; AesGcm128::NONCE_LEN].classify().into();
 
     let aad = [0xff; 32];
     let plaintext = [0xab; PAYLOAD_SIZE];
 
     let mut ciphertext = vec![0; PAYLOAD_SIZE];
-    let mut tag: Tag = [0u8; AesGcm128::TAG_LEN].into();
+    let mut tag: Tag = [0u8; AesGcm128::TAG_LEN].classify().into();
 
     for _ in 0..10000 {
-        key.encrypt(&mut ciphertext, &mut tag, &nonce, &aad, &plaintext)
-            .unwrap();
+        key.encrypt(
+            &mut ciphertext,
+            &mut tag,
+            &nonce,
+            &aad,
+            plaintext.classify_ref(),
+        )
+        .unwrap();
     }
 }

--- a/libcrux-iot/aes/examples/bench_typed_refs.rs
+++ b/libcrux-iot/aes/examples/bench_typed_refs.rs
@@ -1,5 +1,6 @@
 // structs for typed_owned
 use libcrux_iot_aes::{Aead as _, AeadConsts as _, AesGcm128};
+use libcrux_secrets::{ClassifyRef, ClassifyRefMut};
 
 fn main() {
     const PAYLOAD_SIZE: usize = 3045;
@@ -8,8 +9,12 @@ fn main() {
 
     let mut tag_bytes = [0u8; AesGcm128::TAG_LEN];
 
-    let key = algo.new_key(&[0x16; AesGcm128::KEY_LEN]).unwrap();
-    let nonce = algo.new_nonce(&[0x12; AesGcm128::NONCE_LEN]).unwrap();
+    let key = algo
+        .new_key((&[0x16; AesGcm128::KEY_LEN]).classify_ref())
+        .unwrap();
+    let nonce = algo
+        .new_nonce((&[0x12; AesGcm128::NONCE_LEN]).classify_ref())
+        .unwrap();
 
     let aad = [0xff; 32];
     let plaintext = [0xab; PAYLOAD_SIZE];
@@ -17,8 +22,8 @@ fn main() {
     let mut ciphertext = vec![0; PAYLOAD_SIZE];
 
     for _ in 0..10000 {
-        let tag = algo.new_tag_mut(&mut tag_bytes).unwrap();
-        key.encrypt(&mut ciphertext, tag, nonce, &aad, &plaintext)
+        let tag = algo.new_tag_mut(tag_bytes.classify_ref_mut()).unwrap();
+        key.encrypt(&mut ciphertext, tag, nonce, &aad, plaintext.classify_ref())
             .unwrap();
     }
 }

--- a/libcrux-iot/aes/src/aes_gcm_128.rs
+++ b/libcrux-iot/aes/src/aes_gcm_128.rs
@@ -36,17 +36,18 @@ type_aliases!(AesGcm128, "AES-GCM 128");
 ///     aes_gcm_128::portable::{Key, Nonce, PortableAesGcm128, Tag},
 ///     AeadConsts as _, NONCE_LEN, TAG_LEN,
 /// };
+/// use libcrux_secrets::{Classify, ClassifyRef, ClassifyRefMut};
 ///
-/// let k: Key<PortableAesGcm128> = [0; PortableAesGcm128::KEY_LEN].into();
-/// let nonce: Nonce<PortableAesGcm128> = [0; NONCE_LEN].into();
-/// let mut tag: Tag<PortableAesGcm128> = [0; TAG_LEN].into();
+/// let k: Key<PortableAesGcm128> = [0; PortableAesGcm128::KEY_LEN].classify().into();
+/// let nonce: Nonce<PortableAesGcm128> = [0; NONCE_LEN].classify().into();
+/// let mut tag: Tag<PortableAesGcm128> = [0; TAG_LEN].classify().into();
 ///
 /// let pt = b"the quick brown fox jumps over the lazy dog";
 /// let mut ct = [0; 43];
 /// let mut pt_out = [0; 43];
 ///
-/// k.encrypt(&mut ct, &mut tag, &nonce, b"", pt).unwrap();
-/// k.decrypt(&mut pt_out, &nonce, b"", &ct, &tag).unwrap();
+/// k.encrypt(&mut ct, &mut tag, &nonce, b"", pt.classify_ref()).unwrap();
+/// k.decrypt(pt_out.classify_ref_mut(), &nonce, b"", &ct, &tag).unwrap();
 /// assert_eq!(pt, &pt_out);
 /// ```
 pub mod portable {

--- a/libcrux-iot/aes/src/aes_gcm_256.rs
+++ b/libcrux-iot/aes/src/aes_gcm_256.rs
@@ -36,17 +36,18 @@ type_aliases!(AesGcm256, "AES-GCM 256");
 ///     aes_gcm_256::portable::{Key, Nonce, PortableAesGcm256, Tag},
 ///     AeadConsts as _, NONCE_LEN, TAG_LEN,
 /// };
+/// use libcrux_secrets::{Classify, ClassifyRef, ClassifyRefMut};
 ///
-/// let k: Key<PortableAesGcm256> = [0; PortableAesGcm256::KEY_LEN].into();
-/// let nonce: Nonce<PortableAesGcm256> = [0; NONCE_LEN].into();
-/// let mut tag: Tag<PortableAesGcm256> = [0; TAG_LEN].into();
+/// let k: Key<PortableAesGcm256> = [0; PortableAesGcm256::KEY_LEN].classify().into();
+/// let nonce: Nonce<PortableAesGcm256> = [0; NONCE_LEN].classify().into();
+/// let mut tag: Tag<PortableAesGcm256> = [0; TAG_LEN].classify().into();
 ///
 /// let pt = b"the quick brown fox jumps over the lazy dog";
 /// let mut ct = [0; 43];
 /// let mut pt_out = [0; 43];
 ///
-/// k.encrypt(&mut ct, &mut tag, &nonce, b"", pt).unwrap();
-/// k.decrypt(&mut pt_out, &nonce, b"", &ct, &tag).unwrap();
+/// k.encrypt(&mut ct, &mut tag, &nonce, b"", pt.classify_ref()).unwrap();
+/// k.decrypt(pt_out.classify_ref_mut(), &nonce, b"", &ct, &tag).unwrap();
 /// assert_eq!(pt, &pt_out);
 /// ```
 pub mod portable {

--- a/libcrux-iot/aes/src/lib.rs
+++ b/libcrux-iot/aes/src/lib.rs
@@ -16,17 +16,18 @@
 //! use libcrux_iot_aes::{
 //!     AeadConsts as _, AesGcm128, AesGcm128Key, AesGcm128Nonce, AesGcm128Tag, NONCE_LEN, TAG_LEN,
 //! };
+//! use libcrux_secrets::{Classify, ClassifyRef, ClassifyRefMut};
 //!
-//! let k: AesGcm128Key = [0; AesGcm128::KEY_LEN].into();
-//! let nonce: AesGcm128Nonce = [0; NONCE_LEN].into();
-//! let mut tag: AesGcm128Tag = [0; TAG_LEN].into();
+//! let k: AesGcm128Key = [0; AesGcm128::KEY_LEN].classify().into();
+//! let nonce: AesGcm128Nonce = [0; NONCE_LEN].classify().into();
+//! let mut tag: AesGcm128Tag = [0; TAG_LEN].classify().into();
 //!
 //! let pt = b"the quick brown fox jumps over the lazy dog";
 //! let mut ct = [0; 43];
 //! let mut pt_out = [0; 43];
 //!
-//! k.encrypt(&mut ct, &mut tag, &nonce, b"", pt).unwrap();
-//! k.decrypt(&mut pt_out, &nonce, b"", &ct, &tag).unwrap();
+//! k.encrypt(&mut ct, &mut tag, &nonce, b"", pt.classify_ref()).unwrap();
+//! k.decrypt(pt_out.classify_ref_mut(), &nonce, b"", &ct, &tag).unwrap();
 //! assert_eq!(pt, &pt_out);
 //! ```
 //!
@@ -74,17 +75,18 @@ mod aes_gcm;
 ///     aes_gcm_128::{AesGcm128, Key, Nonce, Tag},
 ///     AeadConsts as _, NONCE_LEN, TAG_LEN,
 /// };
+/// use libcrux_secrets::{Classify, ClassifyRef, ClassifyRefMut};
 ///
-/// let k: Key = [0; AesGcm128::KEY_LEN].into();
-/// let nonce: Nonce = [0; NONCE_LEN].into();
-/// let mut tag: Tag = [0; TAG_LEN].into();
+/// let k: Key = [0; AesGcm128::KEY_LEN].classify().into();
+/// let nonce: Nonce = [0; NONCE_LEN].classify().into();
+/// let mut tag: Tag = [0; TAG_LEN].classify().into();
 ///
 /// let pt = b"the quick brown fox jumps over the lazy dog";
 /// let mut ct = [0; 43];
 /// let mut pt_out = [0; 43];
 ///
-/// k.encrypt(&mut ct, &mut tag, &nonce, b"", pt).unwrap();
-/// k.decrypt(&mut pt_out, &nonce, b"", &ct, &tag).unwrap();
+/// k.encrypt(&mut ct, &mut tag, &nonce, b"", pt.classify_ref()).unwrap();
+/// k.decrypt(pt_out.classify_ref_mut(), &nonce, b"", &ct, &tag).unwrap();
 /// assert_eq!(pt, &pt_out);
 /// ```
 ///
@@ -93,22 +95,23 @@ mod aes_gcm;
 /// ```rust
 /// // Using the multiplexed API
 /// use libcrux_iot_aes::{aes_gcm_128::AesGcm128, Aead as _, AeadConsts as _, NONCE_LEN, TAG_LEN};
+/// use libcrux_secrets::{ClassifyRef, ClassifyRefMut};
 ///
 /// let algo = AesGcm128;
 ///
 /// let mut tag_bytes = [0; TAG_LEN];
-/// let tag = algo.new_tag_mut(&mut tag_bytes).unwrap();
+/// let tag = algo.new_tag_mut(tag_bytes.classify_ref_mut()).unwrap();
 ///
-/// let key = algo.new_key(&[0; AesGcm128::KEY_LEN]).unwrap();
-/// let nonce = algo.new_nonce(&[0; NONCE_LEN]).unwrap();
+/// let key = algo.new_key((&[0; AesGcm128::KEY_LEN]).classify_ref()).unwrap();
+/// let nonce = algo.new_nonce((&[0; NONCE_LEN]).classify_ref()).unwrap();
 ///
 /// let pt = b"the quick brown fox jumps over the lazy dog";
 /// let mut ct = [0; 43];
 /// let mut pt_out = [0; 43];
 ///
-/// key.encrypt(&mut ct, tag, nonce, b"", pt).unwrap();
-/// let tag = algo.new_tag(&tag_bytes).unwrap();
-/// key.decrypt(&mut pt_out, nonce, b"", &ct, tag).unwrap();
+/// key.encrypt(&mut ct, tag, nonce, b"", pt.classify_ref()).unwrap();
+/// let tag = algo.new_tag(tag_bytes.classify_ref()).unwrap();
+/// key.decrypt(pt_out.classify_ref_mut(), nonce, b"", &ct, tag).unwrap();
 /// assert_eq!(pt, &pt_out);
 /// ```
 pub mod aes_gcm_128;
@@ -136,17 +139,18 @@ pub mod aes_gcm_128;
 ///     aes_gcm_256::{AesGcm256, Key, Nonce, Tag},
 ///     AeadConsts as _, NONCE_LEN, TAG_LEN,
 /// };
+/// use libcrux_secrets::{Classify, ClassifyRef, ClassifyRefMut};
 ///
-/// let k: Key = [0; AesGcm256::KEY_LEN].into();
-/// let nonce: Nonce = [0; NONCE_LEN].into();
-/// let mut tag: Tag = [0; TAG_LEN].into();
+/// let k: Key = [0; AesGcm256::KEY_LEN].classify().into();
+/// let nonce: Nonce = [0; NONCE_LEN].classify().into();
+/// let mut tag: Tag = [0; TAG_LEN].classify().into();
 ///
 /// let pt = b"the quick brown fox jumps over the lazy dog";
 /// let mut ct = [0; 43];
 /// let mut pt_out = [0; 43];
 ///
-/// k.encrypt(&mut ct, &mut tag, &nonce, b"", pt).unwrap();
-/// k.decrypt(&mut pt_out, &nonce, b"", &ct, &tag).unwrap();
+/// k.encrypt(&mut ct, &mut tag, &nonce, b"", pt.classify_ref()).unwrap();
+/// k.decrypt(pt_out.classify_ref_mut(), &nonce, b"", &ct, &tag).unwrap();
 /// assert_eq!(pt, &pt_out);
 /// ```
 ///
@@ -155,22 +159,23 @@ pub mod aes_gcm_128;
 /// ```rust
 /// // Using the multiplexed API
 /// use libcrux_iot_aes::{aes_gcm_256::AesGcm256, Aead as _, AeadConsts as _, NONCE_LEN, TAG_LEN};
+/// use libcrux_secrets::{ClassifyRef, ClassifyRefMut};
 ///
 /// let algo = AesGcm256;
 ///
 /// let mut tag_bytes = [0; TAG_LEN];
-/// let tag = algo.new_tag_mut(&mut tag_bytes).unwrap();
+/// let tag = algo.new_tag_mut(tag_bytes.classify_ref_mut()).unwrap();
 ///
-/// let key = algo.new_key(&[0; AesGcm256::KEY_LEN]).unwrap();
-/// let nonce = algo.new_nonce(&[0; NONCE_LEN]).unwrap();
+/// let key = algo.new_key((&[0; AesGcm256::KEY_LEN]).classify_ref()).unwrap();
+/// let nonce = algo.new_nonce((&[0; NONCE_LEN]).classify_ref()).unwrap();
 ///
 /// let pt = b"the quick brown fox jumps over the lazy dog";
 /// let mut ct = [0; 43];
 /// let mut pt_out = [0; 43];
 ///
-/// key.encrypt(&mut ct, tag, nonce, b"", pt).unwrap();
-/// let tag = algo.new_tag(&tag_bytes).unwrap();
-/// key.decrypt(&mut pt_out, nonce, b"", &ct, tag).unwrap();
+/// key.encrypt(&mut ct, tag, nonce, b"", pt.classify_ref()).unwrap();
+/// let tag = algo.new_tag(tag_bytes.classify_ref()).unwrap();
+/// key.decrypt(pt_out.classify_ref_mut(), nonce, b"", &ct, tag).unwrap();
 /// assert_eq!(pt, &pt_out);
 /// ```
 pub mod aes_gcm_256;

--- a/libcrux-iot/aes/src/traits_api.rs
+++ b/libcrux-iot/aes/src/traits_api.rs
@@ -1,9 +1,8 @@
 use libcrux_traits::aead::{arrayref, consts, slice, typed_owned};
 
 use crate::{
-    aes_gcm_128, aes_gcm_256,
+    NONCE_LEN, TAG_LEN, aes_gcm_128, aes_gcm_256,
     implementations::{AesGcm128, AesGcm256, PortableAesGcm128, PortableAesGcm256},
-    NONCE_LEN, TAG_LEN,
 };
 
 /// Macro to implement the libcrux_traits public API traits
@@ -28,14 +27,14 @@ macro_rules! api {
     ($mod_name:ident, $variant:ident, $multiplexing:ty, $portable:ident) => {
         mod $mod_name {
             use super::*;
-            use libcrux_secrets::U8;
+            use libcrux_secrets::{U8, DeclassifyRef, DeclassifyRefMut};
 
             use libcrux_traits::aead::arrayref::{DecryptError, EncryptError, KeyGenError};
             use $variant::KEY_LEN;
 
-            pub type Key = [u8; KEY_LEN];
-            pub type Tag = [u8; TAG_LEN];
-            pub type Nonce = [u8; NONCE_LEN];
+            pub type Key = [U8; KEY_LEN];
+            pub type Tag = [U8; TAG_LEN];
+            pub type Nonce = [U8; NONCE_LEN];
 
             mod _libcrux_traits_apis_multiplex {
                 use super::*;
@@ -48,7 +47,7 @@ macro_rules! api {
 
                 /// The plaintext length must be equal to the ciphertext length.
                 impl arrayref::Aead<KEY_LEN, TAG_LEN, NONCE_LEN> for $multiplexing {
-                    fn keygen(key: &mut [u8; KEY_LEN], rand: &[u8; KEY_LEN]) -> Result<(), KeyGenError> {
+                    fn keygen(key: &mut [U8; KEY_LEN], rand: &[U8; KEY_LEN]) -> Result<(), KeyGenError> {
                         *key = *rand;
                         Ok(())
                     }
@@ -59,7 +58,7 @@ macro_rules! api {
                         key: &Key,
                         nonce: &Nonce,
                         aad: &[u8],
-                        plaintext: &[u8],
+                        plaintext: &[U8],
                     ) -> Result<(), EncryptError> {
                         if plaintext.len() / crate::aes::AES_BLOCK_LEN >= (u32::MAX - 1) as usize {
                             return Err(EncryptError::PlaintextTooLong);
@@ -72,7 +71,7 @@ macro_rules! api {
                     }
 
                     fn decrypt(
-                        plaintext: &mut [u8],
+                        plaintext: &mut [U8],
                         key: &Key,
                         nonce: &Nonce,
                         aad: &[u8],
@@ -103,7 +102,7 @@ macro_rules! api {
 
                 /// The plaintext length must be equal to the ciphertext length.
                 impl arrayref::Aead<KEY_LEN, TAG_LEN, NONCE_LEN> for $portable {
-                    fn keygen(key: &mut [u8; KEY_LEN], rand: &[u8; KEY_LEN]) -> Result<(), KeyGenError> {
+                    fn keygen(key: &mut [U8; KEY_LEN], rand: &[U8; KEY_LEN]) -> Result<(), KeyGenError> {
                         *key = *rand;
                         Ok(())
                     }
@@ -114,15 +113,19 @@ macro_rules! api {
                         key: &Key,
                         nonce: &Nonce,
                         aad: &[u8],
-                        plaintext: &[u8],
+                        plaintext: &[U8],
                     ) -> Result<(), EncryptError> {
                         assert_eq!(plaintext.len(), ciphertext.len());
-                        ciphertext.copy_from_slice(plaintext);
-                        crate::portable::$variant::encrypt(key, nonce, aad.into_iter(), ciphertext, tag)
+                        // declassify: for now, we only implement the libcrux-traits APIs in a secrets
+                        // aware way, but don't use libcrux-secrets internally within this crate.
+                        // Therefore, we need perform declassify operations at the boundaries between
+                        // the libcrux-traits APIs and the internal ones.
+                        ciphertext.copy_from_slice(plaintext.declassify_ref());
+                        crate::portable::$variant::encrypt(key.declassify_ref(), nonce.declassify_ref(), aad.into_iter(), ciphertext, tag.declassify_ref_mut())
                     }
 
                     fn decrypt(
-                        plaintext: &mut [u8],
+                        plaintext: &mut [U8],
                         key: &Key,
                         nonce: &Nonce,
                         aad: &[u8],
@@ -130,8 +133,13 @@ macro_rules! api {
                         tag: &Tag,
                     ) -> Result<(), DecryptError> {
                         assert_eq!(plaintext.len(), ciphertext.len());
+                        // declassify: for now, we only implement the libcrux-traits APIs in a secrets
+                        // aware way, but don't use libcrux-secrets internally within this crate.
+                        // Therefore, we need perform declassify operations at the boundaries between
+                        // the libcrux-traits APIs and the internal ones.
+                        let plaintext = plaintext.declassify_ref_mut();
                         plaintext.copy_from_slice(ciphertext);
-                        crate::portable::$variant::decrypt(key, nonce, aad.into_iter(), tag, plaintext)
+                        crate::portable::$variant::decrypt(key.declassify_ref(), nonce.declassify_ref(), aad.into_iter(), tag.declassify_ref(), plaintext)
                     }
                 }
             }

--- a/libcrux-iot/aes/tests/key_centric.rs
+++ b/libcrux-iot/aes/tests/key_centric.rs
@@ -2,21 +2,24 @@ use libcrux_iot_aes::{
     aes_gcm_128::{Key, Nonce, Tag},
     AesGcm128,
 };
+use libcrux_secrets::{ClassifyRef, ClassifyRefMut, U8};
 
 #[test]
 fn test_key_centric_owned() {
     use libcrux_iot_aes::AeadConsts as _;
 
-    let k: Key = [0; AesGcm128::KEY_LEN].into();
-    let nonce: Nonce = [0; AesGcm128::NONCE_LEN].into();
-    let mut tag: Tag = [0; AesGcm128::TAG_LEN].into();
+    let k: Key = [U8(0); AesGcm128::KEY_LEN].into();
+    let nonce: Nonce = [U8(0); AesGcm128::NONCE_LEN].into();
+    let mut tag: Tag = [U8(0); AesGcm128::TAG_LEN].into();
 
     let pt = b"the quick brown fox jumps over the lazy dog";
     let mut ct = [0; 43];
     let mut pt_out = [0; 43];
 
-    k.encrypt(&mut ct, &mut tag, &nonce, b"", pt).unwrap();
-    k.decrypt(&mut pt_out, &nonce, b"", &ct, &tag).unwrap();
+    k.encrypt(&mut ct, &mut tag, &nonce, b"", pt.classify_ref())
+        .unwrap();
+    k.decrypt(pt_out.classify_ref_mut(), &nonce, b"", &ct, &tag)
+        .unwrap();
     assert_eq!(pt, &pt_out);
 }
 
@@ -27,16 +30,22 @@ fn test_key_centric_refs() {
     let algo = AesGcm128;
 
     let mut tag_bytes = [0; AesGcm128::TAG_LEN];
-    let key = algo.new_key(&[0; AesGcm128::KEY_LEN]).unwrap();
-    let tag = algo.new_tag_mut(&mut tag_bytes).unwrap();
-    let nonce = algo.new_nonce(&[0; AesGcm128::NONCE_LEN]).unwrap();
+    let key = algo
+        .new_key((&[0; AesGcm128::KEY_LEN]).classify_ref())
+        .unwrap();
+    let tag = algo.new_tag_mut(tag_bytes.classify_ref_mut()).unwrap();
+    let nonce = algo
+        .new_nonce((&[0; AesGcm128::NONCE_LEN]).classify_ref())
+        .unwrap();
 
     let pt = b"the quick brown fox jumps over the lazy dog";
     let mut ct = [0; 43];
     let mut pt_out = [0; 43];
 
-    key.encrypt(&mut ct, tag, nonce, b"", pt).unwrap();
-    let tag = algo.new_tag(&tag_bytes).unwrap();
-    key.decrypt(&mut pt_out, nonce, b"", &ct, tag).unwrap();
+    key.encrypt(&mut ct, tag, nonce, b"", pt.classify_ref())
+        .unwrap();
+    let tag = algo.new_tag(tag_bytes.classify_ref()).unwrap();
+    key.decrypt(pt_out.classify_ref_mut(), nonce, b"", &ct, tag)
+        .unwrap();
     assert_eq!(pt, &pt_out);
 }

--- a/libcrux-iot/aes/tests/self.rs
+++ b/libcrux-iot/aes/tests/self.rs
@@ -2,19 +2,20 @@ use libcrux_iot_aes::{
     aes_gcm_128::{Key, Nonce, Tag},
     AesGcm128,
 };
+use libcrux_secrets::{Classify, ClassifyRef, ClassifyRefMut};
 
 // tests that an error is returned if ptxt.len() != ctxt.len()
 #[test]
 fn non_matching_lengths() {
     use libcrux_iot_aes::AeadConsts as _;
 
-    let k: Key = [0; AesGcm128::KEY_LEN].into();
-    let nonce: Nonce = [0; AesGcm128::NONCE_LEN].into();
-    let mut tag: Tag = [0; AesGcm128::TAG_LEN].into();
+    let k: Key = [0; AesGcm128::KEY_LEN].classify().into();
+    let nonce: Nonce = [0; AesGcm128::NONCE_LEN].classify().into();
+    let mut tag: Tag = [0; AesGcm128::TAG_LEN].classify().into();
 
     let pt = vec![0; 12];
 
-    k.encrypt(&mut [0; 43], &mut tag, &nonce, b"", &pt)
+    k.encrypt(&mut [0; 43], &mut tag, &nonce, b"", pt.classify_ref())
         .unwrap_err();
 }
 
@@ -26,19 +27,23 @@ fn ptxt_too_long() {
     use libcrux_iot_aes::AeadConsts as _;
     use libcrux_traits::aead::arrayref::{DecryptError, EncryptError};
 
-    let k: Key = [0; AesGcm128::KEY_LEN].into();
-    let nonce: Nonce = [0; AesGcm128::NONCE_LEN].into();
-    let mut tag: Tag = [0; AesGcm128::TAG_LEN].into();
+    let k: Key = [0; AesGcm128::KEY_LEN].classify().into();
+    let nonce: Nonce = [0; AesGcm128::NONCE_LEN].classify().into();
+    let mut tag: Tag = [0; AesGcm128::TAG_LEN].classify().into();
 
     // unsafely create a slice that is too long
     let pt: &mut [u8] =
         unsafe { std::slice::from_raw_parts_mut(8 as *mut u8, u32::MAX as usize * 16) };
 
     // check that encryption returns error
-    let e = k.encrypt(&mut [], &mut tag, &nonce, b"", &pt).unwrap_err();
+    let e = k
+        .encrypt(&mut [], &mut tag, &nonce, b"", pt.classify_ref())
+        .unwrap_err();
     assert_eq!(e, EncryptError::PlaintextTooLong);
 
     // check that decryption returns error
-    let e = k.decrypt(pt, &nonce, b"", &mut [], &tag).unwrap_err();
+    let e = k
+        .decrypt(pt.classify_ref_mut(), &nonce, b"", &mut [], &tag)
+        .unwrap_err();
     assert_eq!(e, DecryptError::PlaintextTooLong);
 }

--- a/libcrux-iot/aes/tests/wycheproof.rs
+++ b/libcrux-iot/aes/tests/wycheproof.rs
@@ -1,3 +1,4 @@
+use libcrux_secrets::{ClassifyRef, ClassifyRefMut, DeclassifyRef};
 use wycheproof::{aead::Test, TestResult};
 
 fn run<Cipher: libcrux_iot_aes::Aead>(test: &Test, cipher: Cipher) {
@@ -5,25 +6,37 @@ fn run<Cipher: libcrux_iot_aes::Aead>(test: &Test, cipher: Cipher) {
     let mut plaintext = vec![0u8; test.pt.len()];
     let mut tag_bytes = [0u8; 16];
 
-    let key = cipher.new_key(&test.key).unwrap();
-    let nonce = cipher.new_nonce(&test.nonce).unwrap();
-    let tag = cipher.new_tag_mut(&mut tag_bytes).unwrap();
+    let key = cipher.new_key(test.key.classify_ref()).unwrap();
+    let nonce = cipher.new_nonce(test.nonce.classify_ref()).unwrap();
+    let tag = cipher.new_tag_mut(tag_bytes.classify_ref_mut()).unwrap();
 
-    key.encrypt(&mut ciphertext, tag, nonce, &test.aad, &test.pt)
-        .unwrap();
+    key.encrypt(
+        &mut ciphertext,
+        tag,
+        nonce,
+        &test.aad,
+        test.pt.classify_ref(),
+    )
+    .unwrap();
 
-    let tag = cipher.new_tag(&tag_bytes).unwrap();
-    key.decrypt(&mut plaintext, nonce, &test.aad, &ciphertext, tag)
-        .unwrap();
+    let tag = cipher.new_tag(tag_bytes.classify_ref()).unwrap();
+    key.decrypt(
+        plaintext.classify_ref_mut(),
+        nonce,
+        &test.aad,
+        &ciphertext,
+        tag,
+    )
+    .unwrap();
 
     assert_eq!(plaintext.as_slice(), test.pt.as_slice());
 
     if test.result == TestResult::Valid {
         assert_eq!(test.ct.as_slice(), &ciphertext);
-        assert_eq!(test.tag.as_slice(), tag.as_ref());
+        assert_eq!(test.tag.as_slice(), tag.as_ref().declassify_ref());
     } else {
         let ct_ok = test.ct.as_slice() == ciphertext;
-        let tag_ok = test.tag.as_slice() == tag.as_ref();
+        let tag_ok = test.tag.as_slice() == tag.as_ref().declassify_ref();
         assert!(!ct_ok || !tag_ok);
     }
 }


### PR DESCRIPTION
I've changed the libcrux-traits impls to be secrets aware, de-/classifying when calling into the internals of the aes implementation.

The second commit fixes the tests and examples to also compile if the check-secret-independence feature is enabled. This second commit was largely generated by Claude Opus 4.8.