### PR TITLE
[eurydice] fix cloop! macro step_by implementation

### DIFF
--- a/c/ml-kem/extracted/code_gen.txt
+++ b/c/ml-kem/extracted/code_gen.txt
@@ -3,4 +3,4 @@ Charon: e656e17bff6ca5efac8ab6919b9b74cb9a8dd8ad
 Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
 Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
 F*: unset
-Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd

--- a/c/ml-kem/extracted/header.txt
+++ b/c/ml-kem/extracted/header.txt
@@ -8,5 +8,5 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */

--- a/c/ml-kem/extracted/internal/libcrux_iot_core.h
+++ b/c/ml-kem/extracted/internal/libcrux_iot_core.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #ifndef internal_libcrux_iot_core_H
@@ -48,6 +48,19 @@ static inline int16_t core_num__i16__wrapping_sub(int16_t x0, int16_t x1);
 static inline int32_t core_num__i32__wrapping_add(int32_t x0, int32_t x1);
 
 static inline int32_t core_num__i32__wrapping_mul(int32_t x0, int32_t x1);
+
+/**
+A monomorphic instance of core.option.Option
+with types uint32_t
+
+*/
+typedef struct core_option_Option_7e_s {
+  core_option_Option_87_tags tag;
+  uint32_t f0;
+} core_option_Option_7e;
+
+static inline core_option_Option_7e core_num__u32__checked_add(uint32_t x0,
+                                                               uint32_t x1);
 
 static inline uint32_t core_num__u32__from_le_bytes(Eurydice_array_u8x4 x0);
 

--- a/c/ml-kem/extracted/internal/libcrux_iot_mlkem_portable.h
+++ b/c/ml-kem/extracted/internal/libcrux_iot_mlkem_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #ifndef internal_libcrux_iot_mlkem_portable_H

--- a/c/ml-kem/extracted/internal/libcrux_iot_sha3.h
+++ b/c/ml-kem/extracted/internal/libcrux_iot_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #ifndef internal_libcrux_iot_sha3_H
@@ -42,10 +42,10 @@ This function found in impl {libcrux_iot_sha3::state::KeccakState}
 libcrux_iot_sha3_state_KeccakState libcrux_iot_sha3_state_new_18(void);
 
 /**
-This function found in impl {libcrux_iot_sha3::state::KeccakState}
+This function found in impl {core::convert::From<[u32; 2usize]> for
+libcrux_iot_sha3::lane::Lane2U32}
 */
-Eurydice_arr_a0 libcrux_iot_sha3_state_get_lane_18(
-    const libcrux_iot_sha3_state_KeccakState *self, size_t i, size_t j);
+Eurydice_arr_a0 libcrux_iot_sha3_lane_from_29(Eurydice_arr_a0 value);
 
 /**
 This function found in impl {core::ops::index::Index<usize, u32> for
@@ -55,22 +55,22 @@ const uint32_t *libcrux_iot_sha3_lane_index_cc(const Eurydice_arr_a0 *self,
                                                size_t index);
 
 /**
+This function found in impl {libcrux_iot_sha3::lane::Lane2U32}
+*/
+Eurydice_arr_a0 libcrux_iot_sha3_lane_interleave_8d(Eurydice_arr_a0 self);
+
+/**
+This function found in impl {libcrux_iot_sha3::state::KeccakState}
+*/
+Eurydice_arr_a0 libcrux_iot_sha3_state_get_lane_18(
+    const libcrux_iot_sha3_state_KeccakState *self, size_t i, size_t j);
+
+/**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
 */
 void libcrux_iot_sha3_state_set_lane_18(
     libcrux_iot_sha3_state_KeccakState *self, size_t i, size_t j,
     Eurydice_arr_a0 lane);
-
-/**
-This function found in impl {core::convert::From<[u32; 2usize]> for
-libcrux_iot_sha3::lane::Lane2U32}
-*/
-Eurydice_arr_a0 libcrux_iot_sha3_lane_from_29(Eurydice_arr_a0 value);
-
-/**
-This function found in impl {libcrux_iot_sha3::lane::Lane2U32}
-*/
-Eurydice_arr_a0 libcrux_iot_sha3_lane_interleave_8d(Eurydice_arr_a0 self);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -203,6 +203,30 @@ void libcrux_iot_sha3_state_set_with_zeta_18(
           2147483784U, 32778U,      2147483785U, 1U,          32904U,      \
           129U,        136U,        2147516544U, 129U,        11U}}))
 
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
 void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(
     libcrux_iot_sha3_state_KeccakState *s);
 
