### PR TITLE
[ci]: run workflows on PRs with any base branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "*"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/combined-c-extract-build-test.yml
+++ b/.github/workflows/combined-c-extract-build-test.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "*"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/measure-binary-size.yml
+++ b/.github/workflows/measure-binary-size.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "*"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/measure-stacks-qemu.yml
+++ b/.github/workflows/measure-stacks-qemu.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "*"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/mldsa-build-test.yml
+++ b/.github/workflows/mldsa-build-test.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "*"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/mldsa-c-extract-build-test.yml
+++ b/.github/workflows/mldsa-c-extract-build-test.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "*"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/mlkem-build-test.yml
+++ b/.github/workflows/mlkem-build-test.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "*"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/mlkem-c-extract-build-test.yml
+++ b/.github/workflows/mlkem-c-extract-build-test.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "*"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/sha3-build-test.yml
+++ b/.github/workflows/sha3-build-test.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "*"]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/sha3-c-extract-build-test.yml
+++ b/.github/workflows/sha3-c-extract-build-test.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main", "*"]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Previously, we filtered on branches: ["main", "*"]. "*" only matches characters except `/`, so these workflows did not run on branches like `name/feature`. This is inconvenient for stacked PRs.