@@ -240,6 +264,30 @@ void libcrux_iot_sha3_keccak_keccakf1600_round1_theta_d(
     libcrux_iot_sha3_state_KeccakState *s);
 
 void libcrux_iot_sha3_keccak_keccakf1600_round1_theta(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(
     libcrux_iot_sha3_state_KeccakState *s);
 
 void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(
@@ -281,6 +329,30 @@ void libcrux_iot_sha3_keccak_keccakf1600_round2_theta_d(
 void libcrux_iot_sha3_keccak_keccakf1600_round2_theta(
     libcrux_iot_sha3_state_KeccakState *s);
 
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
 void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(
     libcrux_iot_sha3_state_KeccakState *s);
 
@@ -320,7 +392,49 @@ void libcrux_iot_sha3_keccak_keccakf1600_round3_theta_d(
 void libcrux_iot_sha3_keccak_keccakf1600_round3_theta(
     libcrux_iot_sha3_state_KeccakState *s);
 
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s);
+
 void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -333,6 +447,24 @@ void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_56(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
 - BASE_ROUND= 0
 */
@@ -341,10 +473,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_56(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 - BASE_ROUND= 0
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -365,10 +533,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_4rounds_56(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 4
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_23(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 4
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_23(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
 - BASE_ROUND= 4
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_23(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 4
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_23(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 4
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_23(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -381,10 +585,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_23(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 4
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_23(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 4
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_23(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 - BASE_ROUND= 4
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_23(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 4
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_23(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 4
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_23(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -405,10 +645,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_4rounds_23(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 8
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_70(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 8
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_70(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
 - BASE_ROUND= 8
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_70(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 8
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_70(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 8
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_70(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -421,10 +697,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_70(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 8
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_70(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 8
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_70(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 - BASE_ROUND= 8
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_70(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 8
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_70(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 8
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_70(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -445,10 +757,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_4rounds_70(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 12
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_60(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 12
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_60(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
 - BASE_ROUND= 12
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_60(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 12
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_60(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 12
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_60(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -461,10 +809,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_60(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 12
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_60(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 12
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_60(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 - BASE_ROUND= 12
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_60(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 12
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_60(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 12
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_60(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -485,10 +869,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_4rounds_60(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 16
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_18(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 16
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_18(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
 - BASE_ROUND= 16
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_18(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 16
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_18(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 16
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_18(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -501,10 +921,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_18(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 16
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_18(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 16
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_18(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 - BASE_ROUND= 16
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_18(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 16
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_18(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 16
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_18(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -525,10 +981,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_4rounds_18(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 20
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_fc(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 20
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_fc(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
 - BASE_ROUND= 20
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_fc(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 20
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_fc(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 20
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_fc(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -541,10 +1033,46 @@ void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_fc(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 20
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_fc(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 20
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_fc(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 - BASE_ROUND= 20
 */
 void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_fc(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 20
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_fc(
+    libcrux_iot_sha3_state_KeccakState *s);
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 20
+*/
+void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_fc(
     libcrux_iot_sha3_state_KeccakState *s);
 
 /**
@@ -576,8 +1104,8 @@ with const generics
 - RATE= 72
 */
 void libcrux_iot_sha3_state_load_block_2u32_c6(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 A monomorphic instance of libcrux_iot_sha3.state.load_block_full_2u32
@@ -585,8 +1113,8 @@ with const generics
 - RATE= 72
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_c6(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -729,8 +1257,8 @@ with const generics
 - RATE= 136
 */
 void libcrux_iot_sha3_state_load_block_2u32_b2(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 A monomorphic instance of libcrux_iot_sha3.state.load_block_full_2u32
@@ -738,8 +1266,8 @@ with const generics
 - RATE= 136
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_b2(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -919,8 +1447,8 @@ with const generics
 - RATE= 168
 */
 void libcrux_iot_sha3_state_load_block_2u32_60(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 A monomorphic instance of libcrux_iot_sha3.state.load_block_full_2u32
@@ -928,8 +1456,8 @@ with const generics
 - RATE= 168
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_60(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -1043,8 +1571,8 @@ with const generics
 - RATE= 144
 */
 void libcrux_iot_sha3_state_load_block_2u32_9e(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 A monomorphic instance of libcrux_iot_sha3.state.load_block_full_2u32
@@ -1052,8 +1580,8 @@ with const generics
 - RATE= 144
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_9e(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}
@@ -1196,8 +1724,8 @@ with const generics
 - RATE= 104
 */
 void libcrux_iot_sha3_state_load_block_2u32_53(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start);
 
 /**
 A monomorphic instance of libcrux_iot_sha3.state.load_block_full_2u32
@@ -1205,8 +1733,8 @@ with const generics
 - RATE= 104
 */
 void libcrux_iot_sha3_state_load_block_full_2u32_53(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start);
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start);
 
 /**
 This function found in impl {libcrux_iot_sha3::state::KeccakState}

--- a/c/ml-kem/extracted/libcrux_iot_core.c
+++ b/c/ml-kem/extracted/libcrux_iot_core.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #include "internal/libcrux_iot_core.h"

--- a/c/ml-kem/extracted/libcrux_iot_core.h
+++ b/c/ml-kem/extracted/libcrux_iot_core.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #ifndef libcrux_iot_core_H

--- a/c/ml-kem/extracted/libcrux_iot_mlkem1024.h
+++ b/c/ml-kem/extracted/libcrux_iot_mlkem1024.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #ifndef libcrux_iot_mlkem1024_H

--- a/c/ml-kem/extracted/libcrux_iot_mlkem1024_portable.c
+++ b/c/ml-kem/extracted/libcrux_iot_mlkem1024_portable.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #include "libcrux_iot_mlkem1024_portable.h"

--- a/c/ml-kem/extracted/libcrux_iot_mlkem1024_portable.h
+++ b/c/ml-kem/extracted/libcrux_iot_mlkem1024_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #ifndef libcrux_iot_mlkem1024_portable_H

--- a/c/ml-kem/extracted/libcrux_iot_mlkem768.h
+++ b/c/ml-kem/extracted/libcrux_iot_mlkem768.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #ifndef libcrux_iot_mlkem768_H

--- a/c/ml-kem/extracted/libcrux_iot_mlkem768_portable.c
+++ b/c/ml-kem/extracted/libcrux_iot_mlkem768_portable.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #include "libcrux_iot_mlkem768_portable.h"

--- a/c/ml-kem/extracted/libcrux_iot_mlkem768_portable.h
+++ b/c/ml-kem/extracted/libcrux_iot_mlkem768_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #ifndef libcrux_iot_mlkem768_portable_H

--- a/c/ml-kem/extracted/libcrux_iot_mlkem_portable.c
+++ b/c/ml-kem/extracted/libcrux_iot_mlkem_portable.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #include "internal/libcrux_iot_mlkem_portable.h"
@@ -2267,12 +2267,6 @@ static KRML_MUSTINLINE void serialize_public_key_mut_df(
       t_as_ntt,
       libcrux_secrets_int_classify_public_classify_ref_mut_a1_75(&lvalue)[0U],
       scratch);
-  Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
-      serialized,
-      (KRML_CLITERAL(core_ops_range_Range_87){
-          .start = (size_t)0U,
-          .end = libcrux_iot_ml_kem_constants_ranked_bytes_per_ring_element(
-              (size_t)4U)}));
   Eurydice_slice_copy(
       Eurydice_slice_subslice_from_mut_6d(
           serialized,
@@ -2852,8 +2846,8 @@ generics
 */
 static KRML_MUSTINLINE void sample_from_binomial_distribution_2_a7(
     Eurydice_borrow_slice_u8 randomness, Eurydice_arr_04 *sampled_i16s) {
-  for (size_t i0 = (size_t)0U; i0 < randomness.meta / (size_t)4U; i0++) {
-    size_t chunk_number = i0;
+  for (size_t i = (size_t)0U; i < randomness.meta / (size_t)4U; i++) {
+    size_t chunk_number = i;
     Eurydice_borrow_slice_u8 byte_chunk = Eurydice_slice_subslice_shared_c8(
         randomness, (KRML_CLITERAL(core_ops_range_Range_87){
                         .start = chunk_number * (size_t)4U,
@@ -2871,19 +2865,49 @@ static KRML_MUSTINLINE void sample_from_binomial_distribution_2_a7(
         libcrux_secrets_int_public_integers_classify_27_df(1431655765U);
     uint32_t coin_toss_outcomes =
         core_num__u32__wrapping_add(even_bits, odd_bits);
-    for (uint32_t i = 0U; i < 32U / 4U; i++) {
-      uint32_t outcome_set = i;
-      uint32_t outcome_set0 = outcome_set * 4U;
-      int16_t outcome_1 = libcrux_secrets_int_as_i16_b8(
-          coin_toss_outcomes >> (uint32_t)outcome_set0 &
-          libcrux_secrets_int_public_integers_classify_27_df(3U));
-      int16_t outcome_2 = libcrux_secrets_int_as_i16_b8(
-          coin_toss_outcomes >>
-              (uint32_t)core_num__u32__wrapping_add(outcome_set0, 2U) &
-          libcrux_secrets_int_public_integers_classify_27_df(3U));
-      size_t offset = (size_t)(outcome_set0 >> 2U);
-      int16_t uu____0 = core_num__i16__wrapping_sub(outcome_1, outcome_2);
-      sampled_i16s->data[(size_t)8U * chunk_number + offset] = uu____0;
+    uint32_t outcome_set = 0U;
+    uint32_t step = 4U;
+    uint32_t end = 32U;
+    bool first_iter = true;
+    while (true) {
+      if (first_iter) {
+        first_iter = false;
+        if (outcome_set >= end) {
+          break;
+        }
+        int16_t outcome_1 = libcrux_secrets_int_as_i16_b8(
+            coin_toss_outcomes >> (uint32_t)outcome_set &
+            libcrux_secrets_int_public_integers_classify_27_df(3U));
+        int16_t outcome_2 = libcrux_secrets_int_as_i16_b8(
+            coin_toss_outcomes >>
+                (uint32_t)core_num__u32__wrapping_add(outcome_set, 2U) &
+            libcrux_secrets_int_public_integers_classify_27_df(3U));
+        size_t offset = (size_t)(outcome_set >> 2U);
+        int16_t uu____0 = core_num__i16__wrapping_sub(outcome_1, outcome_2);
+        sampled_i16s->data[(size_t)8U * chunk_number + offset] = uu____0;
+      } else {
+        core_option_Option_7e uu____1 =
+            core_num__u32__checked_add(outcome_set, step);
+        if (uu____1.tag == core_option_None) {
+          break;
+        }
+        uint32_t v = uu____1.f0;
+        outcome_set = v;
+        first_iter = false;
+        if (outcome_set >= end) {
+          break;
+        }
+        int16_t outcome_1 = libcrux_secrets_int_as_i16_b8(
+            coin_toss_outcomes >> (uint32_t)outcome_set &
+            libcrux_secrets_int_public_integers_classify_27_df(3U));
+        int16_t outcome_2 = libcrux_secrets_int_as_i16_b8(
+            coin_toss_outcomes >>
+                (uint32_t)core_num__u32__wrapping_add(outcome_set, 2U) &
+            libcrux_secrets_int_public_integers_classify_27_df(3U));
+        size_t offset = (size_t)(outcome_set >> 2U);
+        int16_t uu____2 = core_num__i16__wrapping_sub(outcome_1, outcome_2);
+        sampled_i16s->data[(size_t)8U * chunk_number + offset] = uu____2;
+      }
     }
   }
 }
@@ -5826,12 +5850,6 @@ static KRML_MUSTINLINE void serialize_public_key_mut_21(
       t_as_ntt,
       libcrux_secrets_int_classify_public_classify_ref_mut_a1_75(&lvalue)[0U],
       scratch);
-  Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
-      serialized,
-      (KRML_CLITERAL(core_ops_range_Range_87){
-          .start = (size_t)0U,
-          .end = libcrux_iot_ml_kem_constants_ranked_bytes_per_ring_element(
-              (size_t)3U)}));
   Eurydice_slice_copy(
       Eurydice_slice_subslice_from_mut_6d(
           serialized,

--- a/c/ml-kem/extracted/libcrux_iot_mlkem_portable.h
+++ b/c/ml-kem/extracted/libcrux_iot_mlkem_portable.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #ifndef libcrux_iot_mlkem_portable_H

--- a/c/ml-kem/extracted/libcrux_iot_sha3.c
+++ b/c/ml-kem/extracted/libcrux_iot_sha3.c
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #include "internal/libcrux_iot_sha3.h"
@@ -65,11 +65,12 @@ libcrux_iot_sha3_state_new_18(void) {
 }
 
 /**
-This function found in impl {libcrux_iot_sha3::state::KeccakState}
+This function found in impl {core::convert::From<[u32; 2usize]> for
+libcrux_iot_sha3::lane::Lane2U32}
 */
-KRML_MUSTINLINE Eurydice_arr_a0 libcrux_iot_sha3_state_get_lane_18(
-    const libcrux_iot_sha3_state_KeccakState *self, size_t i, size_t j) {
-  return self->st.data[(size_t)5U * j + i];
+KRML_MUSTINLINE Eurydice_arr_a0
+libcrux_iot_sha3_lane_from_29(Eurydice_arr_a0 value) {
+  return value;
 }
 
 /**
@@ -79,24 +80,6 @@ libcrux_iot_sha3::lane::Lane2U32}
 KRML_MUSTINLINE const uint32_t *libcrux_iot_sha3_lane_index_cc(
     const Eurydice_arr_a0 *self, size_t index) {
   return &self->data[index];
-}
-
-/**
-This function found in impl {libcrux_iot_sha3::state::KeccakState}
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_state_set_lane_18(
-    libcrux_iot_sha3_state_KeccakState *self, size_t i, size_t j,
-    Eurydice_arr_a0 lane) {
-  self->st.data[(size_t)5U * j + i] = lane;
-}
-
-/**
-This function found in impl {core::convert::From<[u32; 2usize]> for
-libcrux_iot_sha3::lane::Lane2U32}
-*/
-KRML_MUSTINLINE Eurydice_arr_a0
-libcrux_iot_sha3_lane_from_29(Eurydice_arr_a0 value) {
-  return value;
 }
 
 /**
@@ -125,6 +108,23 @@ libcrux_iot_sha3_lane_interleave_8d(Eurydice_arr_a0 self) {
   return libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
       .data = {libcrux_secrets_int_as_u32_a3(even_bits),
                libcrux_secrets_int_as_u32_a3(odd_bits)}}));
+}
+
+/**
+This function found in impl {libcrux_iot_sha3::state::KeccakState}
+*/
+KRML_MUSTINLINE Eurydice_arr_a0 libcrux_iot_sha3_state_get_lane_18(
+    const libcrux_iot_sha3_state_KeccakState *self, size_t i, size_t j) {
+  return self->st.data[(size_t)5U * j + i];
+}
+
+/**
+This function found in impl {libcrux_iot_sha3::state::KeccakState}
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_state_set_lane_18(
+    libcrux_iot_sha3_state_KeccakState *self, size_t i, size_t j,
+    Eurydice_arr_a0 lane) {
+  self->st.data[(size_t)5U * j + i] = lane;
 }
 
 /**
@@ -385,218 +385,334 @@ typedef struct uint32_t_x3_s {
   uint32_t thd;
 } uint32_t_x3;
 
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(
     libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)};
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)};
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
                                           ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
                                           ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
                                           ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
                                           ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)};
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)};
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)};
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)};
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-                         .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)};
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-                         .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-                         .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)};
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____8 = {.fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-                         .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)};
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____9 = {.fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-                         .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-                         .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)};
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
-                                          ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
-                                          ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____10 = {.fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
-                          .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
@@ -606,27 +722,37 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
                                                         (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____11 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
-                          .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
-                          .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
-                                          ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax44);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y4_zeta1(s);
 }
 
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_theta_c_x0_z0(
@@ -848,218 +974,334 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_theta(
   libcrux_iot_sha3_keccak_keccakf1600_round1_theta_d(s);
 }
 
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(
     libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
                                                         (size_t)0U, (size_t)1U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)};
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)};
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
                                           ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
                                           ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
                                           ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
                                           ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)};
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)};
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)};
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)};
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-                         .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)};
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-                         .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-                         .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)};
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
-                                          ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____8 = {.fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-                         .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)};
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____9 = {.fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-                         .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-                         .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)};
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
-                                          ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____10 = {.fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
-                          .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
                                                         (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
@@ -1069,27 +1311,37 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
                                                         (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____11 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
-                          .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
-                          .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
-                                          ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax44);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y4_zeta1(s);
 }
 
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_theta_c_x0_z0(
@@ -1311,218 +1563,334 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_theta(
   libcrux_iot_sha3_keccak_keccakf1600_round2_theta_d(s);
 }
 
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(
     libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)0U, (size_t)1U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)};
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)};
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
                                           ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
                                           ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
                                           ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
                                           ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)};
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)};
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)};
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)};
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-                         .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)};
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-                         .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-                         .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)};
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
-                                          ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____8 = {.fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-                         .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)};
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____9 = {.fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-                         .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-                         .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)};
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
-                                          ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
-                                          ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____10 = {.fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
-                          .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
@@ -1532,27 +1900,37 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____11 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
-                          .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
-                          .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
                                           ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
-                                          ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax44);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y4_zeta1(s);
 }
 
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_theta_c_x0_z0(
@@ -1774,910 +2152,64 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_theta(
   libcrux_iot_sha3_keccak_keccakf1600_round3_theta_d(s);
 }
 
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(
     libcrux_iot_sha3_state_KeccakState *s) {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 9U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 1U)};
-  uint32_t bx40 = uu____0.fst;
-  uint32_t bx00 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 3U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 13U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 4U)};
-  uint32_t bx10 = uu____1.fst;
-  uint32_t bx20 = uu____1.snd;
-  uint32_t bx30 = uu____1.thd;
-  uint32_t ax00 = bx00 ^ (~bx10 & bx20);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 9U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 0U)};
-  uint32_t bx41 = uu____2.fst;
-  uint32_t bx01 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 3U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 12U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 4U)};
-  uint32_t bx11 = uu____3.fst;
-  uint32_t bx21 = uu____3.snd;
-  uint32_t bx31 = uu____3.thd;
-  uint32_t ax01 = bx01 ^ (~bx11 & bx21);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 18U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 5U)};
-  uint32_t bx12 = uu____4.fst;
-  uint32_t bx22 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 8U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 28U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 14U)};
-  uint32_t bx32 = uu____5.fst;
-  uint32_t bx42 = uu____5.snd;
-  uint32_t bx02 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d03 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a13 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d13 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d03, 18U),
-                         .snd = core_num__u32__rotate_left(a13 ^ d13, 5U)};
-  uint32_t bx13 = uu____6.fst;
-  uint32_t bx23 = uu____6.snd;
-  uint32_t a23 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)2U, (size_t)1U);
-  uint32_t d23 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a33 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d33 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a43 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d43 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a23 ^ d23, 7U),
-                         .snd = core_num__u32__rotate_left(a33 ^ d33, 28U),
-                         .thd = core_num__u32__rotate_left(a43 ^ d43, 13U)};
-  uint32_t bx33 = uu____7.fst;
-  uint32_t bx43 = uu____7.snd;
-  uint32_t bx03 = uu____7.thd;
-  uint32_t ax03 = bx03 ^ (~bx13 & bx23);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
-                                          ax03);
-  uint32_t ax12 = bx13 ^ (~bx23 & bx33);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx23 ^ (~bx33 & bx43);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx33 ^ (~bx43 & bx03);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx43 ^ (~bx03 & bx13);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax42);
-  uint32_t a03 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d04 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a14 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)1U, (size_t)0U);
-  uint32_t d14 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____8 = {.fst = core_num__u32__rotate_left(a03 ^ d04, 21U),
-                         .snd = core_num__u32__rotate_left(a14 ^ d14, 1U)};
-  uint32_t bx34 = uu____8.fst;
-  uint32_t bx44 = uu____8.snd;
-  uint32_t a24 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d24 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a34 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d34 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a44 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d44 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____9 = {.fst = core_num__u32__rotate_left(a24 ^ d24, 31U),
-                         .snd = core_num__u32__rotate_left(a34 ^ d34, 28U),
-                         .thd = core_num__u32__rotate_left(a44 ^ d44, 20U)};
-  uint32_t bx04 = uu____9.fst;
-  uint32_t bx14 = uu____9.snd;
-  uint32_t bx24 = uu____9.thd;
-  uint32_t ax04 = bx04 ^ (~bx14 & bx24);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
-                                          ax04);
-  uint32_t ax13 = bx14 ^ (~bx24 & bx34);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
-                                          ax13);
-  uint32_t ax23 = bx24 ^ (~bx34 & bx44);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax23);
-  uint32_t ax33 = bx34 ^ (~bx44 & bx04);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax33);
-  uint32_t ax43 = bx44 ^ (~bx04 & bx14);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax43);
-  uint32_t a04 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)1U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____10 = {.fst = core_num__u32__rotate_left(a04 ^ d0, 20U),
-                          .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
-  uint32_t bx3 = uu____10.fst;
-  uint32_t bx4 = uu____10.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)2U, (size_t)1U);
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 2U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 23U)};
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)3U, (size_t)1U);
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)4U, (size_t)1U);
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)4U, (size_t)0U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____11 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
-                          .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
-                          .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
-  uint32_t bx0 = uu____11.fst;
-  uint32_t bx1 = uu____11.snd;
-  uint32_t bx2 = uu____11.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax0);
-  uint32_t ax14 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
-                                          ax14);
-  uint32_t ax24 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax24);
-  uint32_t ax34 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax34);
-  uint32_t ax44 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax44);
-}
-
-/**
-A monomorphic instance of
-libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
-- BASE_ROUND= 0
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_56(
-    libcrux_iot_sha3_state_KeccakState *s) {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)0U + (size_t)0U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)0U + (size_t)0U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
-                                                        (size_t)1U, (size_t)0U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)3U, (size_t)1U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
                          .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
                          .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
-}
-
-/**
-A monomorphic instance of
-libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
-- BASE_ROUND= 0
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_56(
-    libcrux_iot_sha3_state_KeccakState *s) {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)0U + (size_t)1U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)0U + (size_t)1U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)1U, (size_t)0U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
-                                                        (size_t)3U, (size_t)0U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
-}
-
-/**
-A monomorphic instance of
-libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
-- BASE_ROUND= 0
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_56(
-    libcrux_iot_sha3_state_KeccakState *s) {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)0U + (size_t)2U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)0U + (size_t)2U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)1U, (size_t)1U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)3U, (size_t)0U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
-}
-
-/**
-A monomorphic instance of
-libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_1 with const generics
-- BASE_ROUND= 0
-*/
-KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_56(
-    libcrux_iot_sha3_state_KeccakState *s) {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)0U + (size_t)3U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)0U + (size_t)3U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 1U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
+  uint32_t bx2 = uu____0.fst;
+  uint32_t bx3 = uu____0.snd;
   uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)2U, (size_t)1U);
   uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
@@ -2687,27 +2219,783 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_56(
   uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
                          .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
                          .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
+  uint32_t bx4 = uu____1.fst;
+  uint32_t bx0 = uu____1.snd;
+  uint32_t bx1 = uu____1.thd;
   uint32_t ax0 = bx0 ^ (~bx1 & bx2);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 13U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 9U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 0U)};
+  uint32_t bx4 = uu____0.fst;
+  uint32_t bx0 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 3U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 12U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 4U)};
+  uint32_t bx1 = uu____1.fst;
+  uint32_t bx2 = uu____1.snd;
+  uint32_t bx3 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 8U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 14U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 18U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 5U)};
+  uint32_t bx1 = uu____0.fst;
+  uint32_t bx2 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 7U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 13U)};
+  uint32_t bx3 = uu____1.fst;
+  uint32_t bx4 = uu____1.snd;
+  uint32_t bx0 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 21U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 28U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 20U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 20U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 1U)};
+  uint32_t bx3 = uu____0.fst;
+  uint32_t bx4 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 31U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 27U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 19U)};
+  uint32_t bx0 = uu____1.fst;
+  uint32_t bx1 = uu____1.snd;
+  uint32_t bx2 = uu____1.thd;
+  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_2(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y2_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y3_zeta1(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y4_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)0U + (size_t)0U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)0U + (size_t)0U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)0U + (size_t)1U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)0U + (size_t)1U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)0U + (size_t)2U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)0U + (size_t)2U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)0U + (size_t)3U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)0U + (size_t)3U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_1 with const generics
+- BASE_ROUND= 0
+*/
+KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_56(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_56(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(s);
 }
 
 /**
@@ -2733,175 +3021,227 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_4rounds_56(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 4
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_23(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)4U + (size_t)0U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 4
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_23(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)4U + (size_t)0U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
 - BASE_ROUND= 4
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_23(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_23(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_23(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 4
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_23(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)4U + (size_t)0U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)4U + (size_t)0U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
-                                                        (size_t)1U, (size_t)0U);
+                                                        (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)3U, (size_t)1U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
                                                         (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)4U + (size_t)1U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 4
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_23(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)4U + (size_t)1U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
+                                          ax4);
 }
 
 /**
@@ -2911,170 +3251,116 @@ libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_23(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_23(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_23(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 4
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_23(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)4U + (size_t)1U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)4U + (size_t)1U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)1U, (size_t)0U);
+                                                        (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
                                                         (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)4U + (size_t)2U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 4
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_23(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)4U + (size_t)2U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
+                                          ax4);
 }
 
 /**
@@ -3084,170 +3370,116 @@ libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_23(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_23(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_23(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 4
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_23(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)4U + (size_t)2U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)4U + (size_t)2U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)1U, (size_t)1U);
+                                                        (size_t)1U, (size_t)0U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)4U + (size_t)3U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 4
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_23(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)4U + (size_t)3U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
+                                          ax4);
 }
 
 /**
@@ -3257,170 +3489,10 @@ libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_23(
     libcrux_iot_sha3_state_KeccakState *s) {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)4U + (size_t)3U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)4U + (size_t)3U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)1U, (size_t)1U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)3U, (size_t)1U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_23(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_23(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(s);
 }
 
 /**
@@ -3446,175 +3518,227 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_4rounds_23(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 8
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_70(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)8U + (size_t)0U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 8
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_70(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)8U + (size_t)0U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
 - BASE_ROUND= 8
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_70(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_70(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_70(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 8
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_70(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)8U + (size_t)0U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)8U + (size_t)0U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
-                                                        (size_t)1U, (size_t)0U);
+                                                        (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)3U, (size_t)1U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
                                                         (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)8U + (size_t)1U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 8
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_70(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)8U + (size_t)1U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
+                                          ax4);
 }
 
 /**
@@ -3624,170 +3748,116 @@ libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_70(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_70(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_70(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 8
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_70(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)8U + (size_t)1U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)8U + (size_t)1U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)1U, (size_t)0U);
+                                                        (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
                                                         (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)8U + (size_t)2U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 8
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_70(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)8U + (size_t)2U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
+                                          ax4);
 }
 
 /**
@@ -3797,170 +3867,116 @@ libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_70(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_70(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_70(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 8
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_70(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)8U + (size_t)2U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)8U + (size_t)2U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)1U, (size_t)1U);
+                                                        (size_t)1U, (size_t)0U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)8U + (size_t)3U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 8
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_70(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)8U + (size_t)3U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
+                                          ax4);
 }
 
 /**
@@ -3970,170 +3986,10 @@ libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_70(
     libcrux_iot_sha3_state_KeccakState *s) {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 = (bx00 ^ (~bx10 & bx20)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)8U + (size_t)3U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 = (bx01 ^ (~bx11 & bx21)) ^
-         LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)8U + (size_t)3U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)1U, (size_t)1U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)3U, (size_t)1U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_70(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_70(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(s);
 }
 
 /**
@@ -4159,177 +4015,227 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_4rounds_70(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 12
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_60(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)12U + (size_t)0U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 12
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_60(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)12U + (size_t)0U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
 - BASE_ROUND= 12
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_60(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_60(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_60(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 12
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_60(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 =
-      (bx00 ^ (~bx10 & bx20)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)12U + (size_t)0U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 =
-      (bx01 ^ (~bx11 & bx21)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)12U + (size_t)0U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
-                                                        (size_t)1U, (size_t)0U);
+                                                        (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)3U, (size_t)1U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
                                                         (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)12U + (size_t)1U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 12
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_60(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)12U + (size_t)1U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
+                                          ax4);
 }
 
 /**
@@ -4339,172 +4245,116 @@ libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_60(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_60(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_60(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 12
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_60(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 =
-      (bx00 ^ (~bx10 & bx20)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)12U + (size_t)1U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 =
-      (bx01 ^ (~bx11 & bx21)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)12U + (size_t)1U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)1U, (size_t)0U);
+                                                        (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
                                                         (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)12U + (size_t)2U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 12
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_60(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)12U + (size_t)2U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
+                                          ax4);
 }
 
 /**
@@ -4514,172 +4364,116 @@ libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_60(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_60(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_60(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 12
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_60(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 =
-      (bx00 ^ (~bx10 & bx20)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)12U + (size_t)2U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 =
-      (bx01 ^ (~bx11 & bx21)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)12U + (size_t)2U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)1U, (size_t)1U);
+                                                        (size_t)1U, (size_t)0U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)12U + (size_t)3U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 12
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_60(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)12U + (size_t)3U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
+                                          ax4);
 }
 
 /**
@@ -4689,172 +4483,10 @@ libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_60(
     libcrux_iot_sha3_state_KeccakState *s) {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 =
-      (bx00 ^ (~bx10 & bx20)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)12U + (size_t)3U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 =
-      (bx01 ^ (~bx11 & bx21)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)12U + (size_t)3U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)1U, (size_t)1U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)3U, (size_t)1U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_60(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_60(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(s);
 }
 
 /**
@@ -4880,177 +4512,227 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_4rounds_60(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 16
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_18(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)16U + (size_t)0U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 16
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_18(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)16U + (size_t)0U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
 - BASE_ROUND= 16
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_18(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_18(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_18(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 16
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_18(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 =
-      (bx00 ^ (~bx10 & bx20)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)16U + (size_t)0U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 =
-      (bx01 ^ (~bx11 & bx21)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)16U + (size_t)0U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
-                                                        (size_t)1U, (size_t)0U);
+                                                        (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)3U, (size_t)1U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
                                                         (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)16U + (size_t)1U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 16
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_18(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)16U + (size_t)1U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
+                                          ax4);
 }
 
 /**
@@ -5060,172 +4742,116 @@ libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_18(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_18(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_18(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 16
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_18(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 =
-      (bx00 ^ (~bx10 & bx20)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)16U + (size_t)1U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 =
-      (bx01 ^ (~bx11 & bx21)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)16U + (size_t)1U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)1U, (size_t)0U);
+                                                        (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
                                                         (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)16U + (size_t)2U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 16
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_18(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)16U + (size_t)2U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
+                                          ax4);
 }
 
 /**
@@ -5235,172 +4861,116 @@ libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_18(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_18(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_18(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 16
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_18(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 =
-      (bx00 ^ (~bx10 & bx20)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)16U + (size_t)2U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 =
-      (bx01 ^ (~bx11 & bx21)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)16U + (size_t)2U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)1U, (size_t)1U);
+                                                        (size_t)1U, (size_t)0U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)16U + (size_t)3U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 16
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_18(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)16U + (size_t)3U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
+                                          ax4);
 }
 
 /**
@@ -5410,172 +4980,10 @@ libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_18(
     libcrux_iot_sha3_state_KeccakState *s) {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 =
-      (bx00 ^ (~bx10 & bx20)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)16U + (size_t)3U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 =
-      (bx01 ^ (~bx11 & bx21)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)16U + (size_t)3U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)1U, (size_t)1U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)3U, (size_t)1U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_18(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_18(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(s);
 }
 
 /**
@@ -5601,177 +5009,227 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_4rounds_18(
 
 /**
 A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 20
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_fc(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)0U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)20U + (size_t)0U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 20
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_fc(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)4U, (size_t)1U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)20U + (size_t)0U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
 libcrux_iot_sha3.keccak.keccakf1600_round0_pi_rho_chi_1 with const generics
 - BASE_ROUND= 20
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_1_fc(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta0_fc(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y0_zeta1_fc(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round0_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 20
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_fc(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 =
-      (bx00 ^ (~bx10 & bx20)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)20U + (size_t)0U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 =
-      (bx01 ^ (~bx11 & bx21)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)20U + (size_t)0U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
-                                                        (size_t)1U, (size_t)0U);
+                                                        (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
-                                                        (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)3U, (size_t)1U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
                                                         (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)0U, (size_t)0U,
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)20U + (size_t)1U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 20
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_fc(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)3U, (size_t)0U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)20U + (size_t)1U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
+                                          ax4);
 }
 
 /**
@@ -5781,172 +5239,116 @@ libcrux_iot_sha3.keccak.keccakf1600_round1_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_1_fc(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta0_fc(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y0_zeta1_fc(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round1_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 20
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_fc(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)1U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 =
-      (bx00 ^ (~bx10 & bx20)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)20U + (size_t)1U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)0U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 =
-      (bx01 ^ (~bx11 & bx21)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)20U + (size_t)1U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)1U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)1U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)0U, (size_t)0U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)1U, (size_t)0U);
+                                                        (size_t)1U, (size_t)1U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
                                                         (size_t)2U, (size_t)0U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
                                                         (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
                                                         (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)0U, (size_t)0U,
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)20U + (size_t)2U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 20
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_fc(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
+                                                        (size_t)1U, (size_t)0U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)3U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)20U + (size_t)2U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
+                                          ax4);
 }
 
 /**
@@ -5956,172 +5358,116 @@ libcrux_iot_sha3.keccak.keccakf1600_round2_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_1_fc(
     libcrux_iot_sha3_state_KeccakState *s) {
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta0_fc(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y0_zeta1_fc(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round2_pi_rho_chi_y1_zeta1(s);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta0 with const
+generics
+- BASE_ROUND= 20
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_fc(
+    libcrux_iot_sha3_state_KeccakState *s) {
   uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)1U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)1U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 =
-      (bx00 ^ (~bx10 & bx20)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)20U + (size_t)2U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)1U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)1U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)1U, (size_t)0U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)4U, (size_t)0U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 =
-      (bx01 ^ (~bx11 & bx21)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)20U + (size_t)2U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)1U, (size_t)0U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)4U, (size_t)0U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)2U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)4U, (size_t)3U, (size_t)1U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)1U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)3U, (size_t)0U, (size_t)1U);
   uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
   uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)1U, (size_t)1U);
+                                                        (size_t)1U, (size_t)0U);
   uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
                          .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)2U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)4U,
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)0U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)3U, (size_t)0U);
   uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)4U, (size_t)0U);
+  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 22U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 11U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)20U + (size_t)3U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
+                                          ax0);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
+                                          ax4);
+}
+
+/**
+A monomorphic instance of
+libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_y0_zeta1 with const
+generics
+- BASE_ROUND= 20
+*/
+KRML_MUSTINLINE void
+libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_fc(
+    libcrux_iot_sha3_state_KeccakState *s) {
+  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)0U, (size_t)1U);
+  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
+  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)1U, (size_t)1U);
+  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
+  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d0, 0U),
+                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
+  uint32_t bx0 = uu____0.fst;
+  uint32_t bx1 = uu____0.snd;
+  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)2U, (size_t)1U);
+  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
+  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
+                                                        (size_t)3U, (size_t)1U);
+  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
+  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
                                                         (size_t)4U, (size_t)1U);
   uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)3U, (size_t)0U, (size_t)1U,
+  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 21U),
+                         .snd = core_num__u32__rotate_left(a3 ^ d3, 10U),
+                         .thd = core_num__u32__rotate_left(a4 ^ d4, 7U)};
+  uint32_t bx2 = uu____1.fst;
+  uint32_t bx3 = uu____1.snd;
+  uint32_t bx4 = uu____1.thd;
+  uint32_t ax0 =
+      (bx0 ^ (~bx1 & bx2)) ^
+      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)20U + (size_t)3U];
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
                                           ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
+  uint32_t ax1 = bx1 ^ (~bx2 & bx3);
   libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)2U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)4U, (size_t)3U, (size_t)0U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+                                          ax1);
+  uint32_t ax2 = bx2 ^ (~bx3 & bx4);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
+                                          ax2);
+  uint32_t ax3 = bx3 ^ (~bx4 & bx0);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
+                                          ax3);
+  uint32_t ax4 = bx4 ^ (~bx0 & bx1);
+  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
+                                          ax4);
 }
 
 /**
@@ -6131,172 +5477,10 @@ libcrux_iot_sha3.keccak.keccakf1600_round3_pi_rho_chi_1 with const generics
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_1_fc(
     libcrux_iot_sha3_state_KeccakState *s) {
-  uint32_t a0 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)0U,
-                                                        (size_t)0U, (size_t)0U);
-  uint32_t d00 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a10 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)0U);
-  uint32_t d10 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____0 = {.fst = core_num__u32__rotate_left(a0 ^ d00, 0U),
-                         .snd = core_num__u32__rotate_left(a10 ^ d10, 22U)};
-  uint32_t bx00 = uu____0.fst;
-  uint32_t bx10 = uu____0.snd;
-  uint32_t a20 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)0U);
-  uint32_t d20 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a30 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)0U);
-  uint32_t d30 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a40 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)0U);
-  uint32_t d40 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____1 = {.fst = core_num__u32__rotate_left(a20 ^ d20, 22U),
-                         .snd = core_num__u32__rotate_left(a30 ^ d30, 11U),
-                         .thd = core_num__u32__rotate_left(a40 ^ d40, 7U)};
-  uint32_t bx20 = uu____1.fst;
-  uint32_t bx30 = uu____1.snd;
-  uint32_t bx40 = uu____1.thd;
-  uint32_t ax00 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax00 =
-      (bx00 ^ (~bx10 & bx20)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_0.data[(size_t)20U + (size_t)3U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)0U,
-                                          ax00);
-  uint32_t ax1 = bx10 ^ (~bx20 & bx30);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)0U,
-                                          ax1);
-  uint32_t ax2 = bx20 ^ (~bx30 & bx40);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)0U,
-                                          ax2);
-  uint32_t ax3 = bx30 ^ (~bx40 & bx00);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)0U,
-                                          ax3);
-  uint32_t ax4 = bx40 ^ (~bx00 & bx10);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)0U,
-                                          ax4);
-  uint32_t a00 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)0U, (size_t)1U);
-  uint32_t d01 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a11 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)1U, (size_t)1U);
-  uint32_t d11 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____2 = {.fst = core_num__u32__rotate_left(a00 ^ d01, 0U),
-                         .snd = core_num__u32__rotate_left(a11 ^ d11, 22U)};
-  uint32_t bx01 = uu____2.fst;
-  uint32_t bx11 = uu____2.snd;
-  uint32_t a21 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)2U, (size_t)1U);
-  uint32_t d21 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a31 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)3U, (size_t)1U);
-  uint32_t d31 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a41 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)0U, (size_t)4U, (size_t)1U);
-  uint32_t d41 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____3 = {.fst = core_num__u32__rotate_left(a21 ^ d21, 21U),
-                         .snd = core_num__u32__rotate_left(a31 ^ d31, 10U),
-                         .thd = core_num__u32__rotate_left(a41 ^ d41, 7U)};
-  uint32_t bx21 = uu____3.fst;
-  uint32_t bx31 = uu____3.snd;
-  uint32_t bx41 = uu____3.thd;
-  uint32_t ax01 = libcrux_secrets_int_public_integers_classify_27_df(0U);
-  ax01 =
-      (bx01 ^ (~bx11 & bx21)) ^
-      LIBCRUX_IOT_SHA3_KECCAK_RC_INTERLEAVED_1.data[(size_t)20U + (size_t)3U];
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)0U, (size_t)1U,
-                                          ax01);
-  uint32_t ax10 = bx11 ^ (~bx21 & bx31);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)1U, (size_t)1U,
-                                          ax10);
-  uint32_t ax20 = bx21 ^ (~bx31 & bx41);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)2U, (size_t)1U,
-                                          ax20);
-  uint32_t ax30 = bx31 ^ (~bx41 & bx01);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)3U, (size_t)1U,
-                                          ax30);
-  uint32_t ax40 = bx41 ^ (~bx01 & bx11);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)0U, (size_t)4U, (size_t)1U,
-                                          ax40);
-  uint32_t a01 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)0U);
-  uint32_t d02 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)1U)[0U];
-  uint32_t a12 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)1U, (size_t)0U);
-  uint32_t d12 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)1U)[0U];
-  uint32_t_x2 uu____4 = {.fst = core_num__u32__rotate_left(a01 ^ d02, 2U),
-                         .snd = core_num__u32__rotate_left(a12 ^ d12, 23U)};
-  uint32_t bx22 = uu____4.fst;
-  uint32_t bx32 = uu____4.snd;
-  uint32_t a22 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)2U, (size_t)0U);
-  uint32_t d22 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)1U)[0U];
-  uint32_t a32 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)3U, (size_t)0U);
-  uint32_t d32 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)0U)[0U];
-  uint32_t a42 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)4U, (size_t)0U);
-  uint32_t d42 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)0U)[0U];
-  uint32_t_x3 uu____5 = {.fst = core_num__u32__rotate_left(a22 ^ d22, 31U),
-                         .snd = core_num__u32__rotate_left(a32 ^ d32, 14U),
-                         .thd = core_num__u32__rotate_left(a42 ^ d42, 10U)};
-  uint32_t bx42 = uu____5.fst;
-  uint32_t bx02 = uu____5.snd;
-  uint32_t bx12 = uu____5.thd;
-  uint32_t ax02 = bx02 ^ (~bx12 & bx22);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)0U,
-                                          ax02);
-  uint32_t ax11 = bx12 ^ (~bx22 & bx32);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)0U,
-                                          ax11);
-  uint32_t ax21 = bx22 ^ (~bx32 & bx42);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)0U,
-                                          ax21);
-  uint32_t ax31 = bx32 ^ (~bx42 & bx02);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)0U,
-                                          ax31);
-  uint32_t ax41 = bx42 ^ (~bx02 & bx12);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)0U,
-                                          ax41);
-  uint32_t a02 = libcrux_iot_sha3_state_get_with_zeta_18(
-      s, (size_t)1U, (size_t)0U, (size_t)1U);
-  uint32_t d0 = libcrux_iot_sha3_lane_index_cc(s->d.data, (size_t)0U)[0U];
-  uint32_t a1 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)1U, (size_t)1U);
-  uint32_t d1 = libcrux_iot_sha3_lane_index_cc(&s->d.data[1U], (size_t)0U)[0U];
-  uint32_t_x2 uu____6 = {.fst = core_num__u32__rotate_left(a02 ^ d0, 1U),
-                         .snd = core_num__u32__rotate_left(a1 ^ d1, 22U)};
-  uint32_t bx2 = uu____6.fst;
-  uint32_t bx3 = uu____6.snd;
-  uint32_t a2 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)2U, (size_t)1U);
-  uint32_t d2 = libcrux_iot_sha3_lane_index_cc(&s->d.data[2U], (size_t)0U)[0U];
-  uint32_t a3 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)3U, (size_t)1U);
-  uint32_t d3 = libcrux_iot_sha3_lane_index_cc(&s->d.data[3U], (size_t)1U)[0U];
-  uint32_t a4 = libcrux_iot_sha3_state_get_with_zeta_18(s, (size_t)1U,
-                                                        (size_t)4U, (size_t)1U);
-  uint32_t d4 = libcrux_iot_sha3_lane_index_cc(&s->d.data[4U], (size_t)1U)[0U];
-  uint32_t_x3 uu____7 = {.fst = core_num__u32__rotate_left(a2 ^ d2, 30U),
-                         .snd = core_num__u32__rotate_left(a3 ^ d3, 14U),
-                         .thd = core_num__u32__rotate_left(a4 ^ d4, 10U)};
-  uint32_t bx4 = uu____7.fst;
-  uint32_t bx0 = uu____7.snd;
-  uint32_t bx1 = uu____7.thd;
-  uint32_t ax0 = bx0 ^ (~bx1 & bx2);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)0U, (size_t)1U,
-                                          ax0);
-  uint32_t ax12 = bx1 ^ (~bx2 & bx3);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)1U, (size_t)1U,
-                                          ax12);
-  uint32_t ax22 = bx2 ^ (~bx3 & bx4);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)2U, (size_t)1U,
-                                          ax22);
-  uint32_t ax32 = bx3 ^ (~bx4 & bx0);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)3U, (size_t)1U,
-                                          ax32);
-  uint32_t ax42 = bx4 ^ (~bx0 & bx1);
-  libcrux_iot_sha3_state_set_with_zeta_18(s, (size_t)1U, (size_t)4U, (size_t)1U,
-                                          ax42);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta0_fc(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y0_zeta1_fc(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta0(s);
+  libcrux_iot_sha3_keccak_keccakf1600_round3_pi_rho_chi_y1_zeta1(s);
 }
 
 /**
@@ -6378,43 +5562,11 @@ with const generics
 - RATE= 72
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_c6(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression,
-         (size_t)25U * sizeof(Eurydice_arr_a0));
-  core_ops_range_Range_87 iter =
-      core_iter_traits_collect__core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__into_iter(
-          (KRML_CLITERAL(core_ops_range_Range_87){
-              .start = (size_t)0U, .end = (size_t)72U / (size_t)8U}),
-          core_ops_range_Range_87, size_t, core_ops_range_Range_87);
-  while (true) {
-    core_option_Option_87 uu____0 =
-        core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
-            &iter, size_t, core_option_Option_87);
-    if (uu____0.tag == core_option_None) {
-      for (size_t i = (size_t)0U; i < (size_t)72U / (size_t)8U; i++) {
-        size_t i0 = i;
-        Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-            state, i0 / (size_t)5U, i0 % (size_t)5U);
-        libcrux_iot_sha3_state_set_lane_18(
-            state, i0 / (size_t)5U, i0 % (size_t)5U,
-            libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
-                .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                             libcrux_iot_sha3_lane_index_cc(
-                                 &state_flat.data[i0], (size_t)0U)[0U],
-                         libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                             libcrux_iot_sha3_lane_index_cc(
-                                 &state_flat.data[i0], (size_t)1U)[0U]}})));
-      }
-      return;
-    }
-    size_t i = uu____0.f0;
-    size_t offset = start + (size_t)8U * i;
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
+  for (size_t i = (size_t)0U; i < (size_t)72U / (size_t)8U; i++) {
+    size_t i0 = i;
+    size_t offset = start + (size_t)8U * i0;
     Eurydice_array_u8x4 arr0;
     memcpy(arr0.data,
            Eurydice_slice_subslice_shared_c8(
@@ -6436,14 +5588,20 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_c6(
     uint32_t b = core_num__u32__from_le_bytes(
         core_result_unwrap_26_cc((KRML_CLITERAL(core_result_Result_c7){
             .tag = core_result_Ok, .val = {.case_Ok = arr}})));
-    Eurydice_arr_a0 uu____1 =
+    Eurydice_arr_a0 lane =
         libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29(
             (KRML_CLITERAL(Eurydice_arr_a0){.data = {a, b}})));
-    state_flat.data[i] = uu____1;
+    Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
+        libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
+            .data = {
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U],
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]}})));
   }
-  KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
-                    "panic!");
-  KRML_HOST_EXIT(255U);
 }
 
 /**
@@ -6452,10 +5610,10 @@ with const generics
 - RATE= 72
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_c6(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_c6(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -6509,7 +5667,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_c6(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)72U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -6518,7 +5676,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_c6(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -6527,7 +5685,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_c6(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -6669,16 +5827,16 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_dc(
   size_t blocks = outlen / (size_t)72U;
   size_t last = outlen - outlen % (size_t)72U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   core_ops_range_Range_87 iter =
       core_iter_traits_collect__core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__into_iter(
           (KRML_CLITERAL(core_ops_range_Range_87){.start = (size_t)0U,
                                                   .end = n}),
           core_ops_range_Range_87, size_t, core_ops_range_Range_87);
   while (true) {
-    core_option_Option_87 uu____0 =
-        core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
-            &iter, size_t, core_option_Option_87);
-    if (uu____0.tag == core_option_None) {
+    if (core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
+            &iter, size_t, core_option_Option_87)
+            .tag == core_option_None) {
       libcrux_iot_sha3_keccak_absorb_final_dc(&s, data, data.meta - rem, rem);
       if (blocks == (size_t)0U) {
         libcrux_iot_sha3_keccak_squeeze_first_and_last_c6(&s, out);
@@ -6691,16 +5849,16 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_dc(
           offset += (size_t)72U;
         }
         if (last < outlen) {
-          const_size_t__x2 uu____1 = {.fst = &last, .snd = &offset};
-          EURYDICE_ASSERT(uu____1.fst[0U] == uu____1.snd[0U], "panic!");
+          const_size_t__x2 uu____0 = {.fst = &last, .snd = &offset};
+          EURYDICE_ASSERT(uu____0.fst[0U] == uu____0.snd[0U], "panic!");
           libcrux_iot_sha3_keccak_squeeze_last_c6(
               s, Eurydice_slice_subslice_from_mut_6d(out, offset));
         }
       }
       return;
     }
-    size_t i = uu____0.f0;
-    libcrux_iot_sha3_keccak_absorb_block_c6(&s, data, i * (size_t)72U);
+    libcrux_iot_sha3_keccak_absorb_block_c6(&s, data, start);
+    start += (size_t)72U;
   }
   KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
                     "panic!");
@@ -6736,43 +5894,11 @@ with const generics
 - RATE= 136
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_b2(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression,
-         (size_t)25U * sizeof(Eurydice_arr_a0));
-  core_ops_range_Range_87 iter =
-      core_iter_traits_collect__core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__into_iter(
-          (KRML_CLITERAL(core_ops_range_Range_87){
-              .start = (size_t)0U, .end = (size_t)136U / (size_t)8U}),
-          core_ops_range_Range_87, size_t, core_ops_range_Range_87);
-  while (true) {
-    core_option_Option_87 uu____0 =
-        core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
-            &iter, size_t, core_option_Option_87);
-    if (uu____0.tag == core_option_None) {
-      for (size_t i = (size_t)0U; i < (size_t)136U / (size_t)8U; i++) {
-        size_t i0 = i;
-        Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-            state, i0 / (size_t)5U, i0 % (size_t)5U);
-        libcrux_iot_sha3_state_set_lane_18(
-            state, i0 / (size_t)5U, i0 % (size_t)5U,
-            libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
-                .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                             libcrux_iot_sha3_lane_index_cc(
-                                 &state_flat.data[i0], (size_t)0U)[0U],
-                         libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                             libcrux_iot_sha3_lane_index_cc(
-                                 &state_flat.data[i0], (size_t)1U)[0U]}})));
-      }
-      return;
-    }
-    size_t i = uu____0.f0;
-    size_t offset = start + (size_t)8U * i;
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
+  for (size_t i = (size_t)0U; i < (size_t)136U / (size_t)8U; i++) {
+    size_t i0 = i;
+    size_t offset = start + (size_t)8U * i0;
     Eurydice_array_u8x4 arr0;
     memcpy(arr0.data,
            Eurydice_slice_subslice_shared_c8(
@@ -6794,14 +5920,20 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_b2(
     uint32_t b = core_num__u32__from_le_bytes(
         core_result_unwrap_26_cc((KRML_CLITERAL(core_result_Result_c7){
             .tag = core_result_Ok, .val = {.case_Ok = arr}})));
-    Eurydice_arr_a0 uu____1 =
+    Eurydice_arr_a0 lane =
         libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29(
             (KRML_CLITERAL(Eurydice_arr_a0){.data = {a, b}})));
-    state_flat.data[i] = uu____1;
+    Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
+        libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
+            .data = {
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U],
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]}})));
   }
-  KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
-                    "panic!");
-  KRML_HOST_EXIT(255U);
 }
 
 /**
@@ -6810,10 +5942,10 @@ with const generics
 - RATE= 136
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_b2(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_b2(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -6867,7 +5999,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_b2(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)136U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -6876,7 +6008,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_b2(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -6885,7 +6017,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_b2(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -7027,16 +6159,16 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_22(
   size_t blocks = outlen / (size_t)136U;
   size_t last = outlen - outlen % (size_t)136U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   core_ops_range_Range_87 iter =
       core_iter_traits_collect__core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__into_iter(
           (KRML_CLITERAL(core_ops_range_Range_87){.start = (size_t)0U,
                                                   .end = n}),
           core_ops_range_Range_87, size_t, core_ops_range_Range_87);
   while (true) {
-    core_option_Option_87 uu____0 =
-        core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
-            &iter, size_t, core_option_Option_87);
-    if (uu____0.tag == core_option_None) {
+    if (core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
+            &iter, size_t, core_option_Option_87)
+            .tag == core_option_None) {
       libcrux_iot_sha3_keccak_absorb_final_22(&s, data, data.meta - rem, rem);
       if (blocks == (size_t)0U) {
         libcrux_iot_sha3_keccak_squeeze_first_and_last_b2(&s, out);
@@ -7049,16 +6181,16 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_22(
           offset += (size_t)136U;
         }
         if (last < outlen) {
-          const_size_t__x2 uu____1 = {.fst = &last, .snd = &offset};
-          EURYDICE_ASSERT(uu____1.fst[0U] == uu____1.snd[0U], "panic!");
+          const_size_t__x2 uu____0 = {.fst = &last, .snd = &offset};
+          EURYDICE_ASSERT(uu____0.fst[0U] == uu____0.snd[0U], "panic!");
           libcrux_iot_sha3_keccak_squeeze_last_b2(
               s, Eurydice_slice_subslice_from_mut_6d(out, offset));
         }
       }
       return;
     }
-    size_t i = uu____0.f0;
-    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, i * (size_t)136U);
+    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, start);
+    start += (size_t)136U;
   }
   KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
                     "panic!");
@@ -7129,16 +6261,16 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_220(
   size_t blocks = outlen / (size_t)136U;
   size_t last = outlen - outlen % (size_t)136U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   core_ops_range_Range_87 iter =
       core_iter_traits_collect__core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__into_iter(
           (KRML_CLITERAL(core_ops_range_Range_87){.start = (size_t)0U,
                                                   .end = n}),
           core_ops_range_Range_87, size_t, core_ops_range_Range_87);
   while (true) {
-    core_option_Option_87 uu____0 =
-        core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
-            &iter, size_t, core_option_Option_87);
-    if (uu____0.tag == core_option_None) {
+    if (core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
+            &iter, size_t, core_option_Option_87)
+            .tag == core_option_None) {
       libcrux_iot_sha3_keccak_absorb_final_220(&s, data, data.meta - rem, rem);
       if (blocks == (size_t)0U) {
         libcrux_iot_sha3_keccak_squeeze_first_and_last_b2(&s, out);
@@ -7151,16 +6283,16 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_220(
           offset += (size_t)136U;
         }
         if (last < outlen) {
-          const_size_t__x2 uu____1 = {.fst = &last, .snd = &offset};
-          EURYDICE_ASSERT(uu____1.fst[0U] == uu____1.snd[0U], "panic!");
+          const_size_t__x2 uu____0 = {.fst = &last, .snd = &offset};
+          EURYDICE_ASSERT(uu____0.fst[0U] == uu____0.snd[0U], "panic!");
           libcrux_iot_sha3_keccak_squeeze_last_b2(
               s, Eurydice_slice_subslice_from_mut_6d(out, offset));
         }
       }
       return;
     }
-    size_t i = uu____0.f0;
-    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, i * (size_t)136U);
+    libcrux_iot_sha3_keccak_absorb_block_b2(&s, data, start);
+    start += (size_t)136U;
   }
   KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
                     "panic!");
@@ -7205,43 +6337,11 @@ with const generics
 - RATE= 168
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_60(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression,
-         (size_t)25U * sizeof(Eurydice_arr_a0));
-  core_ops_range_Range_87 iter =
-      core_iter_traits_collect__core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__into_iter(
-          (KRML_CLITERAL(core_ops_range_Range_87){
-              .start = (size_t)0U, .end = (size_t)168U / (size_t)8U}),
-          core_ops_range_Range_87, size_t, core_ops_range_Range_87);
-  while (true) {
-    core_option_Option_87 uu____0 =
-        core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
-            &iter, size_t, core_option_Option_87);
-    if (uu____0.tag == core_option_None) {
-      for (size_t i = (size_t)0U; i < (size_t)168U / (size_t)8U; i++) {
-        size_t i0 = i;
-        Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-            state, i0 / (size_t)5U, i0 % (size_t)5U);
-        libcrux_iot_sha3_state_set_lane_18(
-            state, i0 / (size_t)5U, i0 % (size_t)5U,
-            libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
-                .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                             libcrux_iot_sha3_lane_index_cc(
-                                 &state_flat.data[i0], (size_t)0U)[0U],
-                         libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                             libcrux_iot_sha3_lane_index_cc(
-                                 &state_flat.data[i0], (size_t)1U)[0U]}})));
-      }
-      return;
-    }
-    size_t i = uu____0.f0;
-    size_t offset = start + (size_t)8U * i;
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
+  for (size_t i = (size_t)0U; i < (size_t)168U / (size_t)8U; i++) {
+    size_t i0 = i;
+    size_t offset = start + (size_t)8U * i0;
     Eurydice_array_u8x4 arr0;
     memcpy(arr0.data,
            Eurydice_slice_subslice_shared_c8(
@@ -7263,14 +6363,20 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_60(
     uint32_t b = core_num__u32__from_le_bytes(
         core_result_unwrap_26_cc((KRML_CLITERAL(core_result_Result_c7){
             .tag = core_result_Ok, .val = {.case_Ok = arr}})));
-    Eurydice_arr_a0 uu____1 =
+    Eurydice_arr_a0 lane =
         libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29(
             (KRML_CLITERAL(Eurydice_arr_a0){.data = {a, b}})));
-    state_flat.data[i] = uu____1;
+    Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
+        libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
+            .data = {
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U],
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]}})));
   }
-  KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
-                    "panic!");
-  KRML_HOST_EXIT(255U);
 }
 
 /**
@@ -7279,10 +6385,10 @@ with const generics
 - RATE= 168
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_60(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_60(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -7344,7 +6450,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_60(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)168U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -7353,7 +6459,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_60(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -7362,7 +6468,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_60(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -7466,43 +6572,11 @@ with const generics
 - RATE= 144
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_9e(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression,
-         (size_t)25U * sizeof(Eurydice_arr_a0));
-  core_ops_range_Range_87 iter =
-      core_iter_traits_collect__core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__into_iter(
-          (KRML_CLITERAL(core_ops_range_Range_87){
-              .start = (size_t)0U, .end = (size_t)144U / (size_t)8U}),
-          core_ops_range_Range_87, size_t, core_ops_range_Range_87);
-  while (true) {
-    core_option_Option_87 uu____0 =
-        core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
-            &iter, size_t, core_option_Option_87);
-    if (uu____0.tag == core_option_None) {
-      for (size_t i = (size_t)0U; i < (size_t)144U / (size_t)8U; i++) {
-        size_t i0 = i;
-        Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-            state, i0 / (size_t)5U, i0 % (size_t)5U);
-        libcrux_iot_sha3_state_set_lane_18(
-            state, i0 / (size_t)5U, i0 % (size_t)5U,
-            libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
-                .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                             libcrux_iot_sha3_lane_index_cc(
-                                 &state_flat.data[i0], (size_t)0U)[0U],
-                         libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                             libcrux_iot_sha3_lane_index_cc(
-                                 &state_flat.data[i0], (size_t)1U)[0U]}})));
-      }
-      return;
-    }
-    size_t i = uu____0.f0;
-    size_t offset = start + (size_t)8U * i;
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
+  for (size_t i = (size_t)0U; i < (size_t)144U / (size_t)8U; i++) {
+    size_t i0 = i;
+    size_t offset = start + (size_t)8U * i0;
     Eurydice_array_u8x4 arr0;
     memcpy(arr0.data,
            Eurydice_slice_subslice_shared_c8(
@@ -7524,14 +6598,20 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_9e(
     uint32_t b = core_num__u32__from_le_bytes(
         core_result_unwrap_26_cc((KRML_CLITERAL(core_result_Result_c7){
             .tag = core_result_Ok, .val = {.case_Ok = arr}})));
-    Eurydice_arr_a0 uu____1 =
+    Eurydice_arr_a0 lane =
         libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29(
             (KRML_CLITERAL(Eurydice_arr_a0){.data = {a, b}})));
-    state_flat.data[i] = uu____1;
+    Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
+        libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
+            .data = {
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U],
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]}})));
   }
-  KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
-                    "panic!");
-  KRML_HOST_EXIT(255U);
 }
 
 /**
@@ -7540,10 +6620,10 @@ with const generics
 - RATE= 144
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_9e(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_9e(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -7597,7 +6677,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_9e(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)144U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -7606,7 +6686,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_9e(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -7615,7 +6695,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_9e(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -7757,16 +6837,16 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_3a(
   size_t blocks = outlen / (size_t)144U;
   size_t last = outlen - outlen % (size_t)144U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   core_ops_range_Range_87 iter =
       core_iter_traits_collect__core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__into_iter(
           (KRML_CLITERAL(core_ops_range_Range_87){.start = (size_t)0U,
                                                   .end = n}),
           core_ops_range_Range_87, size_t, core_ops_range_Range_87);
   while (true) {
-    core_option_Option_87 uu____0 =
-        core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
-            &iter, size_t, core_option_Option_87);
-    if (uu____0.tag == core_option_None) {
+    if (core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
+            &iter, size_t, core_option_Option_87)
+            .tag == core_option_None) {
       libcrux_iot_sha3_keccak_absorb_final_3a(&s, data, data.meta - rem, rem);
       if (blocks == (size_t)0U) {
         libcrux_iot_sha3_keccak_squeeze_first_and_last_9e(&s, out);
@@ -7779,16 +6859,16 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_3a(
           offset += (size_t)144U;
         }
         if (last < outlen) {
-          const_size_t__x2 uu____1 = {.fst = &last, .snd = &offset};
-          EURYDICE_ASSERT(uu____1.fst[0U] == uu____1.snd[0U], "panic!");
+          const_size_t__x2 uu____0 = {.fst = &last, .snd = &offset};
+          EURYDICE_ASSERT(uu____0.fst[0U] == uu____0.snd[0U], "panic!");
           libcrux_iot_sha3_keccak_squeeze_last_9e(
               s, Eurydice_slice_subslice_from_mut_6d(out, offset));
         }
       }
       return;
     }
-    size_t i = uu____0.f0;
-    libcrux_iot_sha3_keccak_absorb_block_9e(&s, data, i * (size_t)144U);
+    libcrux_iot_sha3_keccak_absorb_block_9e(&s, data, start);
+    start += (size_t)144U;
   }
   KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
                     "panic!");
@@ -7824,43 +6904,11 @@ with const generics
 - RATE= 104
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_53(
-    libcrux_iot_sha3_state_KeccakState *state, Eurydice_borrow_slice_u8 blocks,
-    size_t start) {
-  Eurydice_arr_c0 state_flat;
-  Eurydice_arr_a0 repeat_expression[25U];
-  for (size_t i = (size_t)0U; i < (size_t)25U; i++) {
-    repeat_expression[i] = libcrux_iot_sha3_lane_zero_8d();
-  }
-  memcpy(state_flat.data, repeat_expression,
-         (size_t)25U * sizeof(Eurydice_arr_a0));
-  core_ops_range_Range_87 iter =
-      core_iter_traits_collect__core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__into_iter(
-          (KRML_CLITERAL(core_ops_range_Range_87){
-              .start = (size_t)0U, .end = (size_t)104U / (size_t)8U}),
-          core_ops_range_Range_87, size_t, core_ops_range_Range_87);
-  while (true) {
-    core_option_Option_87 uu____0 =
-        core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
-            &iter, size_t, core_option_Option_87);
-    if (uu____0.tag == core_option_None) {
-      for (size_t i = (size_t)0U; i < (size_t)104U / (size_t)8U; i++) {
-        size_t i0 = i;
-        Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
-            state, i0 / (size_t)5U, i0 % (size_t)5U);
-        libcrux_iot_sha3_state_set_lane_18(
-            state, i0 / (size_t)5U, i0 % (size_t)5U,
-            libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
-                .data = {libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
-                             libcrux_iot_sha3_lane_index_cc(
-                                 &state_flat.data[i0], (size_t)0U)[0U],
-                         libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
-                             libcrux_iot_sha3_lane_index_cc(
-                                 &state_flat.data[i0], (size_t)1U)[0U]}})));
-      }
-      return;
-    }
-    size_t i = uu____0.f0;
-    size_t offset = start + (size_t)8U * i;
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    Eurydice_borrow_slice_u8 blocks, size_t start) {
+  for (size_t i = (size_t)0U; i < (size_t)104U / (size_t)8U; i++) {
+    size_t i0 = i;
+    size_t offset = start + (size_t)8U * i0;
     Eurydice_array_u8x4 arr0;
     memcpy(arr0.data,
            Eurydice_slice_subslice_shared_c8(
@@ -7882,14 +6930,20 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_2u32_53(
     uint32_t b = core_num__u32__from_le_bytes(
         core_result_unwrap_26_cc((KRML_CLITERAL(core_result_Result_c7){
             .tag = core_result_Ok, .val = {.case_Ok = arr}})));
-    Eurydice_arr_a0 uu____1 =
+    Eurydice_arr_a0 lane =
         libcrux_iot_sha3_lane_interleave_8d(libcrux_iot_sha3_lane_from_29(
             (KRML_CLITERAL(Eurydice_arr_a0){.data = {a, b}})));
-    state_flat.data[i] = uu____1;
+    Eurydice_arr_a0 got = libcrux_iot_sha3_state_get_lane_18(
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U);
+    libcrux_iot_sha3_state_set_lane_18(
+        keccak_state, i0 / (size_t)5U, i0 % (size_t)5U,
+        libcrux_iot_sha3_lane_from_ints_8d((KRML_CLITERAL(Eurydice_arr_a0){
+            .data = {
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)0U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U],
+                libcrux_iot_sha3_lane_index_cc(&got, (size_t)1U)[0U] ^
+                    libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]}})));
   }
-  KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
-                    "panic!");
-  KRML_HOST_EXIT(255U);
 }
 
 /**
@@ -7898,10 +6952,10 @@ with const generics
 - RATE= 104
 */
 KRML_MUSTINLINE void libcrux_iot_sha3_state_load_block_full_2u32_53(
-    libcrux_iot_sha3_state_KeccakState *state, const Eurydice_arr_5c *blocks,
-    size_t start) {
+    libcrux_iot_sha3_state_KeccakState *keccak_state,
+    const Eurydice_arr_5c *blocks, size_t start) {
   libcrux_iot_sha3_state_load_block_2u32_53(
-      state, Eurydice_array_to_slice_shared_15(blocks), start);
+      keccak_state, Eurydice_array_to_slice_shared_15(blocks), start);
 }
 
 /**
@@ -7955,7 +7009,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_53(
     Eurydice_mut_borrow_slice_u8 out) {
   for (size_t i = (size_t)0U; i < (size_t)104U / (size_t)8U; i++) {
     size_t i0 = i;
-    Eurydice_arr_a0 lane = libcrux_iot_sha3_lane_deinterleave_8d(
+    Eurydice_arr_a0 keccak_lane = libcrux_iot_sha3_lane_deinterleave_8d(
         libcrux_iot_sha3_state_get_lane_18(s, i0 / (size_t)5U,
                                            i0 % (size_t)5U));
     Eurydice_mut_borrow_slice_u8 uu____0 = Eurydice_slice_subslice_mut_c8(
@@ -7964,7 +7018,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_53(
             .start = (size_t)8U * i0, .end = (size_t)8U * i0 + (size_t)4U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue0 = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)0U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)0U)[0U]);
     Eurydice_slice_copy(uu____0, Eurydice_array_to_slice_shared_98(&lvalue0),
                         uint8_t);
     Eurydice_mut_borrow_slice_u8 uu____1 = Eurydice_slice_subslice_mut_c8(
@@ -7973,7 +7027,7 @@ KRML_MUSTINLINE void libcrux_iot_sha3_state_store_block_2u32_53(
                  .end = (size_t)8U * i0 + (size_t)8U}));
     /* original Rust expression is not an lvalue in C */
     Eurydice_array_u8x4 lvalue = core_num__u32__to_le_bytes(
-        libcrux_iot_sha3_lane_index_cc(&lane, (size_t)1U)[0U]);
+        libcrux_iot_sha3_lane_index_cc(&keccak_lane, (size_t)1U)[0U]);
     Eurydice_slice_copy(uu____1, Eurydice_array_to_slice_shared_98(&lvalue),
                         uint8_t);
   }
@@ -8115,16 +7169,16 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_dc0(
   size_t blocks = outlen / (size_t)104U;
   size_t last = outlen - outlen % (size_t)104U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   core_ops_range_Range_87 iter =
       core_iter_traits_collect__core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__into_iter(
           (KRML_CLITERAL(core_ops_range_Range_87){.start = (size_t)0U,
                                                   .end = n}),
           core_ops_range_Range_87, size_t, core_ops_range_Range_87);
   while (true) {
-    core_option_Option_87 uu____0 =
-        core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
-            &iter, size_t, core_option_Option_87);
-    if (uu____0.tag == core_option_None) {
+    if (core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
+            &iter, size_t, core_option_Option_87)
+            .tag == core_option_None) {
       libcrux_iot_sha3_keccak_absorb_final_dc0(&s, data, data.meta - rem, rem);
       if (blocks == (size_t)0U) {
         libcrux_iot_sha3_keccak_squeeze_first_and_last_53(&s, out);
@@ -8137,16 +7191,16 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_dc0(
           offset += (size_t)104U;
         }
         if (last < outlen) {
-          const_size_t__x2 uu____1 = {.fst = &last, .snd = &offset};
-          EURYDICE_ASSERT(uu____1.fst[0U] == uu____1.snd[0U], "panic!");
+          const_size_t__x2 uu____0 = {.fst = &last, .snd = &offset};
+          EURYDICE_ASSERT(uu____0.fst[0U] == uu____0.snd[0U], "panic!");
           libcrux_iot_sha3_keccak_squeeze_last_53(
               s, Eurydice_slice_subslice_from_mut_6d(out, offset));
         }
       }
       return;
     }
-    size_t i = uu____0.f0;
-    libcrux_iot_sha3_keccak_absorb_block_53(&s, data, i * (size_t)104U);
+    libcrux_iot_sha3_keccak_absorb_block_53(&s, data, start);
+    start += (size_t)104U;
   }
   KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
                     "panic!");
@@ -8195,10 +7249,10 @@ Eurydice_arr_a2 sha224(Eurydice_borrow_slice_u8 payload) {
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 data) {
+Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 payload) {
   Eurydice_arr_ec out = libcrux_secrets_int_public_integers_classify_27_4b(
       (KRML_CLITERAL(Eurydice_arr_ec){.data = {0U}}));
-  sha256_ema(Eurydice_array_to_slice_mut_01(&out), data);
+  sha256_ema(Eurydice_array_to_slice_mut_01(&out), payload);
   return out;
 }
 
@@ -8208,10 +7262,10 @@ Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 data) {
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 data) {
+Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 payload) {
   Eurydice_arr_65 out = libcrux_secrets_int_public_integers_classify_27_69(
       (KRML_CLITERAL(Eurydice_arr_65){.data = {0U}}));
-  sha384_ema(Eurydice_array_to_slice_mut_9f(&out), data);
+  sha384_ema(Eurydice_array_to_slice_mut_9f(&out), payload);
   return out;
 }
 
@@ -8221,10 +7275,10 @@ Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 data) {
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_c7 sha512(Eurydice_borrow_slice_u8 data) {
+Eurydice_arr_c7 sha512(Eurydice_borrow_slice_u8 payload) {
   Eurydice_arr_c7 out = libcrux_secrets_int_public_integers_classify_27_56(
       (KRML_CLITERAL(Eurydice_arr_c7){.data = {0U}}));
-  sha512_ema(Eurydice_array_to_slice_mut_17(&out), data);
+  sha512_ema(Eurydice_array_to_slice_mut_17(&out), payload);
   return out;
 }
 
@@ -8328,16 +7382,16 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_37(
   size_t blocks = outlen / (size_t)168U;
   size_t last = outlen - outlen % (size_t)168U;
   libcrux_iot_sha3_state_KeccakState s = libcrux_iot_sha3_state_new_18();
+  size_t start = (size_t)0U;
   core_ops_range_Range_87 iter =
       core_iter_traits_collect__core__iter__traits__collect__IntoIterator_Clause1_Item__I__for_I__into_iter(
           (KRML_CLITERAL(core_ops_range_Range_87){.start = (size_t)0U,
                                                   .end = n}),
           core_ops_range_Range_87, size_t, core_ops_range_Range_87);
   while (true) {
-    core_option_Option_87 uu____0 =
-        core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
-            &iter, size_t, core_option_Option_87);
-    if (uu____0.tag == core_option_None) {
+    if (core_iter_range__core__iter__traits__iterator__Iterator_A__for_core__ops__range__Range_A__TraitClause_0___next(
+            &iter, size_t, core_option_Option_87)
+            .tag == core_option_None) {
       libcrux_iot_sha3_keccak_absorb_final_37(&s, data, data.meta - rem, rem);
       if (blocks == (size_t)0U) {
         libcrux_iot_sha3_keccak_squeeze_first_and_last_60(&s, out);
@@ -8350,16 +7404,16 @@ KRML_MUSTINLINE void libcrux_iot_sha3_keccak_keccak_37(
           offset += (size_t)168U;
         }
         if (last < outlen) {
-          const_size_t__x2 uu____1 = {.fst = &last, .snd = &offset};
-          EURYDICE_ASSERT(uu____1.fst[0U] == uu____1.snd[0U], "panic!");
+          const_size_t__x2 uu____0 = {.fst = &last, .snd = &offset};
+          EURYDICE_ASSERT(uu____0.fst[0U] == uu____0.snd[0U], "panic!");
           libcrux_iot_sha3_keccak_squeeze_last_60(
               s, Eurydice_slice_subslice_from_mut_6d(out, offset));
         }
       }
       return;
     }
-    size_t i = uu____0.f0;
-    libcrux_iot_sha3_keccak_absorb_block_60(&s, data, i * (size_t)168U);
+    libcrux_iot_sha3_keccak_absorb_block_60(&s, data, start);
+    start += (size_t)168U;
   }
   KRML_HOST_EPRINTF("KaRaMeL abort at %s:%d\n%s\n", __FILE__, __LINE__,
                     "panic!");

--- a/c/ml-kem/extracted/libcrux_iot_sha3.h
+++ b/c/ml-kem/extracted/libcrux_iot_sha3.h
@@ -8,7 +8,7 @@
  * Eurydice: aaa9fa657fb6f09802edb890252040d94cd93982
  * Karamel: 8c19d41458ce5cbfea029ebc03334ba96d149039
  * F*: unset
- * Libcrux: 5db7272c7ac7c1933d461a7c12ea5d00fdf450d2
+ * Libcrux: 95a43e554866d4eb2db411c066ca0fb528eddbfd
  */
 
 #ifndef libcrux_iot_sha3_H
@@ -115,7 +115,7 @@ Eurydice_arr_a2 sha224(Eurydice_borrow_slice_u8 payload);
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 data);
+Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 payload);
 
 /**
  Returns SHA3-384 digest of input payload.
@@ -123,7 +123,7 @@ Eurydice_arr_ec sha256(Eurydice_borrow_slice_u8 data);
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 data);
+Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 payload);
 
 /**
  Returns SHA3-512 digest of input payload.
@@ -131,7 +131,7 @@ Eurydice_arr_65 sha384(Eurydice_borrow_slice_u8 data);
  Preconditions:
  - `payload` is at most `u32::MAX` bytes long
 */
-Eurydice_arr_c7 sha512(Eurydice_borrow_slice_u8 data);
+Eurydice_arr_c7 sha512(Eurydice_borrow_slice_u8 payload);
 
 /**
  Writes SHAKE-128 digest of input payload to externally allocated buffer.

--- a/libcrux-iot/ml-dsa/src/helper.rs
+++ b/libcrux-iot/ml-dsa/src/helper.rs
@@ -57,13 +57,36 @@ macro_rules! cloop {
             $body
         }
     };
-    (for $i:ident in ($start:literal..$end:expr).step_by($step:literal) $body:block) => {
-        for $i in ($start..($end / $step + 1)) {
-            let $i = $i * $step;
-            if $i >= $end { break; }
+    (for $i:ident in ($start:literal..$end:expr).step_by($step:literal) $body:block) => {{
+        let mut $i = $start;
+        let step = $step;
+        let end = $end;
+        // This is only needed for type inference to connect the types of $i and $end.
+        // Otherwise we can't call checked_add for some usages of cloop.
+        // Optimized out by eurydice.
+        if false {
+            let _ = $i >= end;
+        }
+        // If $body contains a `continue`, we would enter an infinite loop if we did the
+        // step_by addition after the $body. Instead, we initialize $i with $start and
+        // do the step_by increase before the $body, except on the first iteration.
+        let mut first_iter = true;
+        loop {
+            if !first_iter {
+                // This guards against the $i overflowing its type,
+                // in that case break from the loop
+                $i = match $i.checked_add(step) {
+                    Some(v) => v,
+                    None => break
+                };
+            }
+            first_iter = false;
+            if $i >= end {
+                break;
+            }
             $body
         }
-    };
+    }};
 }
 
 #[cfg(not(eurydice))]

--- a/libcrux-iot/ml-kem/src/helper.rs
+++ b/libcrux-iot/ml-kem/src/helper.rs
@@ -27,12 +27,36 @@ macro_rules! cloop {
             $body
         }
     };
-    (for $i:ident in ($start:literal..$end:expr).step_by($step:literal) $body:block) => {
-        for $i in $start..$end / $step {
-            let $i = $i * $step;
+    (for $i:ident in ($start:literal..$end:expr).step_by($step:literal) $body:block) => {{
+        let mut $i = $start;
+        let step = $step;
+        let end = $end;
+        // This is only needed for type inference to connect the types of $i and $end.
+        // Otherwise we can't call checked_add for some usages of cloop.
+        // Optimized out by eurydice.
+        if false {
+            let _ = $i >= end;
+        }
+        // If $body contains a `continue`, we would enter an infinite loop if we did the
+        // step_by addition after the $body. Instead, we initialize $i with $start and
+        // do the step_by increase before the $body, except on the first iteration.
+        let mut first_iter = true;
+        loop {
+            if !first_iter {
+                // This guards against the $i overflowing its type,
+                // in that case break from the loop
+                $i = match $i.checked_add(step) {
+                    Some(v) => v,
+                    None => break
+                };
+            }
+            first_iter = false;
+            if $i >= end {
+                break;
+            }
             $body
         }
-    };
+    }};
 }
 
 #[cfg(not(eurydice))]


### PR DESCRIPTION
The cloop macro contained a bug in the step_by variant when extracting
with eurydice. The macro assumed that $start == 0. While this is the case
in all current uses, a future use of the macro with a non-zero start
could have caused a misextraction to C.

This new version also guards against other possible issues with the
step_by eurydice version, such as integer overflow and continue inside
the loops body.

It also fixes a bug in the ml-kem version of the macro when $end is not divided by $step.

One thing I noticed is that the C extraction is a bit less nice. Eurydice seems to duplicate the loop for the two `first_iter` cases.